### PR TITLE
feat(codebase): expose definition location lookup via resolve_definition

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -1377,4 +1377,19 @@ impl AnalysisResult {
             .filter(|i| i.severity == mir_issues::Severity::Warning)
             .count()
     }
+
+    /// Look up the definition site for a resolved symbol.
+    ///
+    /// Delegates to [`mir_codebase::Codebase::resolve_definition`] via a
+    /// [`mir_codebase::DefinitionQuery`] derived from `symbol.kind`.
+    /// Returns `None` for variable references and for symbols not found in
+    /// the codebase.
+    pub fn resolve_definition(
+        &self,
+        symbol: &crate::symbol::ResolvedSymbol,
+        codebase: &mir_codebase::Codebase,
+    ) -> Option<mir_codebase::storage::Location> {
+        let query = mir_codebase::DefinitionQuery::from(&symbol.kind);
+        codebase.resolve_definition(&query)
+    }
 }

--- a/crates/mir-analyzer/src/symbol.rs
+++ b/crates/mir-analyzer/src/symbol.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use mir_codebase::DefinitionQuery;
 use mir_types::Union;
 use php_ast::Span;
 
@@ -36,4 +37,26 @@ pub enum SymbolKind {
     FunctionCall(Arc<str>),
     /// A class reference (`new Foo`, `instanceof Foo`, type hints).
     ClassReference(Arc<str>),
+}
+
+impl From<&SymbolKind> for DefinitionQuery {
+    fn from(kind: &SymbolKind) -> Self {
+        match kind {
+            SymbolKind::Variable(_) => DefinitionQuery::Variable,
+            SymbolKind::MethodCall { class, method } => DefinitionQuery::MethodCall {
+                class: class.clone(),
+                method: method.clone(),
+            },
+            SymbolKind::StaticCall { class, method } => DefinitionQuery::StaticCall {
+                class: class.clone(),
+                method: method.clone(),
+            },
+            SymbolKind::PropertyAccess { class, property } => DefinitionQuery::PropertyAccess {
+                class: class.clone(),
+                property: property.clone(),
+            },
+            SymbolKind::FunctionCall(fqn) => DefinitionQuery::FunctionCall(fqn.clone()),
+            SymbolKind::ClassReference(fqcn) => DefinitionQuery::ClassReference(fqcn.clone()),
+        }
+    }
 }

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -770,4 +770,77 @@ impl Codebase {
 
         table
     }
+
+    // -----------------------------------------------------------------------
+    // Definition-location lookup
+    // -----------------------------------------------------------------------
+
+    /// Resolve a symbol reference to the source location where it is defined.
+    ///
+    /// Returns `None` for `Variable` references (they have no definition site
+    /// in the codebase) and for symbols that could not be found.
+    ///
+    /// The returned [`storage::Location`] uses byte offsets and a 1-based line
+    /// number — consumers (e.g. an LSP server) can convert these to the wire
+    /// format they need.
+    pub fn resolve_definition(&self, query: &DefinitionQuery) -> Option<crate::storage::Location> {
+        match query {
+            DefinitionQuery::MethodCall { class, method }
+            | DefinitionQuery::StaticCall { class, method } => self
+                .get_method(class.as_ref(), method.as_ref())
+                .and_then(|m| m.location),
+
+            DefinitionQuery::FunctionCall(fqn) => self
+                .functions
+                .get(fqn.as_ref())
+                .and_then(|f| f.location.clone()),
+
+            DefinitionQuery::ClassReference(fqcn) => {
+                if let Some(cls) = self.classes.get(fqcn.as_ref()) {
+                    return cls.location.clone();
+                }
+                if let Some(iface) = self.interfaces.get(fqcn.as_ref()) {
+                    return iface.location.clone();
+                }
+                if let Some(tr) = self.traits.get(fqcn.as_ref()) {
+                    return tr.location.clone();
+                }
+                if let Some(en) = self.enums.get(fqcn.as_ref()) {
+                    return en.location.clone();
+                }
+                None
+            }
+
+            DefinitionQuery::PropertyAccess { class, property } => self
+                .get_property(class.as_ref(), property.as_ref())
+                .and_then(|p| p.location),
+
+            DefinitionQuery::Variable => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DefinitionQuery — codebase-side symbol identity for definition lookups
+// ---------------------------------------------------------------------------
+
+/// Describes a resolved symbol reference without carrying AST spans.
+///
+/// Mirrors the variants of `mir_analyzer::symbol::SymbolKind` but lives in
+/// `mir-codebase` so that `Codebase::resolve_definition` does not create an
+/// upward dependency on `mir-analyzer`.
+#[derive(Debug, Clone)]
+pub enum DefinitionQuery {
+    /// Instance or static method call: `$obj->method()` / `Class::method()`
+    MethodCall { class: Arc<str>, method: Arc<str> },
+    /// Static method call: `Class::method()`
+    StaticCall { class: Arc<str>, method: Arc<str> },
+    /// Free function call: `foo()`
+    FunctionCall(Arc<str>),
+    /// Class/interface/trait/enum reference: `new Foo`, `instanceof Foo`
+    ClassReference(Arc<str>),
+    /// Property access: `$obj->prop`
+    PropertyAccess { class: Arc<str>, property: Arc<str> },
+    /// Variable reference — has no codebase definition site.
+    Variable,
 }

--- a/crates/mir-codebase/src/lib.rs
+++ b/crates/mir-codebase/src/lib.rs
@@ -2,7 +2,7 @@ pub mod codebase;
 pub mod members;
 pub mod storage;
 
-pub use codebase::Codebase;
+pub use codebase::{Codebase, DefinitionQuery};
 pub use members::{MemberInfo, MemberKind};
 pub use storage::{
     ClassStorage, ConstantStorage, EnumCaseStorage, EnumStorage, FnParam, FunctionStorage,


### PR DESCRIPTION
Closes #112

## Summary
- Adds `DefinitionQuery` enum to `mir-codebase` (mirrors `SymbolKind` without creating an upward dep on `mir-analyzer`)
- Adds `Codebase::resolve_definition(&DefinitionQuery) -> Option<storage::Location>` — dispatches by variant to the relevant map
- Adds `From<&SymbolKind> for DefinitionQuery` in `mir-analyzer` so a `ResolvedSymbol` can be converted directly
- Adds `AnalysisResult::resolve_definition()` convenience bridge method

## LSP mapping
Drives `textDocument/definition` — the LSP server looks up the symbol at the cursor position, converts to `DefinitionQuery`, and calls `resolve_definition` to get the file + offset to jump to.

## Test plan
- [ ] All 152 fixture tests pass
- [ ] `cargo build` / `cargo clippy` clean