### PR TITLE
feat(codebase): store definition positions for go-to-definition

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -526,7 +526,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     visibility: c
                                         .visibility
                                         .map(|v| Self::convert_visibility(Some(v))),
-                                    location: None,
+                                    location: Some(
+                                        self.location(member.span.start, member.span.end),
+                                    ),
                                 },
                             );
                         }
@@ -606,7 +608,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     is_static: p.is_static,
                                     is_readonly: p.is_readonly,
                                     default: None,
-                                    location: None,
+                                    location: Some(
+                                        self.location(member.span.start, member.span.end),
+                                    ),
                                 },
                             );
                         }
@@ -617,7 +621,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     name: c.name.into(),
                                     ty: Union::mixed(),
                                     visibility: None,
-                                    location: None,
+                                    location: Some(
+                                        self.location(member.span.start, member.span.end),
+                                    ),
                                 },
                             );
                         }
@@ -668,7 +674,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 EnumCaseStorage {
                                     name: c.name.into(),
                                     value: c.value.as_ref().map(|_| Union::mixed()),
-                                    location: None,
+                                    location: Some(
+                                        self.location(member.span.start, member.span.end),
+                                    ),
                                 },
                             );
                         }
@@ -684,7 +692,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     name: c.name.into(),
                                     ty: Union::mixed(),
                                     visibility: None,
-                                    location: None,
+                                    location: Some(
+                                        self.location(member.span.start, member.span.end),
+                                    ),
                                 },
                             );
                         }

--- a/crates/mir-analyzer/tests/definition_positions.rs
+++ b/crates/mir-analyzer/tests/definition_positions.rs
@@ -1,0 +1,112 @@
+// Integration tests for definition position lookups (mir#78).
+//
+// After analysis, the codebase should store definition locations for all
+// top-level symbols and class members, and the get_symbol_location /
+// get_member_location APIs should return them.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn get_symbol_location_finds_class() {
+    let dir = TempDir::new().unwrap();
+    let file = write(&dir, "Foo.php", "<?php\nclass Foo {}\n");
+    let file_str = file.to_str().unwrap().to_string();
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(&[file]);
+
+    let loc = analyzer.codebase.get_symbol_location("Foo");
+    assert!(loc.is_some(), "should find location for class Foo");
+    let loc = loc.unwrap();
+    assert_eq!(loc.file.as_ref(), file_str.as_str());
+}
+
+#[test]
+fn get_symbol_location_finds_function() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "funcs.php",
+        "<?php\nfunction my_func(): int { return 1; }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(&[file]);
+
+    let loc = analyzer.codebase.get_symbol_location("my_func");
+    assert!(loc.is_some(), "should find location for function my_func");
+}
+
+#[test]
+fn get_symbol_location_finds_interface() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "Iface.php",
+        "<?php\ninterface Renderable { public function render(): string; }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(&[file]);
+
+    let loc = analyzer.codebase.get_symbol_location("Renderable");
+    assert!(loc.is_some(), "should find location for interface");
+}
+
+#[test]
+fn get_member_location_finds_method() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "Bar.php",
+        "<?php\nclass Bar {\n    public function baz(): void {}\n}\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(&[file]);
+
+    let loc = analyzer.codebase.get_member_location("Bar", "baz");
+    assert!(loc.is_some(), "should find location for method Bar::baz");
+}
+
+#[test]
+fn get_member_location_finds_property() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "Qux.php",
+        "<?php\nclass Qux {\n    public string $name = '';\n}\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(&[file]);
+
+    let loc = analyzer.codebase.get_member_location("Qux", "name");
+    assert!(
+        loc.is_some(),
+        "should find location for property Qux::$name"
+    );
+}
+
+#[test]
+fn get_symbol_location_returns_none_for_unknown() {
+    let analyzer = ProjectAnalyzer::new();
+    assert!(analyzer
+        .codebase
+        .get_symbol_location("NonExistent")
+        .is_none());
+    assert!(analyzer
+        .codebase
+        .get_member_location("NonExistent", "foo")
+        .is_none());
+}

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -441,6 +441,75 @@ impl Codebase {
     }
 
     // -----------------------------------------------------------------------
+    // Definition location lookups
+    // -----------------------------------------------------------------------
+
+    /// Look up the definition location of any symbol (class, interface, trait, enum, function).
+    /// Returns the file path and byte offsets.
+    pub fn get_symbol_location(&self, fqcn: &str) -> Option<crate::storage::Location> {
+        if let Some(cls) = self.classes.get(fqcn) {
+            return cls.location.clone();
+        }
+        if let Some(iface) = self.interfaces.get(fqcn) {
+            return iface.location.clone();
+        }
+        if let Some(tr) = self.traits.get(fqcn) {
+            return tr.location.clone();
+        }
+        if let Some(en) = self.enums.get(fqcn) {
+            return en.location.clone();
+        }
+        if let Some(func) = self.functions.get(fqcn) {
+            return func.location.clone();
+        }
+        None
+    }
+
+    /// Look up the definition location of a class member (method, property, constant).
+    pub fn get_member_location(
+        &self,
+        fqcn: &str,
+        member_name: &str,
+    ) -> Option<crate::storage::Location> {
+        // Check methods
+        if let Some(method) = self.get_method(fqcn, member_name) {
+            return method.location.clone();
+        }
+        // Check properties
+        if let Some(prop) = self.get_property(fqcn, member_name) {
+            return prop.location.clone();
+        }
+        // Check class constants
+        if let Some(cls) = self.classes.get(fqcn) {
+            if let Some(c) = cls.own_constants.get(member_name) {
+                return c.location.clone();
+            }
+        }
+        // Check interface constants
+        if let Some(iface) = self.interfaces.get(fqcn) {
+            if let Some(c) = iface.own_constants.get(member_name) {
+                return c.location.clone();
+            }
+        }
+        // Check trait constants
+        if let Some(tr) = self.traits.get(fqcn) {
+            if let Some(c) = tr.own_constants.get(member_name) {
+                return c.location.clone();
+            }
+        }
+        // Check enum constants and cases
+        if let Some(en) = self.enums.get(fqcn) {
+            if let Some(c) = en.own_constants.get(member_name) {
+                return c.location.clone();
+            }
+            if let Some(case) = en.cases.get(member_name) {
+                return case.location.clone();
+            }
+        }
+        None
+    }
+
+    // -----------------------------------------------------------------------
     // Reference tracking (M18 dead-code detection)
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fill in missing `Location` data for interface/trait/enum constants, enum cases, and trait properties during Pass 1 collection
- Add `Codebase::get_symbol_location(fqcn)` — looks up definition location of any class/interface/trait/enum/function
- Add `Codebase::get_member_location(fqcn, member_name)` — looks up definition location of any method/property/constant/enum case

All position data uses byte offsets (`Location { file, start, end }`). The LSP converts to line/col using `span_to_line_col()`.

Closes #78

## Test plan

- [x] All 150 existing tests pass
- [x] `cargo clippy` clean