### PR TITLE
test(fixtures): use snippet-based expect format matching psalm-baseline

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -274,17 +274,20 @@ impl<'a> ClassAnalyzer<'a> {
                     && !child_ret.is_mixed()
                     && !self.return_type_has_template(parent_ret)
                 {
-                    issues.push(Issue::new(
-                        IssueKind::MethodSignatureMismatch {
-                            class: fqcn.to_string(),
-                            method: method_name.to_string(),
-                            detail: format!(
-                                "return type '{}' is not a subtype of parent '{}'",
-                                child_ret, parent_ret
-                            ),
-                        },
-                        loc.clone(),
-                    ));
+                    issues.push(
+                        Issue::new(
+                            IssueKind::MethodSignatureMismatch {
+                                class: fqcn.to_string(),
+                                method: method_name.to_string(),
+                                detail: format!(
+                                    "return type '{}' is not a subtype of parent '{}'",
+                                    child_ret, parent_ret
+                                ),
+                            },
+                            loc.clone(),
+                        )
+                        .with_snippet(method_name.to_string()),
+                    );
                 }
             }
 
@@ -301,17 +304,20 @@ impl<'a> ClassAnalyzer<'a> {
                 .count();
 
             if child_required > parent_required {
-                issues.push(Issue::new(
-                    IssueKind::MethodSignatureMismatch {
-                        class: fqcn.to_string(),
-                        method: method_name.to_string(),
-                        detail: format!(
-                            "overriding method requires {} argument(s) but parent requires {}",
-                            child_required, parent_required
-                        ),
-                    },
-                    loc.clone(),
-                ));
+                issues.push(
+                    Issue::new(
+                        IssueKind::MethodSignatureMismatch {
+                            class: fqcn.to_string(),
+                            method: method_name.to_string(),
+                            detail: format!(
+                                "overriding method requires {} argument(s) but parent requires {}",
+                                child_required, parent_required
+                            ),
+                        },
+                        loc.clone(),
+                    )
+                    .with_snippet(method_name.to_string()),
+                );
             }
 
             // ---- e. Param types must not be narrowed (contravariance) --------
@@ -349,17 +355,20 @@ impl<'a> ClassAnalyzer<'a> {
                 // Contravariance: parent_ty must be subtype of child_ty.
                 // If not, child has narrowed the param type.
                 if !parent_ty.is_subtype_of_simple(child_ty) {
-                    issues.push(Issue::new(
-                        IssueKind::MethodSignatureMismatch {
-                            class: fqcn.to_string(),
-                            method: method_name.to_string(),
-                            detail: format!(
-                                "parameter ${} type '{}' is narrower than parent type '{}'",
-                                child_param.name, child_ty, parent_ty
-                            ),
-                        },
-                        loc.clone(),
-                    ));
+                    issues.push(
+                        Issue::new(
+                            IssueKind::MethodSignatureMismatch {
+                                class: fqcn.to_string(),
+                                method: method_name.to_string(),
+                                detail: format!(
+                                    "parameter ${} type '{}' is narrower than parent type '{}'",
+                                    child_param.name, child_ty, parent_ty
+                                ),
+                            },
+                            loc.clone(),
+                        )
+                        .with_snippet(method_name.to_string()),
+                    );
                     break; // one issue per method is enough
                 }
             }

--- a/crates/mir-analyzer/src/parser/mod.rs
+++ b/crates/mir-analyzer/src/parser/mod.rs
@@ -90,6 +90,18 @@ pub fn span_to_line_col(src: &str, span: Span) -> (u32, u16) {
     (line, col)
 }
 
+/// Extract the exact source text covered by a span.
+pub fn span_text(src: &str, span: Span) -> Option<String> {
+    if span.start >= span.end {
+        return None;
+    }
+    let s = span.start as usize;
+    let e = (span.end as usize).min(src.len());
+    src.get(s..e)
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
 /// Extract the source line containing a span.
 pub fn span_snippet(src: &str, span: Span) -> String {
     let offset = span.start as usize;

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -875,15 +875,18 @@ fn check_type_hint_classes<'arena, 'src>(
             let resolved = codebase.resolve_class_name(file.as_ref(), &name_str);
             if !codebase.type_exists(&resolved) {
                 let (line, col) = crate::parser::span_to_line_col(source, hint.span);
-                issues.push(mir_issues::Issue::new(
-                    mir_issues::IssueKind::UndefinedClass { name: resolved },
-                    mir_issues::Location {
-                        file: file.clone(),
-                        line,
-                        col_start: col,
-                        col_end: col,
-                    },
-                ));
+                issues.push(
+                    mir_issues::Issue::new(
+                        mir_issues::IssueKind::UndefinedClass { name: resolved },
+                        mir_issues::Location {
+                            file: file.clone(),
+                            line,
+                            col_start: col,
+                            col_end: col,
+                        },
+                    )
+                    .with_snippet(crate::parser::span_text(source, hint.span).unwrap_or_default()),
+                );
             }
         }
         TypeHintKind::Nullable(inner) => {
@@ -939,17 +942,20 @@ fn emit_unused_params(
             continue;
         }
         if !ctx.read_vars.contains(name) {
-            issues.push(mir_issues::Issue::new(
-                mir_issues::IssueKind::UnusedParam {
-                    name: name.to_string(),
-                },
-                mir_issues::Location {
-                    file: file.clone(),
-                    line: 1,
-                    col_start: 0,
-                    col_end: 0,
-                },
-            ));
+            issues.push(
+                mir_issues::Issue::new(
+                    mir_issues::IssueKind::UnusedParam {
+                        name: name.to_string(),
+                    },
+                    mir_issues::Location {
+                        file: file.clone(),
+                        line: 1,
+                        col_start: 0,
+                        col_end: 0,
+                    },
+                )
+                .with_snippet(format!("${}", name)),
+            );
         }
     }
 }

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -186,18 +186,24 @@ impl<'a> StatementsAnalyzer<'a> {
                         {
                             let (line, col) =
                                 crate::parser::span_to_line_col(self.source, stmt.span);
-                            self.issues.add(mir_issues::Issue::new(
-                                IssueKind::InvalidReturnType {
-                                    expected: format!("{}", declared),
-                                    actual: format!("{}", ret_ty),
-                                },
-                                mir_issues::Location {
-                                    file: self.file.clone(),
-                                    line,
-                                    col_start: col,
-                                    col_end: col,
-                                },
-                            ));
+                            self.issues.add(
+                                mir_issues::Issue::new(
+                                    IssueKind::InvalidReturnType {
+                                        expected: format!("{}", declared),
+                                        actual: format!("{}", ret_ty),
+                                    },
+                                    mir_issues::Location {
+                                        file: self.file.clone(),
+                                        line,
+                                        col_start: col,
+                                        col_end: col,
+                                    },
+                                )
+                                .with_snippet(
+                                    crate::parser::span_text(self.source, stmt.span)
+                                        .unwrap_or_default(),
+                                ),
+                            );
                         }
                     }
                     self.return_types.push(ret_ty);
@@ -208,18 +214,24 @@ impl<'a> StatementsAnalyzer<'a> {
                         if !declared.is_void() && !declared.is_mixed() {
                             let (line, col) =
                                 crate::parser::span_to_line_col(self.source, stmt.span);
-                            self.issues.add(mir_issues::Issue::new(
-                                IssueKind::InvalidReturnType {
-                                    expected: format!("{}", declared),
-                                    actual: "void".to_string(),
-                                },
-                                mir_issues::Location {
-                                    file: self.file.clone(),
-                                    line,
-                                    col_start: col,
-                                    col_end: col,
-                                },
-                            ));
+                            self.issues.add(
+                                mir_issues::Issue::new(
+                                    IssueKind::InvalidReturnType {
+                                        expected: format!("{}", declared),
+                                        actual: "void".to_string(),
+                                    },
+                                    mir_issues::Location {
+                                        file: self.file.clone(),
+                                        line,
+                                        col_start: col,
+                                        col_end: col,
+                                    },
+                                )
+                                .with_snippet(
+                                    crate::parser::span_text(self.source, stmt.span)
+                                        .unwrap_or_default(),
+                                ),
+                            );
                         }
                     }
                 }
@@ -381,17 +393,23 @@ impl<'a> StatementsAnalyzer<'a> {
                 if !pre_diverges && (then_ctx.diverges || else_ctx.diverges) {
                     let (line, col) =
                         crate::parser::span_to_line_col(self.source, if_stmt.condition.span);
-                    self.issues.add(mir_issues::Issue::new(
-                        IssueKind::RedundantCondition {
-                            ty: format!("{}", cond_type),
-                        },
-                        mir_issues::Location {
-                            file: self.file.clone(),
-                            line,
-                            col_start: col,
-                            col_end: col,
-                        },
-                    ));
+                    self.issues.add(
+                        mir_issues::Issue::new(
+                            IssueKind::RedundantCondition {
+                                ty: format!("{}", cond_type),
+                            },
+                            mir_issues::Location {
+                                file: self.file.clone(),
+                                line,
+                                col_start: col,
+                                col_end: col,
+                            },
+                        )
+                        .with_snippet(
+                            crate::parser::span_text(self.source, if_stmt.condition.span)
+                                .unwrap_or_default(),
+                        ),
+                    );
                 }
 
                 // Merge all branches

--- a/crates/mir-analyzer/tests/fixtures/generic_receiver/class_level_template_resolves_to_concrete_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_receiver/class_level_template_resolves_to_concrete_type.phpt
@@ -15,4 +15,4 @@ function test(): void {
     $first->nonExistentMethod();
 }
 ===expect===
-UndefinedMethod at 14:4
+UndefinedMethod: $first->nonExistentMethod()

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_named_argument_wrong_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_named_argument_wrong_type.phpt
@@ -3,4 +3,4 @@
 function f(int $x): void { var_dump($x); }
 function test(): void { f(x: 'hello'); }
 ===expect===
-InvalidArgument at 3:26
+InvalidArgument: x: 'hello'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_object_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_object_passed_as_int.phpt
@@ -4,4 +4,4 @@ class Foo {}
 function f(int $x): void { var_dump($x); }
 function test(): void { f(new Foo()); }
 ===expect===
-InvalidArgument at 4:26
+InvalidArgument: new Foo()

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_string_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_string_passed_as_int.phpt
@@ -3,4 +3,4 @@
 function f(int $x): void { var_dump($x); }
 function test(): void { f('hello'); }
 ===expect===
-InvalidArgument at 3:26
+InvalidArgument: 'hello'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_variadic_wrong_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_variadic_wrong_type.phpt
@@ -3,4 +3,4 @@
 function f(int ...$xs): void { var_dump($xs); }
 function test(): void { f('a'); }
 ===expect===
-InvalidArgument at 3:26
+InvalidArgument: 'a'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_bare_return_from_non_void.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_bare_return_from_non_void.phpt
@@ -4,4 +4,4 @@ function f(): int {
     return;
 }
 ===expect===
-InvalidReturnType at 3:4
+InvalidReturnType: return;

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_null_returned_from_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_null_returned_from_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(): string {
     return null;
 }
 ===expect===
-InvalidReturnType at 3:4
+InvalidReturnType: return null;

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_return_null_from_void.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_return_null_from_void.phpt
@@ -4,4 +4,4 @@ function f(): void {
     return null;
 }
 ===expect===
-InvalidReturnType at 3:4
+InvalidReturnType: return null;

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_string_returned_from_int_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_string_returned_from_int_function.phpt
@@ -4,4 +4,4 @@ function f(): int {
     return 'hello';
 }
 ===expect===
-InvalidReturnType at 3:4
+InvalidReturnType: return 'hello';

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_wrong_union_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_wrong_union_return.phpt
@@ -5,4 +5,4 @@ function f(): int {
     return $x;
 }
 ===expect===
-InvalidReturnType at 4:4
+InvalidReturnType: return $x;

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_interface_implementation_wrong_signature.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_interface_implementation_wrong_signature.phpt
@@ -7,4 +7,4 @@ class C implements I {
     public function f(int $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_adds_required_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_adds_required_param.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_param_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_param_type.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(int $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_second_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_second_param.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x, int $y): void { var_dump($x, $y); }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_removes_default.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_removes_default.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_widening_return_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_widening_return_type.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(): int|string { return 1; }
 }
 ===expect===
-MethodSignatureMismatch at 1:0
+MethodSignatureMismatch: f

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_both_elements_of_multi_var_destructure.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_both_elements_of_multi_var_destructure.phpt
@@ -7,4 +7,4 @@ function test(): void {
     var_dump($a, $b);
 }
 ===expect===
-PossiblyInvalidArrayOffset at 5:4
+PossiblyInvalidArrayOffset: [$a, $b] = get()

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_destructure_of_array_or_false.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_destructure_of_array_or_false.phpt
@@ -7,4 +7,4 @@ function test(): void {
     var_dump($a, $b);
 }
 ===expect===
-PossiblyInvalidArrayOffset at 5:4
+PossiblyInvalidArrayOffset: [$a, $b] = get()

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_unpack_result_when_stub_present.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_unpack_result_when_stub_present.phpt
@@ -5,4 +5,4 @@ function test(): void {
     var_dump($a);
 }
 ===expect===
-PossiblyInvalidArrayOffset at 3:4
+PossiblyInvalidArrayOffset: [$a] = unpack('N', pack('N', 1))

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_is_string_on_string_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_is_string_on_string_type.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if (is_string($x)) {}
 }
 ===expect===
-RedundantCondition at 3:8
+RedundantCondition: is_string($x)

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_not_null_check_on_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_not_null_check_on_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if ($x !== null) {}
 }
 ===expect===
-RedundantCondition at 3:8
+RedundantCondition: $x !== null

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_null_check_on_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_null_check_on_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if ($x === null) {}
 }
 ===expect===
