### PR TITLE
fix(issues): change UnusedVariable default severity to Info

### DIFF
--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -335,8 +335,10 @@ impl IssueKind {
             | IssueKind::UndefinedProperty { .. }
             | IssueKind::InvalidOperand { .. }
             | IssueKind::OverriddenMethodAccess { .. }
-            | IssueKind::MissingThrowsDocblock { .. }
-            | IssueKind::UnusedVariable { .. } => Severity::Warning,
+            | IssueKind::MissingThrowsDocblock { .. } => Severity::Warning,
+
+            // Unused variables — Info so they are hidden by default (like Psalm errorLevel ≤ 6)
+            IssueKind::UnusedVariable { .. } => Severity::Info,
 
             // Possibly-null / possibly-undefined (only shown in strict mode, level ≥ 7)
             IssueKind::PossiblyUndefinedVariable { .. }


### PR DESCRIPTION
## Summary

- Change `UnusedVariable` default severity from `Warning` to `Info`
- Matches Psalm behavior: UnusedVariable hidden at errorLevel ≤ 6 unless `findUnusedVariables` is explicitly enabled
- Still visible with `--show-info` or `error_level >= 7`

**app-server benchmark impact:** 11,507 → 41 issues (99.6% noise reduction)

## Test plan

- [x] All 159 tests pass
- [x] `cargo clippy` clean
- [x] Verified on app-server: 41 remaining issues (25 MethodSignatureMismatch, 7 ParseError, 4 UndefinedClass, 4 InvalidReturnType, 1 UndefinedFunction)