### PR TITLE
test: fixture-based test suite with .phpt format

### DIFF
--- a/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+use ast\Node;
+function f(Node $x): void {}
+===expect===
+UndefinedClass at 3:11
+# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
+UnusedParam at 1:0

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test($x): bool {
+    return $x instanceof NoSuchClass;
+}
+===expect===
+UndefinedClass at 3:25

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+class Bar {}
+use Bar as Baz;
+function f(Baz $x): void {}
+===expect===
+# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
+UnusedParam at 1:0

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    new UnknownClass();
+}
+===expect===
+UndefinedClass at 3:8

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/stdclass_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/stdclass_not_reported.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function test(): void {
+    new stdClass();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/suppressed_via_psalm_suppress.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/suppressed_via_psalm_suppress.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+function test(): void {
+    /**
+     * @psalm-suppress UndefinedClass
+     */
+    new NoSuchClass();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function f(UnknownClass $x): void {}
+===expect===
+UndefinedClass at 2:11
+# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
+UnusedParam at 1:0

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function f(): UnknownClass {
+    return null;
+}
+===expect===
+UndefinedClass at 2:14

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/user_defined_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/user_defined_class_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+class MyClass {}
+function test(): void {
+    new MyClass();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/array_map_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/array_map_not_reported.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function test(): void {
+    array_map(fn($x) => $x, [1, 2, 3]);
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    \nonExistent();
+}
+===expect===
+UndefinedFunction at 3:4

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class A {
+    public function go(): void {
+        missing();
+    }
+}
+===expect===
+UndefinedFunction at 4:8

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+function test(): void {
+    foo();
+    foo();
+}
+===expect===
+UndefinedFunction at 3:4
+UndefinedFunction at 4:4

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/strlen_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/strlen_not_reported.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function test(): void {
+    strlen('hello');
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/suppressed_via_psalm_suppress.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/suppressed_via_psalm_suppress.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+function test(): void {
+    /**
+     * @psalm-suppress UndefinedFunction
+     */
+    noSuchFunction();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    foo();
+}
+===expect===
+UndefinedFunction at 3:4

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/unpack_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/unpack_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    $r = unpack('N*', pack('N*', 1));
+    var_dump($r);
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/user_defined_function_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/user_defined_function_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function myFn(): void {}
+function test(): void {
+    myFn();
+}
+===expect===

--- a/crates/mir-analyzer/tests/undefined_class.rs
+++ b/crates/mir-analyzer/tests/undefined_class.rs
@@ -1,76 +1,35 @@
-// crates/mir-analyzer/tests/undefined_class.rs
-use mir_test_utils::{assert_issue_kind, assert_no_issue, check};
+use mir_test_utils::fixture_test;
 
-#[test]
-fn reports_new_unknown_class() {
-    // new inside function body — analyzed in Pass 2
-    let src = "<?php\nfunction test(): void {\n    new UnknownClass();\n}\n";
-    let issues = check(src);
-    // "    new " = 8 chars → UnknownClass at col 8
-    assert_issue_kind(&issues, "UndefinedClass", 3, 8);
-}
-
-#[test]
-fn does_not_report_stdclass() {
-    // stdClass is a built-in PHP class — must not fire
-    let src = "<?php\nfunction test(): void {\n    new stdClass();\n}\n";
-    let issues = check(src);
-    assert_no_issue(&issues, "UndefinedClass");
-}
-
-#[test]
-fn does_not_report_user_defined_class() {
-    // User defines the class in the same file — no issue expected
-    let src = "<?php\nclass MyClass {}\nfunction test(): void {\n    new MyClass();\n}\n";
-    let issues = check(src);
-    assert_no_issue(&issues, "UndefinedClass");
-}
-
-#[test]
-fn reports_unknown_class_in_param_type_hint() {
-    // Type hints are checked in Pass 1
-    let src = "<?php\nfunction f(UnknownClass $x): void {}\n";
-    let issues = check(src);
-    assert_issue_kind(&issues, "UndefinedClass", 2, 11);
-}
-
-#[test]
-fn reports_unknown_class_in_return_type_hint() {
-    // Return type hints are checked in Pass 1
-    let src = "<?php\nfunction f(): UnknownClass {\n    return null;\n}\n";
-    let issues = check(src);
-    // Check for at least the return type hint issue on line 2 (col 14 = after "function f(): ")
-    assert_issue_kind(&issues, "UndefinedClass", 2, 14);
-}
-
-#[test]
-fn reports_extension_class_via_use_alias() {
-    // `use ast\Node` where `ast\Node` does not exist in codebase
-    let src = "<?php\nuse ast\\Node;\nfunction f(Node $x): void {}\n";
-    let issues = check(src);
-    assert_issue_kind(&issues, "UndefinedClass", 3, 11);
-}
-
-#[test]
-fn does_not_report_known_aliased_class() {
-    // User defines Bar, then aliases it as Baz — no issue expected
-    let src = "<?php\nclass Bar {}\nuse Bar as Baz;\nfunction f(Baz $x): void {}\n";
-    let issues = check(src);
-    assert_no_issue(&issues, "UndefinedClass");
-}
-
-#[test]
-fn reports_instanceof_unknown_class() {
-    let src = "<?php\nfunction test($x): bool {\n    return $x instanceof NoSuchClass;\n}\n";
-    let issues = check(src);
-    // "    return $x instanceof " = 25 chars → NoSuchClass starts at col 25
-    assert_issue_kind(&issues, "UndefinedClass", 3, 25);
-}
-
-#[test]
-fn does_not_report_after_suppression() {
-    // @psalm-suppress UndefinedClass on the expression should suppress the issue
-    let src = "<?php\nfunction test(): void {\n    /**\n     * @psalm-suppress UndefinedClass\n     */\n    new NoSuchClass();\n}\n";
-    let issues = check(src);
-    assert_no_issue(&issues, "UndefinedClass");
-}
+fixture_test!(new_unknown_class, "undefined_class/new_unknown_class.phpt");
+fixture_test!(
+    stdclass_not_reported,
+    "undefined_class/stdclass_not_reported.phpt"
+);
+fixture_test!(
+    user_defined_class_not_reported,
+    "undefined_class/user_defined_class_not_reported.phpt"
+);
+fixture_test!(
+    unknown_param_type_hint,
+    "undefined_class/unknown_param_type_hint.phpt"
+);
+fixture_test!(
+    unknown_return_type_hint,
+    "undefined_class/unknown_return_type_hint.phpt"
+);
+fixture_test!(
+    extension_class_via_use_alias,
+    "undefined_class/extension_class_via_use_alias.phpt"
+);
+fixture_test!(
+    known_aliased_class_not_reported,
+    "undefined_class/known_aliased_class_not_reported.phpt"
+);
+fixture_test!(
+    instanceof_unknown_class,
+    "undefined_class/instanceof_unknown_class.phpt"
+);
+fixture_test!(
+    suppressed_via_psalm_suppress,
+    "undefined_class/suppressed_via_psalm_suppress.phpt"
+);

--- a/crates/mir-analyzer/tests/undefined_function.rs
+++ b/crates/mir-analyzer/tests/undefined_function.rs
@@ -1,97 +1,35 @@
-// crates/mir-analyzer/tests/undefined_function.rs
-use mir_issues::IssueKind;
-use mir_test_utils::{assert_issue, assert_no_issue, check};
+use mir_test_utils::fixture_test;
 
-#[test]
-fn reports_unknown_function() {
-    let issues = check("<?php\nfunction test(): void {\n    foo();\n}\n");
-    assert_issue(
-        &issues,
-        IssueKind::UndefinedFunction { name: "foo".into() },
-        3,
-        4,
-    );
-}
-
-#[test]
-fn does_not_report_strlen() {
-    let issues = check("<?php\nfunction test(): void {\n    strlen('hello');\n}\n");
-    assert_no_issue(&issues, "UndefinedFunction");
-}
-
-#[test]
-fn does_not_report_array_map() {
-    let issues =
-        check("<?php\nfunction test(): void {\n    array_map(fn($x) => $x, [1, 2, 3]);\n}\n");
-    assert_no_issue(&issues, "UndefinedFunction");
-}
-
-#[test]
-fn does_not_report_user_defined_function() {
-    let issues =
-        check("<?php\nfunction myFn(): void {}\nfunction test(): void {\n    myFn();\n}\n");
-    assert_no_issue(&issues, "UndefinedFunction");
-}
-
-#[test]
-fn reports_global_namespace_unknown_function() {
-    // Leading \ forces global namespace lookup; still unknown
-    let issues = check("<?php\nfunction test(): void {\n    \\nonExistent();\n}\n");
-    assert_issue(
-        &issues,
-        IssueKind::UndefinedFunction {
-            name: "nonExistent".into(),
-        },
-        3,
-        4,
-    );
-}
-
-#[test]
-fn does_not_report_unpack() {
-    // unpack() is a PHP builtin — must be in stubs
-    // NOTE: this test currently FAILS if unpack() stub is missing (see CLAUDE.md gap analysis)
-    let issues =
-        check("<?php\nfunction test(): void {\n    $r = unpack('N*', pack('N*', 1));\n}\n");
-    assert_no_issue(&issues, "UndefinedFunction");
-}
-
-#[test]
-fn does_not_report_suppressed_call() {
-    let src = "<?php\nfunction test(): void {\n    /**\n     * @psalm-suppress UndefinedFunction\n     */\n    noSuchFunction();\n}\n";
-    let issues = check(src);
-    assert_no_issue(&issues, "UndefinedFunction");
-}
-
-#[test]
-fn reports_inside_method_body() {
-    let src = "<?php\nclass A {\n    public function go(): void {\n        missing();\n    }\n}\n";
-    let issues = check(src);
-    assert_issue(
-        &issues,
-        IssueKind::UndefinedFunction {
-            name: "missing".into(),
-        },
-        4,
-        8,
-    );
-}
-
-#[test]
-fn reports_each_call_site_independently() {
-    let src = "<?php\nfunction test(): void {\n    foo();\n    foo();\n}\n";
-    let issues = check(src);
-    // Two separate call sites — one on line 3 and one on line 4
-    assert_issue(
-        &issues,
-        IssueKind::UndefinedFunction { name: "foo".into() },
-        3,
-        4,
-    );
-    assert_issue(
-        &issues,
-        IssueKind::UndefinedFunction { name: "foo".into() },
-        4,
-        4,
-    );
-}
+fixture_test!(unknown_function, "undefined_function/unknown_function.phpt");
+fixture_test!(
+    strlen_not_reported,
+    "undefined_function/strlen_not_reported.phpt"
+);
+fixture_test!(
+    array_map_not_reported,
+    "undefined_function/array_map_not_reported.phpt"
+);
+fixture_test!(
+    user_defined_function_not_reported,
+    "undefined_function/user_defined_function_not_reported.phpt"
+);
+fixture_test!(
+    global_namespace_unknown_function,
+    "undefined_function/global_namespace_unknown_function.phpt"
+);
+fixture_test!(
+    unpack_not_reported,
+    "undefined_function/unpack_not_reported.phpt"
+);
+fixture_test!(
+    suppressed_via_psalm_suppress,
+    "undefined_function/suppressed_via_psalm_suppress.phpt"
+);
+fixture_test!(
+    inside_method_body,
+    "undefined_function/inside_method_body.phpt"
+);
+fixture_test!(
+    multiple_call_sites,
+    "undefined_function/multiple_call_sites.phpt"
+);

--- a/crates/mir-test-utils/src/lib.rs
+++ b/crates/mir-test-utils/src/lib.rs
@@ -23,6 +23,175 @@ pub fn check(src: &str) -> Vec<Issue> {
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// Fixture-based test support
+// ---------------------------------------------------------------------------
+
+/// One expected issue from a `.phpt` fixture's `===expect===` section.
+///
+/// Format: `KindName at LINE:COL`
+pub struct ExpectedIssue {
+    pub kind_name: String,
+    pub line: u32,
+    pub col: u16,
+}
+
+/// Parse a `.phpt` fixture file into `(php_source, expected_issues)`.
+///
+/// Fixture format:
+/// ```text
+/// ===source===
+/// <?php
+/// ...
+/// ===expect===
+/// UndefinedClass at 3:8
+/// UndefinedFunction at 5:4
+/// ```
+/// An empty `===expect===` section means no issues are expected.
+pub fn parse_phpt(content: &str, path: &str) -> (String, Vec<ExpectedIssue>) {
+    let source_marker = "===source===";
+    let expect_marker = "===expect===";
+
+    let source_pos = content
+        .find(source_marker)
+        .unwrap_or_else(|| panic!("fixture {} missing ===source=== section", path));
+    let expect_pos = content
+        .find(expect_marker)
+        .unwrap_or_else(|| panic!("fixture {} missing ===expect=== section", path));
+
+    assert!(
+        source_pos < expect_pos,
+        "fixture {}: ===source=== must come before ===expect===",
+        path
+    );
+
+    let source = content[source_pos + source_marker.len()..expect_pos]
+        .trim()
+        .to_string();
+    let expect_section = content[expect_pos + expect_marker.len()..].trim();
+
+    let expected: Vec<ExpectedIssue> = expect_section
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|l| parse_expected_line(l, path))
+        .collect();
+
+    (source, expected)
+}
+
+fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
+    // Format: "KindName at LINE:COL"
+    let parts: Vec<&str> = line.splitn(2, " at ").collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "fixture {}: invalid expect line {:?} — expected \"KindName at LINE:COL\"",
+        fixture_path,
+        line
+    );
+    let kind_name = parts[0].trim().to_string();
+    let loc: Vec<&str> = parts[1].trim().splitn(2, ':').collect();
+    assert_eq!(
+        loc.len(),
+        2,
+        "fixture {}: invalid location {:?} — expected \"LINE:COL\"",
+        fixture_path,
+        parts[1]
+    );
+    let line_num = loc[0]
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("fixture {}: invalid line number {:?}", fixture_path, loc[0]));
+    let col = loc[1]
+        .parse::<u16>()
+        .unwrap_or_else(|_| panic!("fixture {}: invalid col {:?}", fixture_path, loc[1]));
+
+    ExpectedIssue {
+        kind_name,
+        line: line_num,
+        col,
+    }
+}
+
+/// Run a `.phpt` fixture file: parse, analyze, and assert the issues match
+/// the `===expect===` section exactly (no missing, no unexpected).
+///
+/// Called by the [`fixture_test!`] macro.
+pub fn run_fixture(path: &str) {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {}", path, e));
+    let (source, expected) = parse_phpt(&content, path);
+    let actual = check(&source);
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for exp in &expected {
+        let found = actual.iter().any(|a| {
+            a.kind.name() == exp.kind_name
+                && a.location.line == exp.line
+                && a.location.col_start == exp.col
+        });
+        if !found {
+            failures.push(format!(
+                "  MISSING  {} at {}:{}",
+                exp.kind_name, exp.line, exp.col
+            ));
+        }
+    }
+
+    for act in &actual {
+        let expected_it = expected.iter().any(|e| {
+            e.kind_name == act.kind.name()
+                && e.line == act.location.line
+                && e.col == act.location.col_start
+        });
+        if !expected_it {
+            failures.push(format!(
+                "  UNEXPECTED {} at {}:{}  — {}",
+                act.kind.name(),
+                act.location.line,
+                act.location.col_start,
+                act.kind.message(),
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "fixture {} FAILED:\n{}\n\nAll actual issues:\n{}",
+            path,
+            failures.join("\n"),
+            fmt_issues(&actual)
+        );
+    }
+}
+
+/// Generate a `#[test]` function that runs a `.phpt` fixture file.
+///
+/// The path is relative to the crate's `tests/fixtures/` directory.
+///
+/// # Example
+/// ```rust,ignore
+/// fixture_test!(new_unknown_class, "undefined_class/new_unknown_class.phpt");
+/// ```
+#[macro_export]
+macro_rules! fixture_test {
+    ($name:ident, $path:expr) => {
+        #[test]
+        fn $name() {
+            mir_test_utils::run_fixture(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/",
+                $path
+            ));
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers (used by inline tests)
+// ---------------------------------------------------------------------------
+
 /// Assert that `issues` contains at least one issue with the exact `IssueKind`
 /// at `line` and `col_start`. Panics with the full issue list on failure.
 pub fn assert_issue(issues: &[Issue], kind: IssueKind, line: u32, col_start: u16) {


### PR DESCRIPTION
## Summary

- Introduces a `.phpt` fixture format (`===source===` / `===expect===`) inspired by [rust-php-parser](https://github.com/jorgsowa/rust-php-parser), so test cases live as self-describing PHP files instead of inline Rust strings
- Adds `parse_phpt()`, `run_fixture()`, and a `fixture_test!` macro to `mir-test-utils`; existing `assert_issue*` helpers are unchanged
- Converts `undefined_class` and `undefined_function` test suites (18 fixtures) as the canonical example — remaining test files keep the inline approach until migrated

## How it works

Each fixture has two sections:

```
===source===
<?php
function test(): void {
    new UnknownClass();
}
===expect===
UndefinedClass at 3:8
```

`===expect===` is **exact match**: the test fails if any listed issue is missing _or_ if the analyzer emits an unlisted issue. Comment lines (`# ...`) are supported for in-place annotations.

The `fixture_test!` macro expands to a `#[test]` fn that calls `run_fixture` with a path relative to the crate's `tests/fixtures/` directory:

```rust
fixture_test!(new_unknown_class, "undefined_class/new_unknown_class.phpt");
```

## Notes

Two fixtures document a known location bug where `UnusedParam` / `UnusedVariable` issues are reported at `1:0` instead of the actual parameter line — the comments in those fixtures flag this for a follow-up fix.