### PR TITLE
feat(issues): add RelatedLocation to Issue for secondary diagnostic spans

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use mir_codebase::storage::{MethodStorage, Visibility};
 use mir_codebase::Codebase;
-use mir_issues::{Issue, IssueKind, Location};
+use mir_issues::{Issue, IssueKind, Location, RelatedLocation};
 
 // ---------------------------------------------------------------------------
 // ClassAnalyzer
@@ -158,13 +158,24 @@ impl<'a> ClassAnalyzer<'a> {
                 }
 
                 let loc = issue_location(cls.location.as_ref(), fqcn);
+                let mut related = Vec::new();
+                if let Some(rel_loc) = method.location.as_ref() {
+                    related.push(RelatedLocation {
+                        location: issue_location(Some(rel_loc), &method.fqcn),
+                        message: format!(
+                            "abstract method '{}' declared in '{}'",
+                            method_name, ancestor_fqcn
+                        ),
+                    });
+                }
                 let mut issue = Issue::new(
                     IssueKind::UnimplementedAbstractMethod {
                         class: fqcn.to_string(),
                         method: method_name.to_string(),
                     },
                     loc,
-                );
+                )
+                .with_related(related);
                 if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources) {
                     issue = issue.with_snippet(snippet);
                 }
@@ -198,7 +209,7 @@ impl<'a> ClassAnalyzer<'a> {
                 None => continue,
             };
 
-            for (method_name, _method) in &iface.own_methods {
+            for (method_name, iface_method) in &iface.own_methods {
                 // Check if the class provides a concrete implementation
                 let implemented = cls
                     .get_method(method_name.as_ref())
@@ -207,6 +218,16 @@ impl<'a> ClassAnalyzer<'a> {
 
                 if !implemented {
                     let loc = issue_location(cls.location.as_ref(), fqcn);
+                    let mut related = Vec::new();
+                    if let Some(rel_loc) = iface_method.location.as_ref() {
+                        related.push(RelatedLocation {
+                            location: issue_location(Some(rel_loc), &iface_method.fqcn),
+                            message: format!(
+                                "method '{}' required by interface '{}'",
+                                method_name, iface_fqcn
+                            ),
+                        });
+                    }
                     let mut issue = Issue::new(
                         IssueKind::UnimplementedInterfaceMethod {
                             class: fqcn.to_string(),
@@ -214,7 +235,8 @@ impl<'a> ClassAnalyzer<'a> {
                             method: method_name.to_string(),
                         },
                         loc,
-                    );
+                    )
+                    .with_related(related);
                     if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources) {
                         issue = issue.with_snippet(snippet);
                     }
@@ -246,6 +268,18 @@ impl<'a> ClassAnalyzer<'a> {
             };
 
             let loc = issue_location(own_method.location.as_ref(), fqcn);
+
+            // Build a related location pointing at the parent method definition,
+            // shared by all override-mismatch issues below.
+            let parent_related: Vec<RelatedLocation> = parent
+                .location
+                .as_ref()
+                .map(|rel_loc| RelatedLocation {
+                    location: issue_location(Some(rel_loc), &parent.fqcn),
+                    message: format!("parent method '{}' defined here", method_name),
+                })
+                .into_iter()
+                .collect();
 
             // ---- a. Cannot override a final method -------------------------
             if parent.is_final {
@@ -315,7 +349,8 @@ impl<'a> ClassAnalyzer<'a> {
                             },
                             loc.clone(),
                         )
-                        .with_snippet(method_name.to_string()),
+                        .with_snippet(method_name.to_string())
+                        .with_related(parent_related.clone()),
                     );
                 }
             }
@@ -345,7 +380,8 @@ impl<'a> ClassAnalyzer<'a> {
                         },
                         loc.clone(),
                     )
-                    .with_snippet(method_name.to_string()),
+                    .with_snippet(method_name.to_string())
+                    .with_related(parent_related.clone()),
                 );
             }
 
@@ -396,7 +432,8 @@ impl<'a> ClassAnalyzer<'a> {
                             },
                             loc.clone(),
                         )
-                        .with_snippet(method_name.to_string()),
+                        .with_snippet(method_name.to_string())
+                        .with_related(parent_related.clone()),
                     );
                     break; // one issue per method is enough
                 }

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -47,6 +47,19 @@ impl fmt::Display for Location {
 }
 
 // ---------------------------------------------------------------------------
+// RelatedLocation — secondary diagnostic span
+// ---------------------------------------------------------------------------
+
+/// A secondary location attached to an [`Issue`] to give context for the
+/// diagnostic (e.g. "parent method declared here", "interface requires this").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelatedLocation {
+    pub location: Location,
+    /// Short human-readable label, e.g. `"declared here"`.
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
 // IssueKind
 // ---------------------------------------------------------------------------
 
@@ -725,6 +738,9 @@ pub struct Issue {
     pub location: Location,
     pub snippet: Option<String>,
     pub suppressed: bool,
+    /// Secondary diagnostic spans — e.g. "parent method declared here".
+    /// Maps to `Diagnostic.relatedInformation` in the LSP protocol.
+    pub related: Vec<RelatedLocation>,
 }
 
 impl Issue {
@@ -736,11 +752,17 @@ impl Issue {
             location,
             snippet: None,
             suppressed: false,
+            related: Vec::new(),
         }
     }
 
     pub fn with_snippet(mut self, snippet: impl Into<String>) -> Self {
         self.snippet = Some(snippet.into());
+        self
+    }
+
+    pub fn with_related(mut self, related: Vec<RelatedLocation>) -> Self {
+        self.related = related;
         self
     }
 
@@ -764,7 +786,16 @@ impl fmt::Display for Issue {
             sev,
             self.kind.name().bold(),
             self.kind.message()
-        )
+        )?;
+        for rel in &self.related {
+            write!(
+                f,
+                "\n  {} note: {}",
+                rel.location.bright_black(),
+                rel.message
+            )?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes #114

## Summary
- Adds `RelatedLocation { location, message }` struct to `mir-issues`
- Adds `related: Vec<RelatedLocation>` field to `Issue` with a `with_related()` builder
- `Issue::Display` renders related locations as indented `note:` lines
- Populates related locations for three class-level checks in `mir-analyzer`:
  - `UnimplementedAbstractMethod` → points to abstract method declaration
  - `UnimplementedInterfaceMethod` → points to interface method declaration
  - `MethodSignatureMismatch` (return type / param count / param type) → points to parent method definition

## LSP mapping
`Issue.related` maps directly to `Diagnostic.relatedInformation` in the LSP protocol.

## Test plan
- [ ] All 152 fixture tests pass (`cargo test -p mir-analyzer --test fixtures`)
- [ ] `cargo build` clean
- [ ] `cargo clippy` clean