### PR TITLE
feat(analyzer): incremental re-analysis for a single changed file

### DIFF
--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -48,6 +48,7 @@ impl<'a> ExpressionAnalyzer<'a> {
     /// Record a resolved symbol.
     pub fn record_symbol(&mut self, span: php_ast::Span, kind: SymbolKind, resolved_type: Union) {
         self.symbols.push(ResolvedSymbol {
+            file: self.file.clone(),
             span,
             kind,
             resolved_type,

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -429,6 +429,99 @@ impl ProjectAnalyzer {
         }
     }
 
+    /// Incrementally re-analyze a changed file and update a shared
+    /// [`AnalysisResult`] in place.
+    ///
+    /// This is the primary incremental API for LSP `textDocument/didChange`:
+    ///
+    /// 1. Evicts stale issues and symbols for `path` (and its dependents) from
+    ///    `result`.
+    /// 2. Removes the old codebase definitions for `path`.
+    /// 3. Re-parses `path` with `new_source` and re-runs Pass 1 + Pass 2.
+    /// 4. For each file in [`Codebase::dependents_of`]`(path)`, re-analyzes
+    ///    that file as well (shallow: one level of dependents).
+    /// 5. Merges the new issues and symbols back into `result`.
+    ///
+    /// # Prerequisites
+    ///
+    /// Requires that [`analyze`] has been called at least once so that the
+    /// codebase is finalized and the reverse dependency index is populated.
+    pub fn reanalyze_file(&self, path: &str, new_source: &str, result: &mut AnalysisResult) {
+        // Collect the set of files to re-analyze: the changed file + one level
+        // of dependents.
+        let mut to_reanalyze: Vec<(Arc<str>, Option<String>)> = Vec::new();
+        to_reanalyze.push((Arc::from(path), Some(new_source.to_string())));
+
+        for dep in self.codebase.dependents_of(path) {
+            let src = std::fs::read_to_string(dep.as_ref()).ok();
+            to_reanalyze.push((dep, src));
+        }
+
+        // Evict stale entries from result for every file we are about to re-analyze.
+        let files_to_evict: Vec<Arc<str>> = to_reanalyze.iter().map(|(f, _)| f.clone()).collect();
+        result
+            .issues
+            .retain(|i| !files_to_evict.contains(&i.location.file));
+        result.symbols.retain(|s| !files_to_evict.contains(&s.file));
+
+        // Remove codebase definitions for the primary file and rebuild.
+        self.codebase.remove_file_definitions(path);
+
+        // Re-run Pass 1 + Pass 2 for each file.
+        for (file, src_opt) in &to_reanalyze {
+            let src = match src_opt {
+                Some(s) => s.clone(),
+                None => continue, // dependent file could not be read — skip
+            };
+
+            // If this is the primary changed file, definitions were already removed.
+            // For dependents we keep existing definitions (they didn't change).
+            if file.as_ref() != path {
+                self.codebase.remove_file_definitions(file.as_ref());
+            }
+
+            let arena = bumpalo::Bump::new();
+            let parsed = php_rs_parser::parse(&arena, &src);
+
+            // Parse errors
+            for err in &parsed.errors {
+                result.issues.push(Issue::new(
+                    mir_issues::IssueKind::ParseError {
+                        message: err.to_string(),
+                    },
+                    mir_issues::Location {
+                        file: file.clone(),
+                        line: 1,
+                        col_start: 0,
+                        col_end: 0,
+                    },
+                ));
+            }
+
+            // Pass 1: re-collect definitions
+            let collector =
+                DefinitionCollector::new(&self.codebase, file.clone(), &src, &parsed.source_map);
+            result.issues.extend(collector.collect(&parsed.program));
+
+            // Re-finalize after each file so Pass 2 sees an up-to-date graph.
+            self.codebase.invalidate_finalization();
+            self.codebase.finalize();
+
+            // Pass 2: re-analyze bodies
+            let (body_issues, symbols) =
+                self.analyze_bodies(&parsed.program, file.clone(), &src, &parsed.source_map);
+            result.issues.extend(body_issues);
+            result.symbols.extend(symbols);
+        }
+
+        // Rebuild the reverse dep index so subsequent calls stay accurate.
+        let rev = build_reverse_deps(&self.codebase);
+        self.codebase.set_dependents(rev.clone());
+        if let Some(cache) = &self.cache {
+            cache.set_reverse_deps(rev);
+        }
+    }
+
     /// Analyze a PHP source string without a real file path.
     /// Useful for tests and LSP single-file mode.
     pub fn analyze_source(source: &str) -> AnalysisResult {

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -205,9 +205,10 @@ impl ProjectAnalyzer {
             self.lazy_load_missing_classes(psr4.clone(), &mut all_issues);
         }
 
-        // ---- Build reverse dep graph and persist it for the next run ---------
+        // ---- Build reverse dep graph, persist for cache and store on codebase --
+        let rev = build_reverse_deps(&self.codebase);
+        self.codebase.set_dependents(rev.clone());
         if let Some(cache) = &self.cache {
-            let rev = build_reverse_deps(&self.codebase);
             cache.set_reverse_deps(rev);
         }
 

--- a/crates/mir-analyzer/src/symbol.rs
+++ b/crates/mir-analyzer/src/symbol.rs
@@ -13,6 +13,8 @@ use php_ast::Span;
 /// A single resolved symbol observed during Pass 2.
 #[derive(Debug, Clone)]
 pub struct ResolvedSymbol {
+    /// Absolute path of the source file this symbol was resolved in.
+    pub file: Arc<str>,
     /// Byte-offset span in the source file.
     pub span: Span,
     /// What kind of symbol this is.

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -54,6 +54,13 @@ pub struct Codebase {
     /// namespace data that mir already collects, instead of reimplementing it.
     pub file_namespaces: DashMap<Arc<str>, String>,
 
+    /// Reverse dependency index: maps a file path to the set of files that
+    /// import or depend on it (via `use`, `extends`, `implements`, or trait
+    /// `use`). Populated by `ProjectAnalyzer` after Pass 1.
+    ///
+    /// Use [`Codebase::dependents_of`] to query this map.
+    pub dependents: DashMap<Arc<str>, DashSet<Arc<str>>>,
+
     /// Whether finalize() has been called.
     finalized: std::sync::atomic::AtomicBool,
 }
@@ -106,6 +113,7 @@ impl Codebase {
         // Remove file-level metadata
         self.file_imports.remove(file_path);
         self.file_namespaces.remove(file_path);
+        self.dependents.remove(file_path);
 
         self.invalidate_finalization();
     }
@@ -296,6 +304,42 @@ impl Codebase {
     /// subclass is expected to implement the method, matching Psalm errorLevel=3 behaviour.
     pub fn is_abstract_class(&self, fqcn: &str) -> bool {
         self.classes.get(fqcn).is_some_and(|c| c.is_abstract)
+    }
+
+    // -----------------------------------------------------------------------
+    // Reverse dependency index
+    // -----------------------------------------------------------------------
+
+    /// Return the set of files that directly depend on `file` (via `use`,
+    /// `extends`, `implements`, or trait `use`).
+    ///
+    /// The returned paths are absolute file paths as stored in `symbol_to_file`.
+    /// Returns an empty `Vec` when `file` has no known dependents (e.g. it is a
+    /// leaf file or the index has not been built yet).
+    pub fn dependents_of(&self, file: &str) -> Vec<Arc<str>> {
+        self.dependents
+            .get(file)
+            .map(|set| set.iter().map(|e| e.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Overwrite the reverse dependency index with the provided map.
+    ///
+    /// Called by `ProjectAnalyzer` after Pass 1 + codebase finalization, when
+    /// the full import/extends/implements graph is available.
+    pub fn set_dependents(
+        &self,
+        map: std::collections::HashMap<String, std::collections::HashSet<String>>,
+    ) {
+        self.dependents.clear();
+        for (defining_file, dependent_files) in map {
+            let key: Arc<str> = Arc::from(defining_file.as_str());
+            let set = DashSet::new();
+            for dep in dependent_files {
+                set.insert(Arc::from(dep.as_str()));
+            }
+            self.dependents.insert(key, set);
+        }
     }
 
     /// Return the declared template params for `fqcn` (class or interface), or


### PR DESCRIPTION
Closes #116

## Summary

### `ResolvedSymbol::file` (new field)
Adds `file: Arc<str>` to `ResolvedSymbol` so symbols can be evicted per-file during incremental re-analysis. `ExpressionAnalyzer::record_symbol()` fills it from `self.file`.

### `ProjectAnalyzer::reanalyze_file(path, new_source, result)`
In-place incremental update of a shared `AnalysisResult`:

1. **Evict** — removes stale issues and symbols for `path` + its direct dependents from `result`
2. **Remove definitions** — calls `codebase.remove_file_definitions()` for each affected file
3. **Pass 1** — re-parses + re-collects definitions per file
4. **Re-finalize** — rebuilds inheritance after each file
5. **Pass 2** — re-analyzes bodies per file
6. **Merge** — appends new issues/symbols into `result`
7. **Rebuild dep index** — keeps `codebase.dependents` and the cache in sync

Shallow propagation: one level of dependents (the files that directly import the changed file). This is sufficient for most LSP `textDocument/didChange` scenarios.

## Prerequisite
Depends on #115 (`Codebase::dependents_of`).

## Test plan
- [ ] All 152 fixture tests pass
- [ ] `cargo build` / `cargo clippy` clean