### PR TITLE
refactor: adopt SymbolTable from php-ast 0.4.0 for pre-indexing

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -52,18 +52,6 @@ impl<'a> DefinitionCollector<'a> {
 
     pub fn collect<'arena, 'src>(mut self, program: &Program<'arena, 'src>) -> Vec<Issue> {
         let _ = self.visit_program(program);
-        // For files using simple (non-braced) namespaces or no namespace at all,
-        // the import table has not been stored yet — do it now.
-        if !self.codebase.file_imports.contains_key(self.file.as_ref()) {
-            self.codebase
-                .file_imports
-                .insert(self.file.clone(), self.use_aliases.clone());
-            if let Some(ns) = &self.namespace {
-                self.codebase
-                    .file_namespaces
-                    .insert(self.file.clone(), ns.clone());
-            }
-        }
         self.issues.into_issues()
     }
 
@@ -277,15 +265,6 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                         let saved_aliases = self.use_aliases.clone();
                         self.use_aliases.clear();
                         self.process_stmts(stmts);
-                        // Store the import table for this file so Pass 2 can use it
-                        self.codebase
-                            .file_imports
-                            .insert(self.file.clone(), self.use_aliases.clone());
-                        if let Some(ns_name) = &self.namespace {
-                            self.codebase
-                                .file_namespaces
-                                .insert(self.file.clone(), ns_name.clone());
-                        }
                         self.use_aliases = saved_aliases;
                     }
                     php_ast::ast::NamespaceBody::Simple => {

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -130,8 +130,48 @@ impl ProjectAnalyzer {
             })
             .collect();
 
-        // Definition collection is sequential — DashMap handles concurrent writes,
-        // but sequential avoids contention on small projects.
+        // ---- Pre-index pass: use SymbolTable to build FQCN index & file imports ---
+        // SymbolTable is lightweight (no type inference) so we run it in parallel.
+        file_data.par_iter().for_each(|(file, src)| {
+            let arena = bumpalo::Bump::new();
+            let result = php_rs_parser::parse(&arena, src);
+            let table = php_ast::symbol_table::SymbolTable::build(&result.program);
+
+            // Populate known_symbols with all top-level FQCNs
+            for sym in table.symbols() {
+                if sym.parent.is_none() {
+                    self.codebase
+                        .known_symbols
+                        .insert(Arc::from(sym.fqn.as_str()));
+                }
+            }
+
+            // Populate file_imports from SymbolTable imports
+            let mut imports = std::collections::HashMap::new();
+            for imp in table.imports() {
+                imports.insert(imp.local_name().to_string(), imp.name.to_string());
+            }
+            if !imports.is_empty() {
+                self.codebase.file_imports.insert(file.clone(), imports);
+            }
+
+            // Populate file_namespaces from top-level symbol FQNs
+            // (infer namespace from the first namespaced symbol)
+            for sym in table.symbols() {
+                if sym.parent.is_none() {
+                    if let Some(pos) = sym.fqn.rfind('\\') {
+                        let ns = &sym.fqn[..pos];
+                        self.codebase
+                            .file_namespaces
+                            .insert(file.clone(), ns.to_string());
+                        break;
+                    }
+                }
+            }
+        });
+
+        // ---- Pass 1: definition collection (sequential) -------------------------
+        // DashMap handles concurrent writes, but sequential avoids contention.
         for (file, src) in &file_data {
             let arena = bumpalo::Bump::new();
             let result = php_rs_parser::parse(&arena, src);

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -32,6 +32,11 @@ pub struct Codebase {
     /// path of the file that defines it. Populated during Pass 1.
     pub symbol_to_file: DashMap<Arc<str>, Arc<str>>,
 
+    /// Lightweight FQCN index populated by `SymbolTable` before Pass 1.
+    /// Enables O(1) "does this symbol exist?" checks before full definitions
+    /// are available.
+    pub known_symbols: DashSet<Arc<str>>,
+
     /// Per-file `use` alias maps: alias → FQCN.  Populated during Pass 1.
     ///
     /// Key: absolute file path (as `Arc<str>`).
@@ -95,6 +100,7 @@ impl Codebase {
             self.functions.remove(sym.as_ref());
             self.constants.remove(sym.as_ref());
             self.symbol_to_file.remove(sym.as_ref());
+            self.known_symbols.remove(sym.as_ref());
         }
 
         // Remove file-level metadata


### PR DESCRIPTION
## Summary
- Adds a parallel pre-indexing pass using `SymbolTable::build()` before the sequential `DefinitionCollector` loop
- Populates `file_imports`, `file_namespaces`, and a new `known_symbols: DashSet` on `Codebase`, removing that responsibility from `DefinitionCollector`
- `known_symbols` enables O(1) FQCN existence checks before full definitions are available

## Test plan
- [x] `cargo test` — all 175 tests pass
- [x] app-server benchmark — identical output to main branch (no regressions)

Closes #94