### PR TITLE
feat(cli): add --find-dead-code flag, disable dead code detection by default

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -27,6 +27,8 @@ pub struct ProjectAnalyzer {
     pub psr4: Option<Arc<crate::composer::Psr4Map>>,
     /// Whether stubs have already been loaded (to avoid double-loading).
     stubs_loaded: std::sync::atomic::AtomicBool,
+    /// When true, run dead code detection at the end of analysis.
+    pub find_dead_code: bool,
 }
 
 impl ProjectAnalyzer {
@@ -37,6 +39,7 @@ impl ProjectAnalyzer {
             on_file_done: None,
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
+            find_dead_code: false,
         }
     }
 
@@ -48,6 +51,7 @@ impl ProjectAnalyzer {
             on_file_done: None,
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
+            find_dead_code: false,
         }
     }
 
@@ -65,6 +69,7 @@ impl ProjectAnalyzer {
             on_file_done: None,
             psr4: Some(psr4),
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
+            find_dead_code: false,
         };
         Ok((analyzer, map))
     }
@@ -216,8 +221,11 @@ impl ProjectAnalyzer {
         }
 
         // ---- Dead-code detection (M18) --------------------------------------
-        let dead_code_issues = crate::dead_code::DeadCodeAnalyzer::new(&self.codebase).analyze();
-        all_issues.extend(dead_code_issues);
+        if self.find_dead_code {
+            let dead_code_issues =
+                crate::dead_code::DeadCodeAnalyzer::new(&self.codebase).analyze();
+            all_issues.extend(dead_code_issues);
+        }
 
         AnalysisResult {
             issues: all_issues,

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -91,6 +91,10 @@ struct Cli {
     /// Delete all cached results and exit
     #[arg(long)]
     clear_cache: bool,
+
+    /// Run dead code detection (UnusedMethod, UnusedProperty, UnusedFunction)
+    #[arg(long)]
+    find_dead_code: bool,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
@@ -198,6 +202,8 @@ fn main() {
                 analyzer.cache = Some(mir_analyzer::cache::AnalysisCache::open(cache_dir));
             }
         }
+
+        analyzer.find_dead_code = cli.find_dead_code;
 
         let vendor_files = map.vendor_files();
 
@@ -380,6 +386,8 @@ fn main() {
     } else {
         ProjectAnalyzer::new()
     };
+
+    analyzer.find_dead_code = cli.find_dead_code;
 
     // Load type stubs first (needed before collect_types_only)
     analyzer.load_stubs();


### PR DESCRIPTION
## Summary
- Adds `find_dead_code: bool` field to `ProjectAnalyzer` (default `false`); wraps `DeadCodeAnalyzer::analyze()` behind it
- Adds `--find-dead-code` CLI flag that opts into dead code detection; consistent with Psalm's default-off behavior
- Removes unconditional overhead from every analysis run

Closes #53