### PR TITLE
chore: upgrade php-ast/php-rs-parser to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "php-ast"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2ba12f9fb7454758848aa054fe9d68f427bba8f411520b476995a1e64416bb"
+checksum = "0d5a308bf0bd456c28f8b9cb93bc1f37faf5402c531a1087f46c34a2903f2306"
 dependencies = [
  "bumpalo",
  "serde",
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffda679959e34dc202e5cab735bdace205d2201632b34554a136bc210586811a"
+checksum = "c7b35759abe5da820bac48e5aedea81e018cf32ab20ed5075c62a155c6a76d3e"
 dependencies = [
  "memchr",
  "php-ast",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7f7db244990e923acce3131537724c15019eafe7dc513ef7e67acc011cd78b"
+checksum = "cad3a83439d31f6285681e274b9f8038ea9129d85ee6da9ab624f941845538ed"
 dependencies = [
  "bumpalo",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.2.0" }
 mir-test-utils = { path = "crates/mir-test-utils", version = "0.2.0" }
 
 # PHP parsing
-php-rs-parser = "0.4.0"
-php-ast       = "0.4.0"
+php-rs-parser = "0.5.0"
+php-ast       = "0.5.0"
 bumpalo       = { version = "3", features = ["collections"] }
 
 # Data structures

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -30,7 +30,7 @@ pub struct DefinitionCollector<'a> {
     codebase: &'a Codebase,
     file: Arc<str>,
     source: &'a str,
-    source_map: php_ast::source_map::SourceMap,
+    source_map: &'a php_ast::source_map::SourceMap,
     namespace: Option<String>,
     /// `use` aliases: alias → FQCN
     use_aliases: std::collections::HashMap<String, String>,
@@ -38,9 +38,14 @@ pub struct DefinitionCollector<'a> {
 }
 
 impl<'a> DefinitionCollector<'a> {
-    pub fn new(codebase: &'a Codebase, file: Arc<str>, source: &'a str) -> Self {
+    pub fn new(
+        codebase: &'a Codebase,
+        file: Arc<str>,
+        source: &'a str,
+        source_map: &'a php_ast::source_map::SourceMap,
+    ) -> Self {
         Self {
-            source_map: php_ast::source_map::SourceMap::new(source),
+            source_map,
             codebase,
             file,
             source,

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -189,7 +189,8 @@ impl ProjectAnalyzer {
                 ));
             }
 
-            let collector = DefinitionCollector::new(&self.codebase, file.clone(), src);
+            let collector =
+                DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
             let issues = collector.collect(&result.program);
             all_issues.extend(issues);
         }
@@ -235,15 +236,19 @@ impl ProjectAnalyzer {
                         // Miss — analyze and store
                         let arena = bumpalo::Bump::new();
                         let parsed = php_rs_parser::parse(&arena, src);
-                        let (issues, symbols) =
-                            self.analyze_bodies(&parsed.program, file.clone(), src);
+                        let (issues, symbols) = self.analyze_bodies(
+                            &parsed.program,
+                            file.clone(),
+                            src,
+                            &parsed.source_map,
+                        );
                         cache.put(file, h, issues.clone());
                         (issues, symbols)
                     }
                 } else {
                     let arena = bumpalo::Bump::new();
                     let parsed = php_rs_parser::parse(&arena, src);
-                    self.analyze_bodies(&parsed.program, file.clone(), src)
+                    self.analyze_bodies(&parsed.program, file.clone(), src, &parsed.source_map)
                 };
                 if let Some(cb) = &self.on_file_done {
                     cb();
@@ -337,8 +342,12 @@ impl ProjectAnalyzer {
                     let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
                     let arena = bumpalo::Bump::new();
                     let result = php_rs_parser::parse(&arena, &src);
-                    let collector =
-                        crate::collector::DefinitionCollector::new(&self.codebase, file, &src);
+                    let collector = crate::collector::DefinitionCollector::new(
+                        &self.codebase,
+                        file,
+                        &src,
+                        &result.source_map,
+                    );
                     let issues = collector.collect(&result.program);
                     all_issues.extend(issues);
                 }
@@ -385,15 +394,24 @@ impl ProjectAnalyzer {
             ));
         }
 
-        let collector = DefinitionCollector::new(&self.codebase, file.clone(), new_content);
+        let collector = DefinitionCollector::new(
+            &self.codebase,
+            file.clone(),
+            new_content,
+            &parsed.source_map,
+        );
         all_issues.extend(collector.collect(&parsed.program));
 
         // 3. Re-finalize (invalidation already done by remove_file_definitions)
         self.codebase.finalize();
 
         // 4. Run Pass 2 on this file
-        let (body_issues, symbols) =
-            self.analyze_bodies(&parsed.program, file.clone(), new_content);
+        let (body_issues, symbols) = self.analyze_bodies(
+            &parsed.program,
+            file.clone(),
+            new_content,
+            &parsed.source_map,
+        );
         all_issues.extend(body_issues);
 
         // 5. Update cache if present
@@ -420,7 +438,8 @@ impl ProjectAnalyzer {
         let arena = bumpalo::Bump::new();
         let result = php_rs_parser::parse(&arena, source);
         let mut all_issues = Vec::new();
-        let collector = DefinitionCollector::new(&analyzer.codebase, file.clone(), source);
+        let collector =
+            DefinitionCollector::new(&analyzer.codebase, file.clone(), source, &result.source_map);
         all_issues.extend(collector.collect(&result.program));
         analyzer.codebase.finalize();
         let mut type_envs = std::collections::HashMap::new();
@@ -429,6 +448,7 @@ impl ProjectAnalyzer {
             &result.program,
             file.clone(),
             source,
+            &result.source_map,
             &mut type_envs,
             &mut all_symbols,
         ));
@@ -446,6 +466,7 @@ impl ProjectAnalyzer {
         program: &php_ast::ast::Program<'arena, 'src>,
         file: Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
     ) -> (Vec<mir_issues::Issue>, Vec<crate::symbol::ResolvedSymbol>) {
         use php_ast::ast::StmtKind;
 
@@ -455,13 +476,27 @@ impl ProjectAnalyzer {
         for stmt in program.stmts.iter() {
             match &stmt.kind {
                 StmtKind::Function(decl) => {
-                    self.analyze_fn_decl(decl, &file, source, &mut all_issues, &mut all_symbols);
+                    self.analyze_fn_decl(
+                        decl,
+                        &file,
+                        source,
+                        source_map,
+                        &mut all_issues,
+                        &mut all_symbols,
+                    );
                 }
                 StmtKind::Class(decl) => {
-                    self.analyze_class_decl(decl, &file, source, &mut all_issues, &mut all_symbols);
+                    self.analyze_class_decl(
+                        decl,
+                        &file,
+                        source,
+                        source_map,
+                        &mut all_issues,
+                        &mut all_symbols,
+                    );
                 }
                 StmtKind::Enum(decl) => {
-                    self.analyze_enum_decl(decl, &file, source, &mut all_issues);
+                    self.analyze_enum_decl(decl, &file, source, source_map, &mut all_issues);
                 }
                 StmtKind::Namespace(ns) => {
                     if let php_ast::ast::NamespaceBody::Braced(stmts) = &ns.body {
@@ -472,6 +507,7 @@ impl ProjectAnalyzer {
                                         decl,
                                         &file,
                                         source,
+                                        source_map,
                                         &mut all_issues,
                                         &mut all_symbols,
                                     );
@@ -481,12 +517,19 @@ impl ProjectAnalyzer {
                                         decl,
                                         &file,
                                         source,
+                                        source_map,
                                         &mut all_issues,
                                         &mut all_symbols,
                                     );
                                 }
                                 StmtKind::Enum(decl) => {
-                                    self.analyze_enum_decl(decl, &file, source, &mut all_issues);
+                                    self.analyze_enum_decl(
+                                        decl,
+                                        &file,
+                                        source,
+                                        source_map,
+                                        &mut all_issues,
+                                    );
                                 }
                                 _ => {}
                             }
@@ -501,11 +544,13 @@ impl ProjectAnalyzer {
     }
 
     /// Analyze a single function declaration body and collect issues + inferred return type.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_fn_decl<'arena, 'src>(
         &self,
         decl: &php_ast::ast::FunctionDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         all_symbols: &mut Vec<crate::symbol::ResolvedSymbol>,
     ) {
@@ -514,11 +559,11 @@ impl ProjectAnalyzer {
         // Check parameter and return type hints for undefined classes.
         for param in decl.params.iter() {
             if let Some(hint) = &param.type_hint {
-                check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
             }
         }
         if let Some(hint) = &decl.return_type {
-            check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+            check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
         }
         use crate::context::Context;
         use crate::stmt::StatementsAnalyzer;
@@ -574,12 +619,11 @@ impl ProjectAnalyzer {
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
         let mut buf = IssueBuffer::new();
-        let sm = php_ast::source_map::SourceMap::new(source);
         let mut sa = StatementsAnalyzer::new(
             &self.codebase,
             file.clone(),
             source,
-            &sm,
+            source_map,
             &mut buf,
             all_symbols,
         );
@@ -599,11 +643,13 @@ impl ProjectAnalyzer {
     }
 
     /// Analyze all method bodies on a class declaration and collect issues + inferred return types.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_class_decl<'arena, 'src>(
         &self,
         decl: &php_ast::ast::ClassDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         all_symbols: &mut Vec<crate::symbol::ResolvedSymbol>,
     ) {
@@ -630,11 +676,18 @@ impl ProjectAnalyzer {
             // Check parameter and return type hints for undefined classes (even abstract methods).
             for param in method.params.iter() {
                 if let Some(hint) = &param.type_hint {
-                    check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                    check_type_hint_classes(
+                        hint,
+                        &self.codebase,
+                        file,
+                        source,
+                        source_map,
+                        all_issues,
+                    );
                 }
             }
             if let Some(hint) = &method.return_type {
-                check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
             }
 
             let Some(body) = &method.body else { continue };
@@ -657,12 +710,11 @@ impl ProjectAnalyzer {
             );
 
             let mut buf = IssueBuffer::new();
-            let sm = php_ast::source_map::SourceMap::new(source);
             let mut sa = StatementsAnalyzer::new(
                 &self.codebase,
                 file.clone(),
                 source,
-                &sm,
+                source_map,
                 &mut buf,
                 all_symbols,
             );
@@ -683,11 +735,13 @@ impl ProjectAnalyzer {
     }
 
     /// Like `analyze_bodies` but also populates `type_envs` with per-scope type environments.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_bodies_typed<'arena, 'src>(
         &self,
         program: &php_ast::ast::Program<'arena, 'src>,
         file: Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
             crate::type_env::TypeEnv,
@@ -703,6 +757,7 @@ impl ProjectAnalyzer {
                         decl,
                         &file,
                         source,
+                        source_map,
                         &mut all_issues,
                         type_envs,
                         all_symbols,
@@ -713,13 +768,14 @@ impl ProjectAnalyzer {
                         decl,
                         &file,
                         source,
+                        source_map,
                         &mut all_issues,
                         type_envs,
                         all_symbols,
                     );
                 }
                 StmtKind::Enum(decl) => {
-                    self.analyze_enum_decl(decl, &file, source, &mut all_issues);
+                    self.analyze_enum_decl(decl, &file, source, source_map, &mut all_issues);
                 }
                 StmtKind::Namespace(ns) => {
                     if let php_ast::ast::NamespaceBody::Braced(stmts) = &ns.body {
@@ -730,6 +786,7 @@ impl ProjectAnalyzer {
                                         decl,
                                         &file,
                                         source,
+                                        source_map,
                                         &mut all_issues,
                                         type_envs,
                                         all_symbols,
@@ -740,13 +797,20 @@ impl ProjectAnalyzer {
                                         decl,
                                         &file,
                                         source,
+                                        source_map,
                                         &mut all_issues,
                                         type_envs,
                                         all_symbols,
                                     );
                                 }
                                 StmtKind::Enum(decl) => {
-                                    self.analyze_enum_decl(decl, &file, source, &mut all_issues);
+                                    self.analyze_enum_decl(
+                                        decl,
+                                        &file,
+                                        source,
+                                        source_map,
+                                        &mut all_issues,
+                                    );
                                 }
                                 _ => {}
                             }
@@ -760,11 +824,13 @@ impl ProjectAnalyzer {
     }
 
     /// Like `analyze_fn_decl` but also captures a `TypeEnv` for the function scope.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_fn_decl_typed<'arena, 'src>(
         &self,
         decl: &php_ast::ast::FunctionDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
@@ -781,11 +847,11 @@ impl ProjectAnalyzer {
 
         for param in decl.params.iter() {
             if let Some(hint) = &param.type_hint {
-                check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
             }
         }
         if let Some(hint) = &decl.return_type {
-            check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+            check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
         }
 
         let resolved_fn = self.codebase.resolve_class_name(file.as_ref(), fn_name);
@@ -833,12 +899,11 @@ impl ProjectAnalyzer {
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
         let mut buf = IssueBuffer::new();
-        let sm = php_ast::source_map::SourceMap::new(source);
         let mut sa = StatementsAnalyzer::new(
             &self.codebase,
             file.clone(),
             source,
-            &sm,
+            source_map,
             &mut buf,
             all_symbols,
         );
@@ -868,11 +933,13 @@ impl ProjectAnalyzer {
     }
 
     /// Like `analyze_class_decl` but also captures a `TypeEnv` per method scope.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_class_decl_typed<'arena, 'src>(
         &self,
         decl: &php_ast::ast::ClassDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
@@ -900,11 +967,18 @@ impl ProjectAnalyzer {
 
             for param in method.params.iter() {
                 if let Some(hint) = &param.type_hint {
-                    check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                    check_type_hint_classes(
+                        hint,
+                        &self.codebase,
+                        file,
+                        source,
+                        source_map,
+                        all_issues,
+                    );
                 }
             }
             if let Some(hint) = &method.return_type {
-                check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
             }
 
             let Some(body) = &method.body else { continue };
@@ -927,12 +1001,11 @@ impl ProjectAnalyzer {
             );
 
             let mut buf = IssueBuffer::new();
-            let sm = php_ast::source_map::SourceMap::new(source);
             let mut sa = StatementsAnalyzer::new(
                 &self.codebase,
                 file.clone(),
                 source,
-                &sm,
+                source_map,
                 &mut buf,
                 all_symbols,
             );
@@ -986,18 +1059,21 @@ impl ProjectAnalyzer {
         for (file, src) in &file_data {
             let arena = bumpalo::Bump::new();
             let result = php_rs_parser::parse(&arena, src);
-            let collector = DefinitionCollector::new(&self.codebase, file.clone(), src);
+            let collector =
+                DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
             // Ignore any issues emitted during vendor collection
             let _ = collector.collect(&result.program);
         }
     }
 
     /// Check type hints in enum methods for undefined classes.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_enum_decl<'arena, 'src>(
         &self,
         decl: &php_ast::ast::EnumDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
+        source_map: &php_ast::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
     ) {
         use php_ast::ast::EnumMemberKind;
@@ -1007,11 +1083,18 @@ impl ProjectAnalyzer {
             };
             for param in method.params.iter() {
                 if let Some(hint) = &param.type_hint {
-                    check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                    check_type_hint_classes(
+                        hint,
+                        &self.codebase,
+                        file,
+                        source,
+                        source_map,
+                        all_issues,
+                    );
                 }
             }
             if let Some(hint) = &method.return_type {
-                check_type_hint_classes(hint, &self.codebase, file, source, all_issues);
+                check_type_hint_classes(hint, &self.codebase, file, source, source_map, all_issues);
             }
         }
     }
@@ -1034,6 +1117,7 @@ fn check_type_hint_classes<'arena, 'src>(
     codebase: &Codebase,
     file: &Arc<str>,
     source: &str,
+    source_map: &php_ast::source_map::SourceMap,
     issues: &mut Vec<mir_issues::Issue>,
 ) {
     use php_ast::ast::TypeHintKind;
@@ -1046,8 +1130,7 @@ fn check_type_hint_classes<'arena, 'src>(
             }
             let resolved = codebase.resolve_class_name(file.as_ref(), &name_str);
             if !codebase.type_exists(&resolved) {
-                let sm = php_ast::source_map::SourceMap::new(source);
-                let lc = sm.offset_to_line_col(hint.span.start);
+                let lc = source_map.offset_to_line_col(hint.span.start);
                 let (line, col) = (lc.line + 1, lc.col as u16);
                 issues.push(
                     mir_issues::Issue::new(
@@ -1064,11 +1147,11 @@ fn check_type_hint_classes<'arena, 'src>(
             }
         }
         TypeHintKind::Nullable(inner) => {
-            check_type_hint_classes(inner, codebase, file, source, issues);
+            check_type_hint_classes(inner, codebase, file, source, source_map, issues);
         }
         TypeHintKind::Union(parts) | TypeHintKind::Intersection(parts) => {
             for part in parts.iter() {
-                check_type_hint_classes(part, codebase, file, source, issues);
+                check_type_hint_classes(part, codebase, file, source, source_map, issues);
             }
         }
         TypeHintKind::Keyword(_, _) => {} // built-in keyword, always valid


### PR DESCRIPTION
## Summary
- Upgrade php-ast and php-rs-parser from 0.4.0 to 0.5.0
- Thread `ParseResult.source_map` through the analysis pipeline instead of recreating `SourceMap::new(source)` at each call site
- `DefinitionCollector` now borrows `&SourceMap` from the parse result
- All Pass 2 analysis functions receive the SourceMap as a parameter

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 175 tests pass