### PR TITLE
fix(analyzer): resolve class-level template params at instance method call sites

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -11,7 +11,7 @@ use mir_types::{Atomic, Union};
 
 use crate::context::Context;
 use crate::expr::ExpressionAnalyzer;
-use crate::generic::{check_template_bounds, infer_template_bindings};
+use crate::generic::{build_class_bindings, check_template_bounds, infer_template_bindings};
 use crate::taint::{classify_sink, is_expr_tainted, SinkKind};
 
 // ---------------------------------------------------------------------------
@@ -290,10 +290,10 @@ impl CallAnalyzer {
 
         for atomic in &receiver.types {
             match atomic {
-                Atomic::TNamedObject { fqcn, .. }
-                | Atomic::TSelf { fqcn }
-                | Atomic::TStaticObject { fqcn }
-                | Atomic::TParent { fqcn } => {
+                Atomic::TNamedObject {
+                    fqcn,
+                    type_params: receiver_type_params,
+                } => {
                     // Resolve short names to FQCN — docblock types may not be fully qualified.
                     let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
                     let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
@@ -339,12 +339,30 @@ impl CallAnalyzer {
                             .unwrap_or_else(Union::mixed);
                         // Bind `static` return type to the actual receiver class (LSB).
                         let ret_raw = substitute_static_in_return(ret_raw, fqcn);
-                        let ret = if !method.template_params.is_empty() {
-                            let bindings = infer_template_bindings(
+
+                        // Build class-level bindings from receiver's concrete type params (e.g. Collection<User> → T=User)
+                        let class_tps = ea.codebase.get_class_template_params(fqcn);
+                        let mut bindings = build_class_bindings(&class_tps, receiver_type_params);
+
+                        // Extend with method-level bindings; warn on name collision (method shadows class template)
+                        if !method.template_params.is_empty() {
+                            let method_bindings = infer_template_bindings(
                                 &method.template_params,
                                 &method.params,
                                 &arg_types,
                             );
+                            for key in method_bindings.keys() {
+                                if bindings.contains_key(key) {
+                                    ea.emit(
+                                        IssueKind::ShadowedTemplateParam {
+                                            name: key.to_string(),
+                                        },
+                                        Severity::Info,
+                                        span,
+                                    );
+                                }
+                            }
+                            bindings.extend(method_bindings);
                             for (name, inferred, bound) in
                                 check_template_bounds(&bindings, &method.template_params)
                             {
@@ -358,6 +376,134 @@ impl CallAnalyzer {
                                     span,
                                 );
                             }
+                        }
+
+                        let ret = if !bindings.is_empty() {
+                            ret_raw.substitute_templates(&bindings)
+                        } else {
+                            ret_raw
+                        };
+                        result = Union::merge(&result, &ret);
+                    } else if ea.codebase.type_exists(fqcn)
+                        && !ea.codebase.has_unknown_ancestor(fqcn)
+                    {
+                        // Class is known AND has no unscanned ancestors → genuine UndefinedMethod.
+                        // If the class has an external/unscanned parent (e.g. a PHPUnit TestCase),
+                        // the method might be inherited from that parent; skip to avoid false positives.
+                        // Classes with __call handle any method dynamically — suppress.
+                        // Interface types: method may exist on the concrete implementation — suppress
+                        // (UndefinedInterfaceMethod is not emitted at default error level).
+                        let is_interface = ea.codebase.interfaces.contains_key(fqcn.as_ref());
+                        let is_abstract = ea.codebase.is_abstract_class(fqcn.as_ref());
+                        if is_interface
+                            || is_abstract
+                            || ea.codebase.get_method(fqcn, "__call").is_some()
+                        {
+                            result = Union::merge(&result, &Union::mixed());
+                        } else {
+                            ea.emit(
+                                IssueKind::UndefinedMethod {
+                                    class: fqcn.to_string(),
+                                    method: method_name.clone(),
+                                },
+                                Severity::Error,
+                                span,
+                            );
+                            result = Union::merge(&result, &Union::mixed());
+                        }
+                    } else {
+                        result = Union::merge(&result, &Union::mixed());
+                    }
+                }
+                Atomic::TSelf { fqcn }
+                | Atomic::TStaticObject { fqcn }
+                | Atomic::TParent { fqcn } => {
+                    let receiver_type_params: &[mir_types::Union] = &[];
+                    // Resolve short names to FQCN — docblock types may not be fully qualified.
+                    let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
+                    let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
+                    if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
+                        // Record reference for dead-code detection (M18)
+                        ea.codebase.mark_method_referenced(fqcn, &method_name);
+                        // Emit DeprecatedMethodCall if the method is marked @deprecated
+                        if method.is_deprecated {
+                            ea.emit(
+                                IssueKind::DeprecatedMethodCall {
+                                    class: fqcn.to_string(),
+                                    method: method_name.clone(),
+                                },
+                                Severity::Info,
+                                span,
+                            );
+                        }
+                        // Visibility check (simplified — only checks private from outside)
+                        check_method_visibility(ea, &method, ctx, span);
+
+                        // Arg type check
+                        let arg_names: Vec<Option<String>> = call
+                            .args
+                            .iter()
+                            .map(|a| a.name.as_ref().map(|n| n.to_string()))
+                            .collect();
+                        check_args(
+                            ea,
+                            CheckArgsParams {
+                                fn_name: &method_name,
+                                params: &method.params,
+                                arg_types: &arg_types,
+                                arg_spans: &arg_spans,
+                                arg_names: &arg_names,
+                                call_span: span,
+                                has_spread: call.args.iter().any(|a| a.unpack),
+                            },
+                        );
+
+                        let ret_raw = method
+                            .effective_return_type()
+                            .cloned()
+                            .unwrap_or_else(Union::mixed);
+                        // Bind `static` return type to the actual receiver class (LSB).
+                        let ret_raw = substitute_static_in_return(ret_raw, fqcn);
+
+                        // Build class-level bindings from receiver's concrete type params (e.g. Collection<User> → T=User)
+                        let class_tps = ea.codebase.get_class_template_params(fqcn);
+                        let mut bindings = build_class_bindings(&class_tps, receiver_type_params);
+
+                        // Extend with method-level bindings; warn on name collision (method shadows class template)
+                        if !method.template_params.is_empty() {
+                            let method_bindings = infer_template_bindings(
+                                &method.template_params,
+                                &method.params,
+                                &arg_types,
+                            );
+                            for key in method_bindings.keys() {
+                                if bindings.contains_key(key) {
+                                    ea.emit(
+                                        IssueKind::ShadowedTemplateParam {
+                                            name: key.to_string(),
+                                        },
+                                        Severity::Info,
+                                        span,
+                                    );
+                                }
+                            }
+                            bindings.extend(method_bindings);
+                            for (name, inferred, bound) in
+                                check_template_bounds(&bindings, &method.template_params)
+                            {
+                                ea.emit(
+                                    IssueKind::InvalidTemplateParam {
+                                        name: name.to_string(),
+                                        expected_bound: format!("{}", bound),
+                                        actual: format!("{}", inferred),
+                                    },
+                                    Severity::Error,
+                                    span,
+                                );
+                            }
+                        }
+
+                        let ret = if !bindings.is_empty() {
                             ret_raw.substitute_templates(&bindings)
                         } else {
                             ret_raw

--- a/crates/mir-analyzer/src/generic.rs
+++ b/crates/mir-analyzer/src/generic.rs
@@ -61,6 +61,24 @@ pub fn check_template_bounds<'a>(
     violations
 }
 
+/// Build template bindings from a receiver's concrete type params.
+///
+/// Zips `class_template_params` (e.g. `[T]` declared on the class) with
+/// `receiver_type_params` (e.g. `[User]` from `Collection<User>`) to produce
+/// `{ T → User }`. If the receiver supplies fewer type params than the class
+/// declares, the trailing template params are left unbound. If the receiver
+/// supplies more, the extras are ignored.
+pub fn build_class_bindings(
+    class_template_params: &[TemplateParam],
+    receiver_type_params: &[Union],
+) -> HashMap<Arc<str>, Union> {
+    class_template_params
+        .iter()
+        .zip(receiver_type_params.iter())
+        .map(|(tp, ty)| (tp.name.clone(), ty.clone()))
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/crates/mir-analyzer/tests/generic_receiver.rs
+++ b/crates/mir-analyzer/tests/generic_receiver.rs
@@ -22,7 +22,7 @@ function test(): void {
 }
 "#;
     let issues = check(src);
-    assert_issue_kind(&issues, "UndefinedMethod", 16, 4);
+    assert_issue_kind(&issues, "UndefinedMethod", 14, 4);
 }
 
 #[test]

--- a/crates/mir-analyzer/tests/generic_receiver.rs
+++ b/crates/mir-analyzer/tests/generic_receiver.rs
@@ -1,0 +1,49 @@
+use mir_test_utils::{assert_issue_kind, assert_no_issue, check};
+
+#[test]
+fn class_level_template_resolves_to_concrete_type() {
+    // In the broken state, first() returns mixed → MixedMethodCall (not UndefinedMethod)
+    // when calling a non-existent method. In the fixed state, first() returns User →
+    // UndefinedMethod. This test gates the fix.
+    let src = r#"<?php
+/** @template T */
+class Collection {
+    /** @return T */
+    public function first(): mixed { return null; }
+}
+class User {
+    public function getName(): string { return 'Alice'; }
+}
+function test(): void {
+    /** @var Collection<User> $items */
+    $items = new Collection();
+    $first = $items->first();
+    $first->nonExistentMethod();
+}
+"#;
+    let issues = check(src);
+    assert_issue_kind(&issues, "UndefinedMethod", 16, 4);
+}
+
+#[test]
+fn class_level_template_allows_valid_user_methods() {
+    // After the fix, calling an existing User method must not emit UndefinedMethod.
+    let src = r#"<?php
+/** @template T */
+class Collection {
+    /** @return T */
+    public function first(): mixed { return null; }
+}
+class User {
+    public function getName(): string { return 'Alice'; }
+}
+function test(): void {
+    /** @var Collection<User> $items */
+    $items = new Collection();
+    $first = $items->first();
+    $first->getName();
+}
+"#;
+    let issues = check(src);
+    assert_no_issue(&issues, "UndefinedMethod");
+}

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -256,6 +256,21 @@ impl Codebase {
         self.classes.get(fqcn).is_some_and(|c| c.is_abstract)
     }
 
+    /// Return the declared template params for `fqcn` (class or interface), or
+    /// an empty vec if the type is not found or has no templates.
+    pub fn get_class_template_params(&self, fqcn: &str) -> Vec<crate::storage::TemplateParam> {
+        if let Some(cls) = self.classes.get(fqcn) {
+            return cls.template_params.clone();
+        }
+        if let Some(iface) = self.interfaces.get(fqcn) {
+            return iface.template_params.clone();
+        }
+        if let Some(tr) = self.traits.get(fqcn) {
+            return tr.template_params.clone();
+        }
+        vec![]
+    }
+
     /// Returns true if the class (or any ancestor/trait) defines a `__get` magic method.
     /// Such classes allow arbitrary property access, suppressing UndefinedProperty.
     pub fn has_magic_get(&self, fqcn: &str) -> bool {

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -239,6 +239,9 @@ pub enum IssueKind {
         expected_bound: String,
         actual: String,
     },
+    ShadowedTemplateParam {
+        name: String,
+    },
 
     // --- Other --------------------------------------------------------------
     DeprecatedCall {
@@ -366,7 +369,8 @@ impl IssueKind {
             | IssueKind::MixedArgument { .. }
             | IssueKind::MixedAssignment { .. }
             | IssueKind::MixedMethodCall { .. }
-            | IssueKind::MixedPropertyFetch { .. } => Severity::Info,
+            | IssueKind::MixedPropertyFetch { .. }
+            | IssueKind::ShadowedTemplateParam { .. } => Severity::Info,
         }
     }
 
@@ -417,6 +421,7 @@ impl IssueKind {
             IssueKind::FinalMethodOverridden { .. } => "FinalMethodOverridden",
             IssueKind::ReadonlyPropertyAssignment { .. } => "ReadonlyPropertyAssignment",
             IssueKind::InvalidTemplateParam { .. } => "InvalidTemplateParam",
+            IssueKind::ShadowedTemplateParam { .. } => "ShadowedTemplateParam",
             IssueKind::TaintedInput { .. } => "TaintedInput",
             IssueKind::TaintedHtml => "TaintedHtml",
             IssueKind::TaintedSql => "TaintedSql",
@@ -629,6 +634,12 @@ impl IssueKind {
                 format!(
                     "Template type '{}' inferred as '{}' does not satisfy bound '{}'",
                     name, actual, expected_bound
+                )
+            }
+            IssueKind::ShadowedTemplateParam { name } => {
+                format!(
+                    "Method template parameter '{}' shadows class-level template parameter with the same name",
+                    name
                 )
             }
             IssueKind::FinalMethodOverridden {

--- a/crates/mir-types/src/union.rs
+++ b/crates/mir-types/src/union.rs
@@ -397,6 +397,20 @@ impl Union {
                     });
                 }
                 Atomic::TNamedObject { fqcn, type_params } => {
+                    // TODO: the docblock parser emits TNamedObject { fqcn: "T" } for bare @return T
+                    // annotations instead of TTemplateParam, because it lacks template context at
+                    // parse time. This block works around that by treating bare unqualified names
+                    // as template param references when they appear in the binding map. Proper fix:
+                    // make the docblock parser template-aware so it emits TTemplateParam directly.
+                    // See issue #26 for context.
+                    if type_params.is_empty() && !fqcn.contains('\\') {
+                        if let Some(resolved) = bindings.get(fqcn.as_ref()) {
+                            for t in &resolved.types {
+                                result.add_type(t.clone());
+                            }
+                            continue;
+                        }
+                    }
                     let new_params = type_params
                         .iter()
                         .map(|p| p.substitute_templates(bindings))


### PR DESCRIPTION
## Summary

- Extract `type_params` from `TNamedObject` in `analyze_method_call` (previously discarded via `..`)
- Add `build_class_bindings` helper in `generic.rs`: zips class template param names with receiver concrete type params to produce bindings like `{T → User}` from `Collection<User>`
- Merge class-level bindings with method-level bindings at call time; emit `ShadowedTemplateParam` (Info) on name collision
- Add `get_class_template_params` accessor to `Codebase` (checks classes, interfaces, traits)
- Add `ShadowedTemplateParam { name }` issue kind at `Severity::Info`
- Workaround in `substitute_templates` for docblock parser emitting `TNamedObject` instead of `TTemplateParam` for bare type names (TODO comment added for proper fix)

Closes #26