### PR TITLE
Fix false-positive UndefinedVariable for sscanf output parameters

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -82,7 +82,17 @@ impl CallAnalyzer {
         if let Some(func) = ea.codebase.functions.get(resolved_fn_name.as_str()) {
             for (i, param) in func.params.iter().enumerate() {
                 if param.is_byref {
-                    if let Some(arg) = call.args.get(i) {
+                    if param.is_variadic {
+                        // Variadic by-ref: mark every remaining argument (e.g. sscanf output vars).
+                        for arg in call.args.iter().skip(i) {
+                            if let ExprKind::Variable(name) = &arg.value.kind {
+                                let var_name = name.as_ref().trim_start_matches('$');
+                                if !ctx.var_is_defined(var_name) {
+                                    ctx.set_var(var_name, Union::mixed());
+                                }
+                            }
+                        }
+                    } else if let Some(arg) = call.args.get(i) {
                         if let ExprKind::Variable(name) = &arg.value.kind {
                             let var_name = name.as_ref().trim_start_matches('$');
                             if !ctx.var_is_defined(var_name) {
@@ -125,7 +135,14 @@ impl CallAnalyzer {
             // Also ensure by-ref vars are defined after the call (for post-call usage)
             for (i, param) in params.iter().enumerate() {
                 if param.is_byref {
-                    if let Some(arg) = call.args.get(i) {
+                    if param.is_variadic {
+                        for arg in call.args.iter().skip(i) {
+                            if let ExprKind::Variable(name) = &arg.value.kind {
+                                let var_name = name.as_ref().trim_start_matches('$');
+                                ctx.set_var(var_name, Union::mixed());
+                            }
+                        }
+                    } else if let Some(arg) = call.args.get(i) {
                         if let ExprKind::Variable(name) = &arg.value.kind {
                             let var_name = name.as_ref().trim_start_matches('$');
                             ctx.set_var(var_name, Union::mixed());

--- a/crates/mir-analyzer/src/stubs.rs
+++ b/crates/mir-analyzer/src/stubs.rs
@@ -66,6 +66,18 @@ fn vari(name: &'static str) -> FnParam {
 }
 
 #[inline]
+fn byref_vari(name: &'static str) -> FnParam {
+    FnParam {
+        name: Arc::from(name),
+        ty: None,
+        default: None,
+        is_variadic: true,
+        is_byref: true,
+        is_optional: true,
+    }
+}
+
+#[inline]
 fn byref(name: &'static str) -> FnParam {
     FnParam {
         name: Arc::from(name),
@@ -284,7 +296,7 @@ fn load_functions(codebase: &Codebase) {
     reg(codebase, "vsprintf", vec![req("format"), req("values")],   t_str());
     reg(codebase, "printf",   vec![req("format"), vari("values")],  t_int());
     reg(codebase, "vprintf",  vec![req("format"), req("values")],   t_int());
-    reg(codebase, "sscanf",   vec![req("string"), req("format"), vari("vars")], Union::mixed());
+    reg(codebase, "sscanf",   vec![req("string"), req("format"), byref_vari("vars")], Union::mixed());
     reg(codebase, "fprintf",  vec![req("handle"), req("format"), vari("values")], t_int());
     reg(codebase, "explode",  vec![req("separator"), req("string"), opt("limit")], t_array());
     reg(codebase, "implode",  vec![req("separator"), opt("array")], t_str());
@@ -1982,6 +1994,32 @@ mod tests {
             cb.functions.contains_key(name),
             "expected stub for `{name}` to be registered"
         );
+    }
+
+    #[test]
+    fn sscanf_vars_param_is_byref_and_variadic() {
+        let cb = stubs_codebase();
+        let func = cb.functions.get("sscanf").expect("sscanf must be defined");
+        let vars = func.params.get(2).expect("sscanf must have a 3rd param");
+        assert!(vars.is_byref, "sscanf vars param must be by-ref");
+        assert!(vars.is_variadic, "sscanf vars param must be variadic");
+    }
+
+    #[test]
+    fn sscanf_output_vars_not_undefined() {
+        use std::path::PathBuf;
+        use crate::project::ProjectAnalyzer;
+        use mir_issues::IssueKind;
+
+        let src = "<?php\nfunction test($str) {\n    sscanf($str, \"%d %d\", $row, $col);\n    return $row + $col;\n}\n";
+        let tmp = std::env::temp_dir().join("mir_test_sscanf_undefined.php");
+        std::fs::write(&tmp, src).unwrap();
+        let result = ProjectAnalyzer::new().analyze(&[tmp.clone()]);
+        std::fs::remove_file(tmp).ok();
+        let undef: Vec<_> = result.issues.iter()
+            .filter(|i| matches!(&i.kind, IssueKind::UndefinedVariable { name } if name == "row" || name == "col"))
+            .collect();
+        assert!(undef.is_empty(), "sscanf output vars must not be reported as UndefinedVariable; got: {undef:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `sscanf($str, "%d %d", $row, $col)` passes `$row`/`$col` as by-reference output parameters — PHP writes to them, so they must not be flagged as undefined
- Added `byref_vari()` stub helper (variadic + by-ref) and changed `sscanf`'s `vars` param from `vari()` to `byref_vari()`
- Extended the by-ref pre-marking loop in `call.rs` to handle variadic by-ref params (previously only `args[i]` was marked; now all `args[i..]` are marked)

Closes #2

## Test plan

- [ ] `sscanf_vars_param_is_byref_and_variadic`: confirms the stub has the correct flags
- [ ] `sscanf_output_vars_not_undefined`: integration test — analyzes a PHP function that calls `sscanf($str, "%d %d", $row, $col)` and asserts no `UndefinedVariable` issues are emitted for `$row` or `$col`
- [ ] All 32 existing tests continue to pass