### PR TITLE
fix(analyzer): further reduce UnusedVariable FPs from 405 to 127

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -35,14 +35,9 @@ impl CallAnalyzer {
         // Resolve function name first (needed for sink check before arg eval)
         let fn_name = match &call.name.kind {
             ExprKind::Identifier(name) => (*name).to_string(),
-            ExprKind::Variable(_) => {
-                // dynamic call — evaluate args anyway
-                for arg in call.args.iter() {
-                    ea.analyze(&arg.value, ctx);
-                }
-                return Union::mixed();
-            }
             _ => {
+                // dynamic call — evaluate name and args for read tracking
+                ea.analyze(call.name, ctx);
                 for arg in call.args.iter() {
                     ea.analyze(&arg.value, ctx);
                 }

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -265,6 +265,11 @@ impl<'a> ExpressionAnalyzer<'a> {
                         let else_ty =
                             self.with_ctx(&mut else_ctx, |ea, c| ea.analyze(t.else_expr, c));
 
+                        // Propagate variable reads from both branches
+                        for name in then_ctx.read_vars.iter().chain(else_ctx.read_vars.iter()) {
+                            ctx.read_vars.insert(name.clone());
+                        }
+
                         Union::merge(&then_ty, &else_ty)
                     }
                     None => {
@@ -579,8 +584,10 @@ impl<'a> ExpressionAnalyzer<'a> {
                         );
                         ty
                     }
-                    ExprKind::Variable(_) => Union::single(Atomic::TObject),
-                    _ => Union::single(Atomic::TObject),
+                    _ => {
+                        self.analyze(n.class, ctx);
+                        Union::single(Atomic::TObject)
+                    }
                 };
                 class_ty
             }
@@ -891,6 +898,11 @@ impl<'a> ExpressionAnalyzer<'a> {
 
                     let arm_body_ty = self.analyze(&arm.body, &mut arm_ctx);
                     result = Union::merge(&result, &arm_body_ty);
+
+                    // Propagate variable reads from arm back to outer scope
+                    for name in &arm_ctx.read_vars {
+                        ctx.read_vars.insert(name.clone());
+                    }
                 }
                 if result.is_empty() {
                     Union::mixed()

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/dynamic_function_call_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/dynamic_function_call_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): string {
+    $fn = static fn(): string => 'hello';
+    return $fn();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/dynamic_new_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/dynamic_new_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): object {
+    $class = 'stdClass';
+    return new $class();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/match_arm_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/match_arm_not_reported.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+function test(string $type): string {
+    $msg = 'hello';
+    return match($type) {
+        'upper' => strtoupper($msg),
+        default => $msg,
+    };
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/ternary_else_branch_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/ternary_else_branch_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(bool $flag): string {
+    $default = 'fallback';
+    return $flag ? 'yes' : $default;
+}
+===expect===


### PR DESCRIPTION
## Summary
- Track variable reads in dynamic `new $class()`, dynamic `$fn()` calls, ternary branches, and match arms
- Reduces UnusedVariable false positives on app-server benchmark from 405 to 127
- Combined with the previous PR, total reduction is **1414 → 127** (~91%)

## Details
| Fix | FPs eliminated |
|-----|---------------|
| Dynamic `new $class()` / `$fn()` | ~62 |
| Ternary branch read propagation | ~154 |
| Match arm read propagation | ~62 |

Total app-server issues now: ~184 (down from ~58,850 originally)

## Test plan
- [x] All existing tests pass
- [x] 4 new fixture tests added and passing
- [x] Benchmarked against app-server codebase