### PR TITLE
fix: MethodSignatureMismatch detects param type narrowing in overrides and interface impls

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -297,8 +297,58 @@ impl<'a> ClassAnalyzer<'a> {
                             child_required, parent_required
                         ),
                     },
-                    loc,
+                    loc.clone(),
                 ));
+            }
+
+            // ---- e. Param types must not be narrowed (contravariance) --------
+            // For each positional param present in both parent and child:
+            //   parent_param_type must be a subtype of child_param_type.
+            //   (Child may widen; it must not narrow.)
+            // Skip when:
+            //   - Either side has no type hint
+            //   - Either type is mixed
+            //   - Either type contains a named object (needs codebase for inheritance check)
+            //   - Either type contains TSelf/TStaticObject
+            //   - Either type contains a template param
+            let shared_len = parent.params.len().min(own_method.params.len());
+            for i in 0..shared_len {
+                let parent_param = &parent.params[i];
+                let child_param = &own_method.params[i];
+
+                let (parent_ty, child_ty) = match (&parent_param.ty, &child_param.ty) {
+                    (Some(p), Some(c)) => (p, c),
+                    _ => continue,
+                };
+
+                if parent_ty.is_mixed()
+                    || child_ty.is_mixed()
+                    || self.type_has_named_objects(parent_ty)
+                    || self.type_has_named_objects(child_ty)
+                    || self.type_has_self_or_static(parent_ty)
+                    || self.type_has_self_or_static(child_ty)
+                    || self.return_type_has_template(parent_ty)
+                    || self.return_type_has_template(child_ty)
+                {
+                    continue;
+                }
+
+                // Contravariance: parent_ty must be subtype of child_ty.
+                // If not, child has narrowed the param type.
+                if !parent_ty.is_subtype_of_simple(child_ty) {
+                    issues.push(Issue::new(
+                        IssueKind::MethodSignatureMismatch {
+                            class: fqcn.to_string(),
+                            method: method_name.to_string(),
+                            detail: format!(
+                                "parameter ${} type '{}' is narrower than parent type '{}'",
+                                child_param.name, child_ty, parent_ty
+                            ),
+                        },
+                        loc.clone(),
+                    ));
+                    break; // one issue per method is enough
+                }
             }
         }
     }

--- a/crates/mir-analyzer/tests/method_signature_mismatch.rs
+++ b/crates/mir-analyzer/tests/method_signature_mismatch.rs
@@ -2,7 +2,6 @@
 use mir_test_utils::{assert_issue_kind, assert_no_issue, check};
 
 #[test]
-#[ignore = "known issue: param type mismatch check not implemented for overrides — MethodSignatureMismatch not emitted"]
 fn reports_override_narrowing_param_type() {
     // Parent accepts string; Child accepts only int — narrowing is not allowed
     let src = "<?php\nclass Base {\n    public function f(string $x): void {}\n}\nclass Child extends Base {\n    public function f(int $x): void {}\n}\n";
@@ -50,7 +49,6 @@ fn reports_override_removes_default() {
 }
 
 #[test]
-#[ignore = "known issue: param type mismatch check not implemented for interface implementations — MethodSignatureMismatch not emitted"]
 fn reports_interface_implementation_wrong_signature() {
     let src = "<?php\ninterface I {\n    public function f(string $x): void;\n}\nclass C implements I {\n    public function f(int $x): void {}\n}\n";
     let issues = check(src);
@@ -69,4 +67,28 @@ fn does_not_report_correct_abstract_implementation() {
     let src = "<?php\nabstract class Base {\n    abstract public function f(string $x): void;\n}\nclass Child extends Base {\n    public function f(string $x): void {}\n}\n";
     let issues = check(src);
     assert_no_issue(&issues, "MethodSignatureMismatch");
+}
+
+#[test]
+fn does_not_report_override_widening_param_type() {
+    // Parent accepts string; Child accepts string|int — widening is allowed
+    let src = "<?php\nclass Base {\n    public function f(string $x): void {}\n}\nclass Child extends Base {\n    public function f(string|int $x): void {}\n}\n";
+    let issues = check(src);
+    assert_no_issue(&issues, "MethodSignatureMismatch");
+}
+
+#[test]
+fn does_not_report_override_no_type_hint_on_parent() {
+    // Parent has no type hint; Child adds one — no enforcement possible
+    let src = "<?php\nclass Base {\n    public function f($x): void {}\n}\nclass Child extends Base {\n    public function f(int $x): void {}\n}\n";
+    let issues = check(src);
+    assert_no_issue(&issues, "MethodSignatureMismatch");
+}
+
+#[test]
+fn reports_override_narrowing_second_param() {
+    // First param matches; second param narrows — should still fire
+    let src = "<?php\nclass Base {\n    public function f(string $x, string $y): void {}\n}\nclass Child extends Base {\n    public function f(string $x, int $y): void {}\n}\n";
+    let issues = check(src);
+    assert_issue_kind(&issues, "MethodSignatureMismatch", 1, 0);
 }


### PR DESCRIPTION
## Summary
- Add section `e.` in `check_override_compat` (`class.rs`) that checks parameter type contravariance: emits `MethodSignatureMismatch` when a child method narrows a param type relative to its parent or interface
- Fix section `d.` to use `loc.clone()` so `loc` remains available for the new check
- Un-ignore two previously-failing tests; add three new tests covering widening (allowed), no type hint on parent (skipped), and narrowing on second param

Closes #41