-RedundantCondition at 3:8
+RedundantCondition: $x === null

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_after_narrowing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_after_narrowing.phpt
@@ -6,4 +6,4 @@ function f(string|int $x): void {
     }
 }
 ===expect===
-RedundantCondition at 4:12
+RedundantCondition: is_string($x)

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
@@ -3,6 +3,5 @@
 use ast\Node;
 function f(Node $x): void {}
 ===expect===
-UndefinedClass at 3:11
-# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
-UnusedParam at 1:0
+UnusedParam: $x
+UndefinedClass: Node

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
@@ -4,4 +4,4 @@ function test($x): bool {
     return $x instanceof NoSuchClass;
 }
 ===expect===
-UndefinedClass at 3:25
+UndefinedClass: NoSuchClass

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
@@ -4,5 +4,4 @@ class Bar {}
 use Bar as Baz;
 function f(Baz $x): void {}
 ===expect===
-# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
-UnusedParam at 1:0
+UnusedParam: $x

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
@@ -4,4 +4,4 @@ function test(): void {
     new UnknownClass();
 }
 ===expect===
-UndefinedClass at 3:8
+UndefinedClass: UnknownClass

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
@@ -2,6 +2,5 @@
 <?php
 function f(UnknownClass $x): void {}
 ===expect===
