### PR TITLE
feat: emit DeprecatedCall and DeprecatedMethodCall diagnostics

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -128,12 +128,24 @@ impl CallAnalyzer {
         // Look up user-defined function in codebase
         if let Some(func) = ea.codebase.functions.get(resolved_fn_name.as_str()) {
             ea.codebase.mark_function_referenced(&func.fqn.clone());
+            let is_deprecated = func.is_deprecated;
             let params = func.params.clone();
             let template_params = func.template_params.clone();
             let return_ty_raw = func
                 .effective_return_type()
                 .cloned()
                 .unwrap_or_else(Union::mixed);
+
+            // Emit DeprecatedCall if the function is marked @deprecated
+            if is_deprecated {
+                ea.emit(
+                    IssueKind::DeprecatedCall {
+                        name: resolved_fn_name.clone(),
+                    },
+                    Severity::Info,
+                    span,
+                );
+            }
 
             check_args(
                 ea,
@@ -288,6 +300,17 @@ impl CallAnalyzer {
                     if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
                         // Record reference for dead-code detection (M18)
                         ea.codebase.mark_method_referenced(fqcn, &method_name);
+                        // Emit DeprecatedMethodCall if the method is marked @deprecated
+                        if method.is_deprecated {
+                            ea.emit(
+                                IssueKind::DeprecatedMethodCall {
+                                    class: fqcn.to_string(),
+                                    method: method_name.clone(),
+                                },
+                                Severity::Info,
+                                span,
+                            );
+                        }
                         // Visibility check (simplified — only checks private from outside)
                         check_method_visibility(ea, &method, ctx, span);
 
@@ -426,6 +449,17 @@ impl CallAnalyzer {
 
         if let Some(method) = ea.codebase.get_method(&fqcn, method_name) {
             ea.codebase.mark_method_referenced(&fqcn, method_name);
+            // Emit DeprecatedMethodCall if the method is marked @deprecated
+            if method.is_deprecated {
+                ea.emit(
+                    IssueKind::DeprecatedMethodCall {
+                        class: fqcn.clone(),
+                        method: method_name.to_string(),
+                    },
+                    Severity::Info,
+                    span,
+                );
+            }
             let arg_names: Vec<Option<String>> = call
                 .args
                 .iter()

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -241,6 +241,13 @@ pub enum IssueKind {
     },
 
     // --- Other --------------------------------------------------------------
+    DeprecatedCall {
+        name: String,
+    },
+    DeprecatedMethodCall {
+        class: String,
+        method: String,
+    },
     DeprecatedMethod {
         class: String,
         method: String,
@@ -345,6 +352,8 @@ impl IssueKind {
             | IssueKind::UnusedMethod { .. }
             | IssueKind::UnusedProperty { .. }
             | IssueKind::UnusedFunction { .. }
+            | IssueKind::DeprecatedCall { .. }
+            | IssueKind::DeprecatedMethodCall { .. }
             | IssueKind::DeprecatedMethod { .. }
             | IssueKind::DeprecatedClass { .. }
             | IssueKind::InternalMethod { .. }
@@ -412,6 +421,8 @@ impl IssueKind {
             IssueKind::TaintedHtml => "TaintedHtml",
             IssueKind::TaintedSql => "TaintedSql",
             IssueKind::TaintedShell => "TaintedShell",
+            IssueKind::DeprecatedCall { .. } => "DeprecatedCall",
+            IssueKind::DeprecatedMethodCall { .. } => "DeprecatedMethodCall",
             IssueKind::DeprecatedMethod { .. } => "DeprecatedMethod",
             IssueKind::DeprecatedClass { .. } => "DeprecatedClass",
             IssueKind::InternalMethod { .. } => "InternalMethod",
@@ -638,6 +649,12 @@ impl IssueKind {
                 "Tainted shell command — possible command injection".to_string()
             }
 
+            IssueKind::DeprecatedCall { name } => {
+                format!("Call to deprecated function {}", name)
+            }
+            IssueKind::DeprecatedMethodCall { class, method } => {
+                format!("Call to deprecated method {}::{}", class, method)
+            }
             IssueKind::DeprecatedMethod { class, method } => {
                 format!("Method {}::{}() is deprecated", class, method)
             }


### PR DESCRIPTION
## Summary

- Added `DeprecatedCall { name }` and `DeprecatedMethodCall { class, method }` variants to `IssueKind`
- Both have severity `Info` (consistent with existing `DeprecatedMethod`/`DeprecatedClass`)
- `analyze_function_call` now emits `DeprecatedCall` when the resolved function has `is_deprecated = true`
- `analyze_method_call` and `analyze_static_method_call` now emit `DeprecatedMethodCall` similarly

This moves deprecated-call detection into mir so the LSP can consume it as a typed diagnostic rather than running its own AST walk.

## Prerequisite for

- jorgsowa/php-lsp#42 — Move deprecated-call detection from LSP into mir Pass 2

## Test plan

- [x] `cargo build` passes
- [x] All 125 tests pass