### PR TITLE
feat(analyzer): incremental single-file re-analysis

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -311,6 +311,65 @@ impl ProjectAnalyzer {
         }
     }
 
+    /// Re-analyze a single file within the existing codebase.
+    ///
+    /// This is the incremental analysis API for LSP:
+    /// 1. Removes old definitions from this file
+    /// 2. Re-runs Pass 1 (definition collection) on the new content
+    /// 3. Re-finalizes the codebase (rebuilds inheritance)
+    /// 4. Re-runs Pass 2 (body analysis) on this file
+    /// 5. Returns the analysis result for this file only
+    pub fn re_analyze_file(&self, file_path: &str, new_content: &str) -> AnalysisResult {
+        // 1. Remove old definitions from this file
+        self.codebase.remove_file_definitions(file_path);
+
+        // 2. Parse new content and run Pass 1
+        let file: Arc<str> = Arc::from(file_path);
+        let arena = bumpalo::Bump::new();
+        let parsed = php_rs_parser::parse(&arena, new_content);
+
+        let mut all_issues = Vec::new();
+
+        // Collect parse errors
+        for err in &parsed.errors {
+            all_issues.push(Issue::new(
+                mir_issues::IssueKind::ParseError {
+                    message: err.to_string(),
+                },
+                mir_issues::Location {
+                    file: file.clone(),
+                    line: 1,
+                    col_start: 0,
+                    col_end: 0,
+                },
+            ));
+        }
+
+        let collector = DefinitionCollector::new(&self.codebase, file.clone(), new_content);
+        all_issues.extend(collector.collect(&parsed.program));
+
+        // 3. Re-finalize (invalidation already done by remove_file_definitions)
+        self.codebase.finalize();
+
+        // 4. Run Pass 2 on this file
+        let (body_issues, symbols) =
+            self.analyze_bodies(&parsed.program, file.clone(), new_content);
+        all_issues.extend(body_issues);
+
+        // 5. Update cache if present
+        if let Some(cache) = &self.cache {
+            let h = hash_content(new_content);
+            cache.evict_with_dependents(&[file_path.to_string()]);
+            cache.put(file_path, h, all_issues.clone());
+        }
+
+        AnalysisResult {
+            issues: all_issues,
+            type_envs: HashMap::new(),
+            symbols,
+        }
+    }
+
     /// Analyze a PHP source string without a real file path.
     /// Useful for tests and LSP single-file mode.
     pub fn analyze_source(source: &str) -> AnalysisResult {

--- a/crates/mir-analyzer/tests/incremental_reanalysis.rs
+++ b/crates/mir-analyzer/tests/incremental_reanalysis.rs
@@ -1,0 +1,137 @@
+// Integration tests for incremental single-file re-analysis (mir#79).
+
+use std::fs;
+use std::path::PathBuf;
+
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn re_analyze_file_picks_up_new_error() {
+    let src_dir = TempDir::new().unwrap();
+
+    // Initial file: valid code, no issues expected for undefined functions
+    let file_a = write(
+        &src_dir,
+        "A.php",
+        "<?php\nfunction greet(): string { return 'hello'; }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    let result1 = analyzer.analyze(std::slice::from_ref(&file_a));
+
+    // The initial code should have no UndefinedFunction issues
+    let undef_fn_count = result1
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert_eq!(
+        undef_fn_count, 0,
+        "initial code should have no UndefinedFunction"
+    );
+
+    // Now re-analyze the same file with content that calls an undefined function
+    let file_path = file_a.to_string_lossy().to_string();
+    let new_content = "<?php\nfunction test(): void { nonexistent_func(); }\n";
+    let result2 = analyzer.re_analyze_file(&file_path, new_content);
+
+    let undef_fn_count2 = result2
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert!(
+        undef_fn_count2 > 0,
+        "re-analyzed code should report UndefinedFunction, got issues: {:?}",
+        result2
+            .issues
+            .iter()
+            .map(|i| i.kind.name())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn re_analyze_file_removes_old_definitions() {
+    let src_dir = TempDir::new().unwrap();
+
+    // Initial: defines class Foo with method bar()
+    let file_a = write(
+        &src_dir,
+        "A.php",
+        "<?php\nclass Foo { public function bar(): void {} }\n",
+    );
+    let file_b = write(
+        &src_dir,
+        "B.php",
+        "<?php\nfunction test(): void { $f = new Foo(); $f->bar(); }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    let result1 = analyzer.analyze(&[file_a.clone(), file_b.clone()]);
+
+    // bar() exists, so no UndefinedMethod on file B
+    let undef_method = result1
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedMethod")
+        .count();
+    assert_eq!(undef_method, 0, "bar() should be found");
+
+    // Now change A.php: rename the method from bar() to baz()
+    let file_path_a = file_a.to_string_lossy().to_string();
+    let new_content_a = "<?php\nclass Foo { public function baz(): void {} }\n";
+    let _result2 = analyzer.re_analyze_file(&file_path_a, new_content_a);
+
+    // Verify the old method bar() is gone and baz() exists
+    assert!(
+        analyzer.codebase().get_method("Foo", "baz").is_some(),
+        "baz() should exist after re-analysis"
+    );
+    assert!(
+        analyzer.codebase().get_method("Foo", "bar").is_none(),
+        "bar() should be removed after re-analysis"
+    );
+}
+
+#[test]
+fn re_analyze_file_fixes_error() {
+    let src_dir = TempDir::new().unwrap();
+
+    // Initial: code with a call to an undefined function
+    let file_a = write(
+        &src_dir,
+        "A.php",
+        "<?php\nfunction test(): void { missing_fn(); }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    let result1 = analyzer.analyze(std::slice::from_ref(&file_a));
+
+    let undef_count = result1
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert!(undef_count > 0, "should have UndefinedFunction initially");
+
+    // Fix the file: define the function and call it
+    let file_path = file_a.to_string_lossy().to_string();
+    let new_content =
+        "<?php\nfunction missing_fn(): void {}\nfunction test(): void { missing_fn(); }\n";
+    let result2 = analyzer.re_analyze_file(&file_path, new_content);
+
+    let undef_count2 = result2
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert_eq!(undef_count2, 0, "after fix, no UndefinedFunction expected");
+}

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -69,6 +69,42 @@ impl Codebase {
     }
 
     // -----------------------------------------------------------------------
+    // Incremental: remove all definitions from a single file
+    // -----------------------------------------------------------------------
+
+    /// Remove all definitions that were defined in the given file.
+    /// This clears classes, interfaces, traits, enums, functions, and constants
+    /// whose defining file matches `file_path`, as well as the file's import
+    /// and namespace entries. After calling this, `invalidate_finalization()`
+    /// is called so the next `finalize()` rebuilds inheritance.
+    pub fn remove_file_definitions(&self, file_path: &str) {
+        // Collect all symbols defined in this file
+        let symbols: Vec<Arc<str>> = self
+            .symbol_to_file
+            .iter()
+            .filter(|entry| entry.value().as_ref() == file_path)
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        // Remove each symbol from its respective map and from symbol_to_file
+        for sym in &symbols {
+            self.classes.remove(sym.as_ref());
+            self.interfaces.remove(sym.as_ref());
+            self.traits.remove(sym.as_ref());
+            self.enums.remove(sym.as_ref());
+            self.functions.remove(sym.as_ref());
+            self.constants.remove(sym.as_ref());
+            self.symbol_to_file.remove(sym.as_ref());
+        }
+
+        // Remove file-level metadata
+        self.file_imports.remove(file_path);
+        self.file_namespaces.remove(file_path);
+
+        self.invalidate_finalization();
+    }
+
+    // -----------------------------------------------------------------------
     // Lookups
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `Codebase::remove_file_definitions(file_path)` — clears all classes, interfaces, traits, enums, functions, constants, imports, and namespaces defined in a single file
- Add `ProjectAnalyzer::re_analyze_file(file_path, new_content) -> AnalysisResult` — re-analyzes one file within the existing codebase context

The re-analysis flow: remove old defs → Pass 1 on new content → re-finalize → Pass 2 → update cache (evict dependents).

This is the incremental analysis API for LSP — responsive diagnostics on file save/change without re-analyzing the entire project.

Closes #79

## Test plan

- [x] 3 new integration tests: picks up new errors, removes old definitions, fixes errors
- [x] All 153 tests pass
- [x] `cargo clippy` clean