-UndefinedClass at 2:11
-# UnusedParam location bug: parameter $x is reported at 1:0 instead of the correct line
-UnusedParam at 1:0
+UnusedParam: $x
+UndefinedClass: UnknownClass

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
@@ -4,4 +4,4 @@ function f(): UnknownClass {
     return null;
 }
 ===expect===
-UndefinedClass at 2:14
+UndefinedClass: UnknownClass

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
@@ -4,4 +4,4 @@ function test(): void {
     \nonExistent();
 }
 ===expect===
-UndefinedFunction at 3:4
+UndefinedFunction: \nonExistent()

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
@@ -6,4 +6,4 @@ class A {
     }
 }
 ===expect===
-UndefinedFunction at 4:8
+UndefinedFunction: missing()

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
@@ -5,5 +5,5 @@ function test(): void {
     foo();
 }
 ===expect===
-UndefinedFunction at 3:4
-UndefinedFunction at 4:4
+UndefinedFunction: foo()
+UndefinedFunction: foo()

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
@@ -4,4 +4,4 @@ function test(): void {
     foo();
 }
 ===expect===
-UndefinedFunction at 3:4
+UndefinedFunction: foo()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_call_on_null_as_undefined_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_call_on_null_as_undefined_method.phpt
@@ -5,4 +5,4 @@ function test(): void {
     $x->foo();
 }
 ===expect===
