### PR TITLE
Add --set-baseline, --update-baseline, --ignore-baseline flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/mir-cli/src/config.rs
+++ b/crates/mir-cli/src/config.rs
@@ -286,6 +286,45 @@ impl Baseline {
             .map(|v| !v.is_empty())
             .unwrap_or(false)
     }
+
+    /// Serialize this baseline to a Psalm-compatible XML file.
+    pub fn write(&self, path: &std::path::Path) -> Result<(), ConfigError> {
+        let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<files>\n");
+
+        let mut files: Vec<&String> = self.entries.keys().collect();
+        files.sort_unstable();
+
+        for file in files {
+            let by_kind = &self.entries[file];
+            let mut kinds: Vec<&String> = by_kind.keys().collect();
+            kinds.sort_unstable();
+
+            out.push_str(&format!("  <file src=\"{}\">\n", xml_escape_attr(file)));
+            for kind in kinds {
+                let snippets = &by_kind[kind];
+                out.push_str(&format!("    <{}>\n", kind));
+                for snippet in snippets {
+                    out.push_str(&format!(
+                        "      <code><![CDATA[{}]]></code>\n",
+                        snippet
+                    ));
+                }
+                out.push_str(&format!("    </{}>\n", kind));
+            }
+            out.push_str("  </file>\n");
+        }
+
+        out.push_str("</files>\n");
+
+        std::fs::write(path, out).map_err(|e| ConfigError::Io(e.to_string()))
+    }
+}
+
+fn xml_escape_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 fn parse_baseline_xml(xml: &str) -> Result<Baseline, ConfigError> {

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -71,6 +71,18 @@ struct Cli {
     /// Override global error level (1 = errors only, 2 = +warnings, 3+ = +info)
     #[arg(long, value_name = "1-8")]
     error_level: Option<u8>,
+
+    /// Save all current issues to a baseline file and exit (default: psalm-baseline.xml)
+    #[arg(long, value_name = "FILE", num_args = 0..=1, default_missing_value = "psalm-baseline.xml")]
+    set_baseline: Option<PathBuf>,
+
+    /// Update the baseline by removing issues that are no longer present
+    #[arg(long)]
+    update_baseline: bool,
+
+    /// Ignore the baseline and report all issues
+    #[arg(long)]
+    ignore_baseline: bool,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
@@ -251,12 +263,17 @@ fn main() {
     }
 }
 
-/// Load baseline from `--baseline` flag or config (auto-discover `baseline.xml` / `psalm-baseline.xml`).
-fn load_baseline(cli: &Cli, _config: &Config) -> Option<Baseline> {
+/// Load baseline from `--baseline` flag or config (auto-discover `psalm-baseline.xml`).
+/// Returns `None` when `--ignore-baseline` or `--set-baseline` is active (both bypass the baseline).
+/// Otherwise returns `Some((path, baseline))`.
+fn load_baseline(cli: &Cli, _config: &Config) -> Option<(PathBuf, Baseline)> {
+    if cli.ignore_baseline || cli.set_baseline.is_some() {
+        return None;
+    }
+
     let path = if let Some(p) = &cli.baseline {
         p.clone()
     } else {
-        // Auto-discover baseline file in the current directory
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let candidate = cwd.join("psalm-baseline.xml");
         if candidate.exists() {
@@ -271,7 +288,7 @@ fn load_baseline(cli: &Cli, _config: &Config) -> Option<Baseline> {
             if !cli.quiet {
                 eprintln!("mir: using baseline {}", path.display());
             }
-            Some(b)
+            Some((path, b))
         }
         Err(e) => {
             eprintln!("mir: baseline error in {}: {}", path.display(), e);
@@ -285,27 +302,72 @@ fn run_output(
     config: &Config,
     files: &[PathBuf],
     result: mir_analyzer::project::AnalysisResult,
-    mut baseline: Option<Baseline>,
+    baseline: Option<(PathBuf, Baseline)>,
     elapsed: std::time::Duration,
 ) {
+    // --set-baseline: write every issue to the baseline file and exit 0.
+    if let Some(path) = &cli.set_baseline {
+        let bl = baseline_from_issues(&result.issues);
+        match bl.write(path) {
+            Ok(()) => {
+                if !cli.quiet {
+                    eprintln!("mir: baseline written to {}", path.display());
+                }
+            }
+            Err(e) => eprintln!("mir: failed to write baseline: {}", e),
+        }
+        return;
+    }
+
+    let (baseline_path, mut baseline_data) = match baseline {
+        Some((p, b)) => (Some(p), Some(b)),
+        None => (None, None),
+    };
+
     // Suppress issues matched by the baseline.
-    // Matching is (file, issue_kind, snippet); falls back to (file, issue_kind) when
-    // no snippet is stored.
-    let suppressed_by_baseline: std::collections::HashSet<usize> = if let Some(bl) = &mut baseline {
+    // For --update-baseline, also accumulate the consumed entries into a new baseline.
+    let mut new_baseline = Baseline::default();
+    let suppressed_by_baseline: std::collections::HashSet<usize> = if let Some(bl) = &mut baseline_data {
         result.issues.iter().enumerate().filter_map(|(idx, issue)| {
             let file = issue.location.file.as_ref();
             let kind = issue.kind.name();
-            let matched = if let Some(snippet) = &issue.snippet {
-                bl.consume(file, kind, snippet)
+            let snippet = issue.snippet.as_deref().unwrap_or("");
+            let matched = bl.consume(file, kind, snippet);
+            if matched {
+                if cli.update_baseline {
+                    new_baseline.entries
+                        .entry(file.to_string())
+                        .or_default()
+                        .entry(kind.to_string())
+                        .or_default()
+                        .push(snippet.to_string());
+                }
+                Some(idx)
             } else {
-                // No snippet — check counts: consume if kind present in file
-                bl.consume(file, kind, "")
-            };
-            if matched { Some(idx) } else { None }
+                None
+            }
         }).collect()
     } else {
         std::collections::HashSet::new()
     };
+
+    // --update-baseline: write back only the issues still present in the baseline.
+    if cli.update_baseline {
+        let path = baseline_path
+            .as_deref()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join("psalm-baseline.xml"));
+        match new_baseline.write(&path) {
+            Ok(()) => {
+                if !cli.quiet {
+                    eprintln!("mir: baseline updated at {}", path.display());
+                }
+            }
+            Err(e) => eprintln!("mir: failed to update baseline: {}", e),
+        }
+    }
 
     // Apply per-issue-kind overrides from config, then filter by effective severity.
     let effective_severity = |issue: &Issue| -> Option<Severity> {
@@ -433,6 +495,20 @@ fn run_output(
     if has_errors {
         process::exit(1);
     }
+}
+
+/// Build a Baseline from a slice of issues (used by --set-baseline).
+fn baseline_from_issues(issues: &[Issue]) -> Baseline {
+    let mut bl = Baseline::default();
+    for issue in issues {
+        bl.entries
+            .entry(issue.location.file.to_string())
+            .or_default()
+            .entry(issue.kind.name().to_string())
+            .or_default()
+            .push(issue.snippet.clone().unwrap_or_default());
+    }
+    bl
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements three Psalm-compatible baseline management CLI flags:

- **`--set-baseline [FILE]`** — run analysis without applying any existing baseline, write all found issues to a Psalm-format XML file (default: `psalm-baseline.xml`), exit 0. Useful for creating a baseline from scratch.
- **`--update-baseline`** — load and apply the existing baseline normally, then rewrite it keeping only issues that are still present. Fixed issues are automatically removed. New issues not in the baseline are still reported as errors.
- **`--ignore-baseline`** — bypass the baseline entirely and report all issues regardless of what's in the baseline file.

Closes #4 (re: baseline support gap vs Psalm).

## Test plan

- [ ] `--set-baseline` generates a valid `psalm-baseline.xml` file and exits 0
- [ ] Running mir again after `--set-baseline` produces no output (all issues suppressed)
- [ ] `--ignore-baseline` reports issues even when a baseline exists
- [ ] `--update-baseline` rewrites the baseline with only still-present issues; fixed issues are dropped
- [ ] `--set-baseline custom.xml` writes to the specified path
- [ ] All three flags appear correctly in `--help`