### PR TITLE
feat: re-export DocblockParser, ParsedDocblock and type_from_hint as public API

### DIFF
--- a/crates/mir-analyzer/src/lib.rs
+++ b/crates/mir-analyzer/src/lib.rs
@@ -13,6 +13,8 @@ pub mod stmt;
 pub mod stubs;
 pub mod taint;
 
+pub use parser::{DocblockParser, ParsedDocblock};
+pub use parser::type_from_hint::type_from_hint;
 pub use project::{AnalysisResult, ProjectAnalyzer};
 pub use stubs::is_builtin_function;
 


### PR DESCRIPTION
## Summary

- Re-exports `DocblockParser` and `ParsedDocblock` from `mir_analyzer` crate root
- Re-exports `type_from_hint()` from `mir_analyzer` crate root

These types and functions were already `pub` within their modules but not re-exported from `lib.rs`, making them unreachable to external crates.

## Prerequisite for

- jorgsowa/php-lsp#39 — Remove duplicate docblock parser, delegate to mir
- jorgsowa/php-lsp#41 — Replace `type_hint_to_class_string` with mir's `type_from_hint`

## Test plan

- [x] `cargo build` passes
- [x] All 113 tests pass