### PR TITLE
refactor: adopt SourceMap from php-ast 0.4.0

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -12,7 +12,7 @@ use std::ops::ControlFlow;
 
 use php_ast::visitor::Visitor;
 
-use crate::parser::{find_preceding_docblock, name_to_string, span_to_line_col, type_from_hint};
+use crate::parser::{find_preceding_docblock, name_to_string, type_from_hint};
 use mir_codebase::storage::{
     ConstantStorage, EnumCaseStorage, FnParam, FunctionStorage, InterfaceStorage, Location,
     MethodStorage, PropertyStorage, TemplateParam, TraitStorage, Visibility,
@@ -30,6 +30,7 @@ pub struct DefinitionCollector<'a> {
     codebase: &'a Codebase,
     file: Arc<str>,
     source: &'a str,
+    source_map: php_ast::source_map::SourceMap,
     namespace: Option<String>,
     /// `use` aliases: alias → FQCN
     use_aliases: std::collections::HashMap<String, String>,
@@ -39,6 +40,7 @@ pub struct DefinitionCollector<'a> {
 impl<'a> DefinitionCollector<'a> {
     pub fn new(codebase: &'a Codebase, file: Arc<str>, source: &'a str) -> Self {
         Self {
+            source_map: php_ast::source_map::SourceMap::new(source),
             codebase,
             file,
             source,
@@ -228,7 +230,8 @@ impl<'a> DefinitionCollector<'a> {
 
     #[allow(dead_code)]
     fn issue_location(&self, start: u32) -> IssueLocation {
-        let (line, col) = span_to_line_col(self.source, php_ast::Span::new(start, start));
+        let lc = self.source_map.offset_to_line_col(start);
+        let (line, col) = (lc.line + 1, lc.col as u16);
         IssueLocation {
             file: self.file.clone(),
             line,

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -21,6 +21,7 @@ pub struct ExpressionAnalyzer<'a> {
     pub codebase: &'a Codebase,
     pub file: Arc<str>,
     pub source: &'a str,
+    pub source_map: &'a php_ast::source_map::SourceMap,
     pub issues: &'a mut IssueBuffer,
     pub symbols: &'a mut Vec<ResolvedSymbol>,
 }
@@ -30,6 +31,7 @@ impl<'a> ExpressionAnalyzer<'a> {
         codebase: &'a Codebase,
         file: Arc<str>,
         source: &'a str,
+        source_map: &'a php_ast::source_map::SourceMap,
         issues: &'a mut IssueBuffer,
         symbols: &'a mut Vec<ResolvedSymbol>,
     ) -> Self {
@@ -37,6 +39,7 @@ impl<'a> ExpressionAnalyzer<'a> {
             codebase,
             file,
             source,
+            source_map,
             issues,
             symbols,
         }
@@ -736,6 +739,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                         self.codebase,
                         self.file.clone(),
                         self.source,
+                        self.source_map,
                         self.issues,
                         self.symbols,
                     );
@@ -1268,7 +1272,8 @@ impl<'a> ExpressionAnalyzer<'a> {
     // -----------------------------------------------------------------------
 
     pub fn emit(&mut self, kind: IssueKind, severity: Severity, span: php_ast::Span) {
-        let (line, col) = crate::parser::span_to_line_col(self.source, span);
+        let lc = self.source_map.offset_to_line_col(span.start);
+        let (line, col) = (lc.line + 1, lc.col as u16);
         let mut issue = Issue::new(
             kind,
             Location {

--- a/crates/mir-analyzer/src/parser/mod.rs
+++ b/crates/mir-analyzer/src/parser/mod.rs
@@ -81,15 +81,6 @@ impl Default for FileParser {
 // Source location helpers
 // ---------------------------------------------------------------------------
 
-/// Convert a byte-offset `Span` to a `(line, col)` pair given the source.
-pub fn span_to_line_col(src: &str, span: Span) -> (u32, u16) {
-    let offset = span.start as usize;
-    let before = &src[..offset.min(src.len())];
-    let line = before.bytes().filter(|&b| b == b'\n').count() as u32 + 1;
-    let col = before.rfind('\n').map(|p| offset - p - 1).unwrap_or(offset) as u16;
-    (line, col)
-}
-
 /// Extract the exact source text covered by a span.
 pub fn span_text(src: &str, span: Span) -> Option<String> {
     if span.start >= span.end {

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -534,8 +534,15 @@ impl ProjectAnalyzer {
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
         let mut buf = IssueBuffer::new();
-        let mut sa =
-            StatementsAnalyzer::new(&self.codebase, file.clone(), source, &mut buf, all_symbols);
+        let sm = php_ast::source_map::SourceMap::new(source);
+        let mut sa = StatementsAnalyzer::new(
+            &self.codebase,
+            file.clone(),
+            source,
+            &sm,
+            &mut buf,
+            all_symbols,
+        );
         sa.analyze_stmts(body, &mut ctx);
         let inferred = merge_return_types(&sa.return_types);
         drop(sa);
@@ -610,10 +617,12 @@ impl ProjectAnalyzer {
             );
 
             let mut buf = IssueBuffer::new();
+            let sm = php_ast::source_map::SourceMap::new(source);
             let mut sa = StatementsAnalyzer::new(
                 &self.codebase,
                 file.clone(),
                 source,
+                &sm,
                 &mut buf,
                 all_symbols,
             );
@@ -784,8 +793,15 @@ impl ProjectAnalyzer {
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
         let mut buf = IssueBuffer::new();
-        let mut sa =
-            StatementsAnalyzer::new(&self.codebase, file.clone(), source, &mut buf, all_symbols);
+        let sm = php_ast::source_map::SourceMap::new(source);
+        let mut sa = StatementsAnalyzer::new(
+            &self.codebase,
+            file.clone(),
+            source,
+            &sm,
+            &mut buf,
+            all_symbols,
+        );
         sa.analyze_stmts(body, &mut ctx);
         let inferred = merge_return_types(&sa.return_types);
         drop(sa);
@@ -871,10 +887,12 @@ impl ProjectAnalyzer {
             );
 
             let mut buf = IssueBuffer::new();
+            let sm = php_ast::source_map::SourceMap::new(source);
             let mut sa = StatementsAnalyzer::new(
                 &self.codebase,
                 file.clone(),
                 source,
+                &sm,
                 &mut buf,
                 all_symbols,
             );
@@ -988,7 +1006,9 @@ fn check_type_hint_classes<'arena, 'src>(
             }
             let resolved = codebase.resolve_class_name(file.as_ref(), &name_str);
             if !codebase.type_exists(&resolved) {
-                let (line, col) = crate::parser::span_to_line_col(source, hint.span);
+                let sm = php_ast::source_map::SourceMap::new(source);
+                let lc = sm.offset_to_line_col(hint.span.start);
+                let (line, col) = (lc.line + 1, lc.col as u16);
                 issues.push(
                     mir_issues::Issue::new(
                         mir_issues::IssueKind::UndefinedClass { name: resolved },

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -21,6 +21,7 @@ pub struct StatementsAnalyzer<'a> {
     pub codebase: &'a Codebase,
     pub file: Arc<str>,
     pub source: &'a str,
+    pub source_map: &'a php_ast::source_map::SourceMap,
     pub issues: &'a mut IssueBuffer,
     pub symbols: &'a mut Vec<ResolvedSymbol>,
     /// Accumulated inferred return types for the current function.
@@ -35,6 +36,7 @@ impl<'a> StatementsAnalyzer<'a> {
         codebase: &'a Codebase,
         file: Arc<str>,
         source: &'a str,
+        source_map: &'a php_ast::source_map::SourceMap,
         issues: &'a mut IssueBuffer,
         symbols: &'a mut Vec<ResolvedSymbol>,
     ) -> Self {
@@ -42,6 +44,7 @@ impl<'a> StatementsAnalyzer<'a> {
             codebase,
             file,
             source,
+            source_map,
             issues,
             symbols,
             return_types: Vec::new(),
@@ -126,7 +129,10 @@ impl<'a> StatementsAnalyzer<'a> {
                 for expr in exprs.iter() {
                     // Taint check (M19): echoing tainted data → XSS
                     if crate::taint::is_expr_tainted(expr, ctx) {
-                        let (line, col) = crate::parser::span_to_line_col(self.source, stmt.span);
+                        let (line, col) = {
+                            let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                            (lc.line + 1, lc.col as u16)
+                        };
                         self.issues.add(mir_issues::Issue::new(
                             IssueKind::TaintedHtml,
                             mir_issues::Location {
@@ -188,8 +194,10 @@ impl<'a> StatementsAnalyzer<'a> {
                                 && !named_object_return_compatible(declared, &check_ty, self.codebase, &self.file)
                                 && !named_object_return_compatible(&declared.remove_null(), &check_ty.remove_null(), self.codebase, &self.file))
                         {
-                            let (line, col) =
-                                crate::parser::span_to_line_col(self.source, stmt.span);
+                            let (line, col) = {
+                                let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                                (lc.line + 1, lc.col as u16)
+                            };
                             self.issues.add(
                                 mir_issues::Issue::new(
                                     IssueKind::InvalidReturnType {
@@ -216,8 +224,10 @@ impl<'a> StatementsAnalyzer<'a> {
                     // Bare `return;` from a non-void declared function is an error.
                     if let Some(declared) = &ctx.fn_return_type.clone() {
                         if !declared.is_void() && !declared.is_mixed() {
-                            let (line, col) =
-                                crate::parser::span_to_line_col(self.source, stmt.span);
+                            let (line, col) = {
+                                let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                                (lc.line + 1, lc.col as u16)
+                            };
                             self.issues.add(
                                 mir_issues::Issue::new(
                                     IssueKind::InvalidReturnType {
@@ -268,8 +278,10 @@ impl<'a> StatementsAnalyzer<'a> {
                                 // Suppress if class is not in codebase at all (could be extension class)
                                 || (!self.codebase.type_exists(&resolved) && !self.codebase.type_exists(fqcn));
                             if !is_throwable {
-                                let (line, col) =
-                                    crate::parser::span_to_line_col(self.source, stmt.span);
+                                let (line, col) = {
+                                    let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                                    (lc.line + 1, lc.col as u16)
+                                };
                                 self.issues.add(mir_issues::Issue::new(
                                     IssueKind::InvalidThrow {
                                         ty: fqcn.to_string(),
@@ -300,8 +312,10 @@ impl<'a> StatementsAnalyzer<'a> {
                                 || self.codebase.has_unknown_ancestor(&resolved)
                                 || self.codebase.has_unknown_ancestor(fqcn);
                             if !is_throwable {
-                                let (line, col) =
-                                    crate::parser::span_to_line_col(self.source, stmt.span);
+                                let (line, col) = {
+                                    let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                                    (lc.line + 1, lc.col as u16)
+                                };
                                 self.issues.add(mir_issues::Issue::new(
                                     IssueKind::InvalidThrow {
                                         ty: fqcn.to_string(),
@@ -317,8 +331,10 @@ impl<'a> StatementsAnalyzer<'a> {
                         }
                         mir_types::Atomic::TMixed | mir_types::Atomic::TObject => {}
                         _ => {
-                            let (line, col) =
-                                crate::parser::span_to_line_col(self.source, stmt.span);
+                            let (line, col) = {
+                                let lc = self.source_map.offset_to_line_col(stmt.span.start);
+                                (lc.line + 1, lc.col as u16)
+                            };
                             self.issues.add(mir_issues::Issue::new(
                                 IssueKind::InvalidThrow {
                                     ty: format!("{}", thrown_ty),
@@ -395,8 +411,10 @@ impl<'a> StatementsAnalyzer<'a> {
 
                 // Emit RedundantCondition if narrowing proves one branch is statically unreachable.
                 if !pre_diverges && (then_ctx.diverges || else_ctx.diverges) {
-                    let (line, col) =
-                        crate::parser::span_to_line_col(self.source, if_stmt.condition.span);
+                    let lc = self
+                        .source_map
+                        .offset_to_line_col(if_stmt.condition.span.start);
+                    let (line, col) = (lc.line + 1, lc.col as u16);
                     self.issues.add(
                         mir_issues::Issue::new(
                             IssueKind::RedundantCondition {
@@ -786,6 +804,7 @@ impl<'a> StatementsAnalyzer<'a> {
             self.codebase,
             self.file.clone(),
             self.source,
+            self.source_map,
             self.issues,
             self.symbols,
         )


### PR DESCRIPTION
## Summary
- Replace hand-rolled `span_to_line_col()` with `php_ast::source_map::SourceMap` for O(1) line/column lookups via binary search
- Add `source_map` field to `ExpressionAnalyzer` and `StatementsAnalyzer`
- Build `SourceMap` in `DefinitionCollector::new` and at each analysis entry point
- Remove `span_to_line_col` from `parser/mod.rs`

## Details
The old `span_to_line_col` scanned for newlines on every call (O(n) per invocation). `SourceMap` builds a line-start index once (O(n)) then resolves any offset in O(log n) via binary search.

Currently `SourceMap` is built per-function rather than per-file since threading a single instance through all function signatures would be more invasive. This is still an improvement since the old approach was O(n) per call.

Closes #92

## Test plan
- [x] All tests pass
- [x] Benchmarked against app-server — no regressions (identical issue counts)