-NullMethodCall at 4:4
+NullMethodCall: $x->foo()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_method_call_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_method_call_on_mixed.phpt
@@ -6,4 +6,4 @@ function test(): void {
     $x->anything();
 }
 ===expect===
-MixedMethodCall at 5:4
+MixedMethodCall: $x->anything()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_instance_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_instance_method.phpt
@@ -6,4 +6,4 @@ function test(): void {
     $f->missing();
 }
 ===expect===
-UndefinedMethod at 5:4
+UndefinedMethod: $f->missing()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_static_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_static_method.phpt
@@ -5,4 +5,4 @@ function test(): void {
     Foo::missing();
 }
 ===expect===
-UndefinedMethod at 4:4
+UndefinedMethod: Foo::missing()

--- a/crates/mir-test-utils/src/lib.rs
+++ b/crates/mir-test-utils/src/lib.rs
@@ -29,11 +29,10 @@ pub fn check(src: &str) -> Vec<Issue> {
 
 /// One expected issue from a `.phpt` fixture's `===expect===` section.
 ///
-/// Format: `KindName at LINE:COL`
+/// Format: `KindName: snippet`
 pub struct ExpectedIssue {
     pub kind_name: String,
-    pub line: u32,
-    pub col: u16,
+    pub snippet: String,
 }
 
 /// Parse a `.phpt` fixture file into `(php_source, expected_issues)`.
@@ -44,8 +43,8 @@ pub struct ExpectedIssue {
 /// <?php
 /// ...
 /// ===expect===
-/// UndefinedClass at 3:8
-/// UndefinedFunction at 5:4
+/// UndefinedClass: UnknownClass
+/// UndefinedFunction: foo()
 /// ```
 /// An empty `===expect===` section means no issues are expected.
 pub fn parse_phpt(content: &str, path: &str) -> (String, Vec<ExpectedIssue>) {
@@ -80,46 +79,58 @@ pub fn parse_phpt(content: &str, path: &str) -> (String, Vec<ExpectedIssue>) {
     (source, expected)
 }
 
+/// Extract only the source section from a fixture file (used in UPDATE_FIXTURES mode
+/// to avoid parsing potentially stale/old-format expect sections).
+fn parse_phpt_source_only(content: &str, path: &str) -> String {
+    let source_marker = "===source===";
+    let expect_marker = "===expect===";
+
+    let source_pos = content
+        .find(source_marker)
+        .unwrap_or_else(|| panic!("fixture {} missing ===source=== section", path));
+    let expect_pos = content
+        .find(expect_marker)
+        .unwrap_or_else(|| panic!("fixture {} missing ===expect=== section", path));
+
+    content[source_pos + source_marker.len()..expect_pos]
+        .trim()
+        .to_string()
+}
+
 fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
-    // Format: "KindName at LINE:COL"
-    let parts: Vec<&str> = line.splitn(2, " at ").collect();
+    // Format: "KindName: snippet"
+    let parts: Vec<&str> = line.splitn(2, ": ").collect();
     assert_eq!(
         parts.len(),
         2,
-        "fixture {}: invalid expect line {:?} — expected \"KindName at LINE:COL\"",
+        "fixture {}: invalid expect line {:?} — expected \"KindName: snippet\"",
         fixture_path,
         line
     );
-    let kind_name = parts[0].trim().to_string();
-    let loc: Vec<&str> = parts[1].trim().splitn(2, ':').collect();
-    assert_eq!(
-        loc.len(),
-        2,
-        "fixture {}: invalid location {:?} — expected \"LINE:COL\"",
-        fixture_path,
-        parts[1]
-    );
-    let line_num = loc[0]
-        .parse::<u32>()
-        .unwrap_or_else(|_| panic!("fixture {}: invalid line number {:?}", fixture_path, loc[0]));
-    let col = loc[1]
-        .parse::<u16>()
-        .unwrap_or_else(|_| panic!("fixture {}: invalid col {:?}", fixture_path, loc[1]));
-
     ExpectedIssue {
-        kind_name,
-        line: line_num,
-        col,
+        kind_name: parts[0].trim().to_string(),
+        snippet: parts[1].trim().to_string(),
     }
 }
 
 /// Run a `.phpt` fixture file: parse, analyze, and assert the issues match
 /// the `===expect===` section exactly (no missing, no unexpected).
 ///
-/// Called by the [`fixture_test!`] macro.
+/// If the environment variable `UPDATE_FIXTURES` is set to `1`, the fixture
+/// file is rewritten with the actual issues instead of asserting.
+///
+/// Called by the auto-generated test functions in `build.rs`.
 pub fn run_fixture(path: &str) {
     let content = std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("failed to read fixture {}: {}", path, e));
+
+    if std::env::var("UPDATE_FIXTURES").as_deref() == Ok("1") {
+        let source = parse_phpt_source_only(&content, path);
+        let actual = check(&source);
+        rewrite_fixture(path, &content, &actual);
+        return;
+    }
+
     let (source, expected) = parse_phpt(&content, path);
     let actual = check(&source);
 
@@ -127,30 +138,23 @@ pub fn run_fixture(path: &str) {
 
     for exp in &expected {
         let found = actual.iter().any(|a| {
-            a.kind.name() == exp.kind_name
-                && a.location.line == exp.line
-                && a.location.col_start == exp.col
+            a.kind.name() == exp.kind_name && a.snippet.as_deref() == Some(exp.snippet.as_str())
         });
         if !found {
-            failures.push(format!(
-                "  MISSING  {} at {}:{}",
-                exp.kind_name, exp.line, exp.col
-            ));
+            failures.push(format!("  MISSING  {}: {}", exp.kind_name, exp.snippet));
         }
     }
 
     for act in &actual {
         let expected_it = expected.iter().any(|e| {
-            e.kind_name == act.kind.name()
-                && e.line == act.location.line
-                && e.col == act.location.col_start
+            e.kind_name == act.kind.name() && Some(e.snippet.as_str()) == act.snippet.as_deref()
         });
         if !expected_it {
+            let snippet = act.snippet.as_deref().unwrap_or("<no snippet>");
             failures.push(format!(
-                "  UNEXPECTED {} at {}:{}  — {}",
+                "  UNEXPECTED {}: {}  — {}",
                 act.kind.name(),
-                act.location.line,
-                act.location.col_start,
+                snippet,
                 act.kind.message(),
             ));
         }
@@ -164,6 +168,35 @@ pub fn run_fixture(path: &str) {
             fmt_issues(&actual)
         );
     }
+}
+
+/// Rewrite the fixture file's `===expect===` section with the actual issues.
+/// Preserves the `===source===` section unchanged.
+fn rewrite_fixture(path: &str, content: &str, actual: &[Issue]) {
+    let source_marker = "===source===";
+    let expect_marker = "===expect===";
+
+    let source_pos = content.find(source_marker).expect("missing ===source===");
+    let expect_pos = content.find(expect_marker).expect("missing ===expect===");
+
+    let source_section = &content[source_pos..expect_pos];
+
+    let mut new_content = String::new();
+    new_content.push_str(source_section);
+    new_content.push_str(expect_marker);
+    new_content.push('\n');
+
+    // Sort issues by (line, col, kind) for deterministic output.
+    let mut sorted: Vec<&Issue> = actual.iter().collect();
+    sorted.sort_by_key(|i| (i.location.line, i.location.col_start, i.kind.name()));
+
+    for issue in sorted {
+        let snippet = issue.snippet.as_deref().unwrap_or("<no snippet>");
+        new_content.push_str(&format!("{}: {}\n", issue.kind.name(), snippet));
+    }
+
+    std::fs::write(path, &new_content)
+        .unwrap_or_else(|e| panic!("failed to write fixture {}: {}", path, e));
 }
 
 /// Generate a `#[test]` function that runs a `.phpt` fixture file.
@@ -250,13 +283,8 @@ fn fmt_issues(issues: &[Issue]) -> String {
     issues
         .iter()
         .map(|i| {
-            format!(
-                "  {} @ line {}, col {} — {}",
-                i.kind.name(),
-                i.location.line,
-                i.location.col_start,
-                i.kind.message(),
-            )
+            let snippet = i.snippet.as_deref().unwrap_or("<no snippet>");
+            format!("  {}: {}  — {}", i.kind.name(), snippet, i.kind.message(),)
         })
         .collect::<Vec<_>>()
         .join("\n")


### PR DESCRIPTION
## Summary

- Replaces `KindName at LINE:COL` in `.phpt` fixture expect sections with `KindName: snippet`, matching how `psalm-baseline.xml` identifies issues — by source text rather than line/column position
- Adds `UPDATE_FIXTURES=1` env mode to `run_fixture` so fixtures can be auto-regenerated after analyzer changes without manual editing
- Ensures all issue kinds emit a snippet: `InvalidReturnType`, `RedundantCondition`, `MethodSignatureMismatch`, `UnusedParam`, and type-hint `UndefinedClass` now populate `Issue::snippet` where they previously did not

## Test plan

- All 72 `.phpt` fixtures migrated and passing (`cargo test` — 0 failures)
- `UPDATE_FIXTURES=1 cargo test` round-trips cleanly (rewrites produce identical content)