### PR TITLE
Add docs badge and repo website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mir
 
+[![Docs](https://img.shields.io/badge/docs-jorgsowa.github.io%2Fmir-blue)](https://jorgsowa.github.io/mir/)
+
 A fast, incremental PHP static analyzer written in Rust, inspired by [Psalm](https://psalm.dev).
 
 ## Features


### PR DESCRIPTION
Adds the docs badge to README and sets the repo homepage to https://jorgsowa.github.io/mir/ via the GitHub API.

Closes #19