### PR TITLE
feat: implement RedundantCondition rule

### DIFF
--- a/crates/mir-analyzer/src/narrowing.rs
+++ b/crates/mir-analyzer/src/narrowing.rs
@@ -359,6 +359,9 @@ fn narrow_from_type_fn(ctx: &mut Context, fn_name: &str, var_name: &str, is_true
     };
     if !narrowed.is_empty() {
         ctx.set_var(var_name, narrowed);
+    } else if !current.is_empty() && !current.is_mixed() {
+        // The type cannot satisfy this type-function constraint → dead branch.
+        ctx.diverges = true;
     }
 }
 

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -321,7 +321,8 @@ impl<'a> StatementsAnalyzer<'a> {
                 let pre_ctx = ctx.clone();
 
                 // Analyse condition expression
-                self.expr_analyzer(ctx).analyze(&if_stmt.condition, ctx);
+                let cond_type = self.expr_analyzer(ctx).analyze(&if_stmt.condition, ctx);
+                let pre_diverges = ctx.diverges;
 
                 // True branch
                 let mut then_ctx = ctx.fork();
@@ -351,6 +352,20 @@ impl<'a> StatementsAnalyzer<'a> {
                     if let Some(else_branch) = &if_stmt.else_branch {
                         self.analyze_stmt(else_branch, &mut else_ctx);
                     }
+                }
+
+                // Emit RedundantCondition if narrowing proves one branch is statically unreachable.
+                if !pre_diverges && (then_ctx.diverges || else_ctx.diverges) {
+                    let (line, col) = crate::parser::span_to_line_col(self.source, if_stmt.condition.span);
+                    self.issues.add(mir_issues::Issue::new(
+                        IssueKind::RedundantCondition { ty: format!("{}", cond_type) },
+                        mir_issues::Location {
+                            file: self.file.clone(),
+                            line,
+                            col_start: col,
+                            col_end: col,
+                        },
+                    ));
                 }
 
                 // Merge all branches

--- a/crates/mir-analyzer/tests/redundant_condition.rs
+++ b/crates/mir-analyzer/tests/redundant_condition.rs
@@ -2,7 +2,6 @@
 use mir_test_utils::{assert_issue_kind, assert_no_issue, check};
 
 #[test]
-#[ignore = "known gap: RedundantCondition rule not yet implemented"]
 fn reports_null_check_on_non_nullable() {
     // $x is string — checking === null is always false
     let src = "<?php\nfunction f(string $x): void {\n    if ($x === null) {}\n}\n";
@@ -12,7 +11,6 @@ fn reports_null_check_on_non_nullable() {
 }
 
 #[test]
-#[ignore = "known gap: RedundantCondition rule not yet implemented"]
 fn reports_not_null_check_on_non_nullable() {
     let src = "<?php\nfunction f(string $x): void {\n    if ($x !== null) {}\n}\n";
     let issues = check(src);
@@ -27,7 +25,6 @@ fn does_not_report_null_check_on_nullable() {
 }
 
 #[test]
-#[ignore = "known gap: RedundantCondition rule not yet implemented"]
 fn reports_is_string_on_string_type() {
     let src = "<?php\nfunction f(string $x): void {\n    if (is_string($x)) {}\n}\n";
     let issues = check(src);
@@ -43,7 +40,6 @@ fn does_not_report_is_string_on_union() {
 }
 
 #[test]
-#[ignore = "known gap: RedundantCondition rule not yet implemented"]
 fn reports_redundant_check_after_narrowing() {
     // After $x is narrowed to string in first branch, second check is redundant
     let src = "<?php\nfunction f(string|int $x): void {\n    if (is_string($x)) {\n        if (is_string($x)) {}\n    }\n}\n";


### PR DESCRIPTION
## Summary

- Emit `RedundantCondition` when `narrow_from_condition()` proves a branch statically unreachable in the if-handler (`stmt.rs`)
- Fix `narrow_from_type_fn()` in `narrowing.rs` to set `ctx.diverges` when `is_string/is_int/etc.` narrowing yields an empty type (else-branch was silently not being marked unreachable)
- Un-ignore the 4 previously failing `RedundantCondition` tests

Closes #40

## Test Plan

- [ ] `cargo test` passes (all RedundantCondition tests green, no new failures)
- [ ] Verify against app-server: `RedundantCondition` fires at `Packager.php:216`