### PR TITLE
test: add fixtures for 10 previously uncovered rule categories

### DIFF
--- a/crates/mir-analyzer/tests/fixtures/final_class_extended/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_class_extended/basic.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+final class Base {}
+class Child extends Base {}
+===expect===
+FinalClassExtended: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/final_class_extended/not_reported_when_not_final.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_class_extended/not_reported_when_not_final.phpt
@@ -1,0 +1,5 @@
+===source===
+<?php
+class Base {}
+class Child extends Base {}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/final_method_overridden/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_method_overridden/basic.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class ParentClass {
+    final public function locked(): void {}
+}
+class Child extends ParentClass {
+    public function locked(): void {}
+}
+===expect===
+FinalMethodOverridden: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/final_method_overridden/non_final_method_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_method_overridden/non_final_method_not_reported.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class ParentClass {
+    public function unlocked(): void {}
+}
+class Child extends ParentClass {
+    public function unlocked(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/null_array_access/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_array_access/basic.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+function test(): void {
+    $x = null;
+    echo $x[0];
+}
+===expect===
+NullArrayAccess: $x[0]

--- a/crates/mir-analyzer/tests/fixtures/null_method_call/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_method_call/basic.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+function test(): void {
+    $x = null;
+    $x->foo();
+}
+===expect===
+NullMethodCall: $x->foo()

--- a/crates/mir-analyzer/tests/fixtures/null_method_call/from_ternary.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_method_call/from_ternary.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+function test(bool $flag): void {
+    $x = $flag ? new stdClass() : null;
+    $x->foo();
+}
+===expect===
+PossiblyNullMethodCall: $x->foo()
+UndefinedMethod: $x->foo()

--- a/crates/mir-analyzer/tests/fixtures/null_property_fetch/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_property_fetch/basic.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+function test(): void {
+    $x = null;
+    echo $x->prop;
+}
+===expect===
+NullPropertyFetch: $x->prop

--- a/crates/mir-analyzer/tests/fixtures/null_property_fetch/from_nullable_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_property_fetch/from_nullable_return.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+class Obj {
+    public int $val = 0;
+}
+function maybeNull(): ?Obj {
+    return null;
+}
+function test(): void {
+    $x = maybeNull();
+    echo $x->val;
+}
+===expect===
+PossiblyNullPropertyFetch: $x->val

--- a/crates/mir-analyzer/tests/fixtures/overridden_method_access/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/overridden_method_access/basic.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class ParentClass {
+    public function doStuff(): void {}
+}
+class Child extends ParentClass {
+    private function doStuff(): void {}
+}
+===expect===
+OverriddenMethodAccess: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/overridden_method_access/same_visibility_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/overridden_method_access/same_visibility_not_reported.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class ParentClass {
+    protected function doStuff(): void {}
+}
+class Child extends ParentClass {
+    protected function doStuff(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/overridden_method_access/widened_visibility_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/overridden_method_access/widened_visibility_not_reported.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class ParentClass {
+    protected function doStuff(): void {}
+}
+class Child extends ParentClass {
+    public function doStuff(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/tainted_html/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_html/basic.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    echo $_GET['x'];
+}
+===expect===
+TaintedHtml: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/tainted_html/sanitized_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_html/sanitized_not_reported.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function test(): void {
+    echo htmlspecialchars($_GET['x']);
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/tainted_html/variable_from_superglobal.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_html/variable_from_superglobal.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+function test(): void {
+    $name = $_POST['name'];
+    echo $name;
+}
+===expect===
+TaintedHtml: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/tainted_shell/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_shell/basic.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+function test(): void {
+    $cmd = $_GET['cmd'];
+    exec($cmd);
+}
+===expect===
+TaintedShell: exec($cmd)

--- a/crates/mir-analyzer/tests/fixtures/tainted_shell/sanitized_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_shell/sanitized_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    $cmd = escapeshellarg($_GET['cmd']);
+    exec($cmd);
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
@@ -1,0 +1,11 @@
+===source===
+<?php
+class Foo {
+    public string $name = '';
+}
+function test(): void {
+    $f = new Foo();
+    echo $f->nonexistent;
+}
+===expect===
+UndefinedProperty: $f->nonexistent

--- a/crates/mir-analyzer/tests/fixtures/undefined_property/inherited_property_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_property/inherited_property_not_reported.phpt
@@ -1,0 +1,11 @@
+===source===
+<?php
+class Base {
+    public string $name = '';
+}
+class Child extends Base {}
+function test(): void {
+    $c = new Child();
+    echo $c->name;
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_property/magic_get_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_property/magic_get_not_reported.phpt
@@ -1,0 +1,13 @@
+===source===
+<?php
+class Magic {
+    public function __get(string $name): mixed {
+        return null;
+    }
+}
+function test(): void {
+    $m = new Magic();
+    echo $m->anything;
+}
+===expect===
+UnusedParam: $name

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/abstract_child_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/abstract_child_not_reported.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+abstract class Base {
+    abstract public function doWork(): void;
+}
+abstract class StillAbstract extends Base {}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+abstract class Base {
+    abstract public function doWork(): void;
+}
+class Incomplete extends Base {}
+===expect===
+UnimplementedAbstractMethod: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/implemented_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/implemented_not_reported.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+abstract class Base {
+    abstract public function doWork(): void;
+}
+class Complete extends Base {
+    public function doWork(): void {}
+}
+===expect===


### PR DESCRIPTION
## Summary
- Adds 23 `.phpt` test fixtures covering 10 rule categories that previously had zero test coverage
- Increases fixture coverage from 11 to 21 rule categories (18% → 34% of issue kinds)
- Includes both positive tests (rule fires) and negative tests (rule correctly suppressed)

### New categories
- **Nullability**: NullMethodCall, NullPropertyFetch, NullArrayAccess
- **Undefined**: UndefinedProperty (with __get suppression, inheritance)
- **Inheritance**: FinalClassExtended, FinalMethodOverridden, OverriddenMethodAccess, UnimplementedAbstractMethod
- **Taint**: TaintedHtml (with sanitization), TaintedShell (with sanitization)

## Test plan
- [x] `cargo test` — all 119 fixture tests pass (up from 96)