### PR TITLE
feat(analysis): add issues_by_file() to AnalysisResult

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -1377,4 +1377,19 @@ impl AnalysisResult {
             .filter(|i| i.severity == mir_issues::Severity::Warning)
             .count()
     }
+
+    /// Group issues by source file.
+    ///
+    /// Returns a map from absolute file path to the slice of issues that belong
+    /// to that file. Useful for LSP `textDocument/publishDiagnostics`, which
+    /// pushes diagnostics per document.
+    pub fn issues_by_file(&self) -> HashMap<std::sync::Arc<str>, Vec<&Issue>> {
+        let mut map: HashMap<std::sync::Arc<str>, Vec<&Issue>> = HashMap::new();
+        for issue in &self.issues {
+            map.entry(issue.location.file.clone())
+                .or_default()
+                .push(issue);
+        }
+        map
+    }
 }


### PR DESCRIPTION
Closes #111

## Summary
- Adds `AnalysisResult::issues_by_file() -> HashMap<Arc<str>, Vec<&Issue>>` to `mir-analyzer`
- Groups the flat `issues` vec by `issue.location.file`
- Zero-cost for callers that don't use it — existing `issues: Vec<Issue>` is unchanged

## LSP mapping
An LSP server calls `textDocument/publishDiagnostics` per document. `issues_by_file()` provides the grouping needed to drive those per-file pushes without the server having to understand `Issue.location`.

## Test plan
- [ ] All 152 fixture tests pass
- [ ] `cargo build` / `cargo clippy` clean