### PR TITLE
docs: document pub visibility of Codebase::file_imports and file_namespaces

### DIFF
--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -29,8 +29,20 @@ pub struct Codebase {
     pub referenced_functions: DashSet<Arc<str>>,
 
     /// Per-file `use` alias maps: alias → FQCN.  Populated during Pass 1.
+    ///
+    /// Key: absolute file path (as `Arc<str>`).
+    /// Value: map of `alias → fully-qualified class name`.
+    ///
+    /// Exposed as `pub` so that external consumers (e.g. `php-lsp`) can read
+    /// import data that mir already collects, instead of reimplementing it.
     pub file_imports: DashMap<Arc<str>, std::collections::HashMap<String, String>>,
     /// Per-file current namespace (if any).  Populated during Pass 1.
+    ///
+    /// Key: absolute file path (as `Arc<str>`).
+    /// Value: the declared namespace string (e.g. `"App\\Controller"`).
+    ///
+    /// Exposed as `pub` so that external consumers (e.g. `php-lsp`) can read
+    /// namespace data that mir already collects, instead of reimplementing it.
     pub file_namespaces: DashMap<Arc<str>, String>,
 
     /// Whether finalize() has been called.


### PR DESCRIPTION
## Summary

- Added doc comments to `Codebase::file_imports` and `Codebase::file_namespaces` documenting their key/value types and that they are intentionally `pub` for external consumers.

Both fields were already `pub` since the initial implementation. This PR makes the intent explicit so consumers like `php-lsp` can confidently read import/namespace data that mir already collects in Pass 1, instead of reimplementing it.

## Prerequisite for

- jorgsowa/php-lsp#40 — Replace UseResolver with mir's `file_imports` from Codebase

## Test plan

- [x] `cargo build` passes
- [x] All tests pass