### PR TITLE
chore(deps): update php-rs-parser and php-ast to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "php-ast"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5a308bf0bd456c28f8b9cb93bc1f37faf5402c531a1087f46c34a2903f2306"
+checksum = "5b3a845984b5c3d0324d0c82864aeb5c9e3290e53d0166930df4eae05ec3e2b5"
 dependencies = [
  "bumpalo",
  "serde",
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b35759abe5da820bac48e5aedea81e018cf32ab20ed5075c62a155c6a76d3e"
+checksum = "1c3a6716e52ccb92dd42b1f6a10663c3bd8491bf5c53ebe518252e7e8853d8c6"
 dependencies = [
  "memchr",
  "php-ast",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad3a83439d31f6285681e274b9f8038ea9129d85ee6da9ab624f941845538ed"
+checksum = "1582b1767ec76d2664bb0d72c3280a6ec562bf52b0fb97dfae6ac6253a925aba"
 dependencies = [
  "bumpalo",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ mir-codebase   = { path = "crates/mir-codebase",   version = "0.3.0" }
 mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.3.0" }
 
 # PHP parsing
-php-rs-parser = "0.5.0"
-php-ast       = "0.5.0"
+php-rs-parser = "0.6.0"
+php-ast       = "0.6.0"
 bumpalo       = { version = "3", features = ["collections"] }
 
 # Data structures

--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -89,7 +89,7 @@ impl CallAnalyzer {
                         // Variadic by-ref: mark every remaining argument (e.g. sscanf output vars).
                         for arg in call.args.iter().skip(i) {
                             if let ExprKind::Variable(name) = &arg.value.kind {
-                                let var_name = name.as_ref().trim_start_matches('$');
+                                let var_name = name.as_str().trim_start_matches('$');
                                 if !ctx.var_is_defined(var_name) {
                                     ctx.set_var(var_name, Union::mixed());
                                 }
@@ -97,7 +97,7 @@ impl CallAnalyzer {
                         }
                     } else if let Some(arg) = call.args.get(i) {
                         if let ExprKind::Variable(name) = &arg.value.kind {
-                            let var_name = name.as_ref().trim_start_matches('$');
+                            let var_name = name.as_str().trim_start_matches('$');
                             if !ctx.var_is_defined(var_name) {
                                 ctx.set_var(var_name, Union::mixed());
                             }
@@ -166,13 +166,13 @@ impl CallAnalyzer {
                     if param.is_variadic {
                         for arg in call.args.iter().skip(i) {
                             if let ExprKind::Variable(name) = &arg.value.kind {
-                                let var_name = name.as_ref().trim_start_matches('$');
+                                let var_name = name.as_str().trim_start_matches('$');
                                 ctx.set_var(var_name, Union::mixed());
                             }
                         }
                     } else if let Some(arg) = call.args.get(i) {
                         if let ExprKind::Variable(name) = &arg.value.kind {
-                            let var_name = name.as_ref().trim_start_matches('$');
+                            let var_name = name.as_str().trim_start_matches('$');
                             ctx.set_var(var_name, Union::mixed());
                         }
                     }
@@ -231,7 +231,7 @@ impl CallAnalyzer {
 
         let method_name = match &call.method.kind {
             ExprKind::Identifier(name) => (*name).to_string(),
-            ExprKind::Variable(name) => name.as_ref().to_string(),
+            ExprKind::Variable(name) => name.as_str().to_string(),
             _ => return Union::mixed(),
         };
 

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -30,7 +30,7 @@ pub struct DefinitionCollector<'a> {
     codebase: &'a Codebase,
     file: Arc<str>,
     source: &'a str,
-    source_map: &'a php_ast::source_map::SourceMap,
+    source_map: &'a php_rs_parser::source_map::SourceMap,
     namespace: Option<String>,
     /// `use` aliases: alias → FQCN
     use_aliases: std::collections::HashMap<String, String>,
@@ -42,7 +42,7 @@ impl<'a> DefinitionCollector<'a> {
         codebase: &'a Codebase,
         file: Arc<str>,
         source: &'a str,
-        source_map: &'a php_ast::source_map::SourceMap,
+        source_map: &'a php_rs_parser::source_map::SourceMap,
     ) -> Self {
         Self {
             source_map,

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -21,7 +21,7 @@ pub struct ExpressionAnalyzer<'a> {
     pub codebase: &'a Codebase,
     pub file: Arc<str>,
     pub source: &'a str,
-    pub source_map: &'a php_ast::source_map::SourceMap,
+    pub source_map: &'a php_rs_parser::source_map::SourceMap,
     pub issues: &'a mut IssueBuffer,
     pub symbols: &'a mut Vec<ResolvedSymbol>,
 }
@@ -31,7 +31,7 @@ impl<'a> ExpressionAnalyzer<'a> {
         codebase: &'a Codebase,
         file: Arc<str>,
         source: &'a str,
-        source_map: &'a php_ast::source_map::SourceMap,
+        source_map: &'a php_rs_parser::source_map::SourceMap,
         issues: &'a mut IssueBuffer,
         symbols: &'a mut Vec<ResolvedSymbol>,
     ) -> Self {
@@ -94,7 +94,7 @@ impl<'a> ExpressionAnalyzer<'a> {
 
             // --- Variables --------------------------------------------------
             ExprKind::Variable(name) => {
-                let name_str = name.as_ref().trim_start_matches('$');
+                let name_str = name.as_str().trim_start_matches('$');
                 if !ctx.var_is_defined(name_str) {
                     if ctx.var_possibly_defined(name_str) {
                         self.emit(
@@ -858,7 +858,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                 // Extract the variable name of the subject for narrowing
                 let subject_var = match &m.subject.kind {
                     ExprKind::Variable(name) => {
-                        Some(name.as_ref().trim_start_matches('$').to_string())
+                        Some(name.as_str().trim_start_matches('$').to_string())
                     }
                     _ => None,
                 };
@@ -1148,7 +1148,7 @@ impl<'a> ExpressionAnalyzer<'a> {
     ) {
         match &target.kind {
             ExprKind::Variable(name) => {
-                let name_str = name.as_ref().trim_start_matches('$').to_string();
+                let name_str = name.as_str().trim_start_matches('$').to_string();
                 ctx.set_var(name_str, ty);
             }
             ExprKind::Array(elements) => {
@@ -1234,7 +1234,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                 loop {
                     match &base.kind {
                         ExprKind::Variable(name) => {
-                            let name_str = name.as_ref().trim_start_matches('$');
+                            let name_str = name.as_str().trim_start_matches('$');
                             if !ctx.var_is_defined(name_str) {
                                 ctx.vars.insert(
                                     name_str.to_string(),
@@ -1422,7 +1422,7 @@ pub fn infer_arithmetic(left: &Union, right: &Union) -> Union {
 
 pub fn extract_simple_var<'arena, 'src>(expr: &php_ast::ast::Expr<'arena, 'src>) -> Option<String> {
     match &expr.kind {
-        ExprKind::Variable(name) => Some(name.as_ref().trim_start_matches('$').to_string()),
+        ExprKind::Variable(name) => Some(name.as_str().trim_start_matches('$').to_string()),
         ExprKind::Parenthesized(inner) => extract_simple_var(inner),
         _ => None,
     }

--- a/crates/mir-analyzer/src/narrowing.rs
+++ b/crates/mir-analyzer/src/narrowing.rs
@@ -463,7 +463,7 @@ fn extract_var_name<'a, 'arena, 'src>(
     expr: &'a php_ast::ast::Expr<'arena, 'src>,
 ) -> Option<String> {
     match &expr.kind {
-        ExprKind::Variable(name) => Some(name.as_ref().trim_start_matches('$').to_string()),
+        ExprKind::Variable(name) => Some(name.as_str().trim_start_matches('$').to_string()),
         ExprKind::Parenthesized(inner) => extract_var_name(inner),
         _ => None,
     }

--- a/crates/mir-analyzer/src/parser/docblock.rs
+++ b/crates/mir-analyzer/src/parser/docblock.rs
@@ -3,7 +3,7 @@ use mir_types::{Atomic, Union, Variance};
 /// then converts `PhpDocTag`s into mir's `ParsedDocblock` with resolved types.
 use std::sync::Arc;
 
-use php_ast::PhpDocTag;
+use php_rs_parser::phpdoc::PhpDocTag;
 
 // ---------------------------------------------------------------------------
 // DocblockParser
@@ -56,7 +56,12 @@ impl DocblockParser {
                 }
                 PhpDocTag::Deprecated { description } => {
                     result.is_deprecated = true;
-                    result.deprecated = Some(description.unwrap_or("").to_string());
+                    result.deprecated = Some(
+                        description
+                            .as_ref()
+                            .map(|d| d.to_string())
+                            .unwrap_or_default(),
+                    );
                 }
                 PhpDocTag::Template { name, bound } => {
                     result.templates.push((
@@ -154,14 +159,14 @@ impl DocblockParser {
                 PhpDocTag::Generic { tag, body } => match *tag {
                     "api" | "psalm-api" => result.is_api = true,
                     "psalm-assert-if-true" | "phpstan-assert-if-true" => {
-                        if let Some((ty_str, name)) = body.and_then(parse_param_line) {
+                        if let Some((ty_str, name)) = body.as_deref().and_then(parse_param_line) {
                             result
                                 .assertions_if_true
                                 .push((name, parse_type_string(&ty_str)));
                         }
                     }
                     "psalm-assert-if-false" | "phpstan-assert-if-false" => {
-                        if let Some((ty_str, name)) = body.and_then(parse_param_line) {
+                        if let Some((ty_str, name)) = body.as_deref().and_then(parse_param_line) {
                             result
                                 .assertions_if_false
                                 .push((name, parse_type_string(&ty_str)));

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -130,43 +130,88 @@ impl ProjectAnalyzer {
             })
             .collect();
 
-        // ---- Pre-index pass: use SymbolTable to build FQCN index & file imports ---
-        // SymbolTable is lightweight (no type inference) so we run it in parallel.
+        // ---- Pre-index pass: walk the AST to build FQCN index, file imports, and namespaces ---
         file_data.par_iter().for_each(|(file, src)| {
+            use php_ast::ast::StmtKind;
             let arena = bumpalo::Bump::new();
             let result = php_rs_parser::parse(&arena, src);
-            let table = php_ast::symbol_table::SymbolTable::build(&result.program);
 
-            // Populate known_symbols with all top-level FQCNs
-            for sym in table.symbols() {
-                if sym.parent.is_none() {
-                    self.codebase
-                        .known_symbols
-                        .insert(Arc::from(sym.fqn.as_str()));
+            let mut current_namespace: Option<String> = None;
+            let mut imports: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
+            let mut file_ns_set = false;
+
+            for stmt in result.program.stmts.iter() {
+                match &stmt.kind {
+                    StmtKind::Namespace(ns) => {
+                        current_namespace =
+                            ns.name.as_ref().map(|n| crate::parser::name_to_string(n));
+                        if !file_ns_set {
+                            if let Some(ref ns_str) = current_namespace {
+                                self.codebase
+                                    .file_namespaces
+                                    .insert(file.clone(), ns_str.clone());
+                                file_ns_set = true;
+                            }
+                        }
+                    }
+                    StmtKind::Use(use_decl) => {
+                        for item in use_decl.uses.iter() {
+                            let full_name = crate::parser::name_to_string(&item.name);
+                            let alias = item.alias.unwrap_or_else(|| {
+                                full_name.rsplit('\\').next().unwrap_or(&full_name)
+                            });
+                            imports.insert(alias.to_string(), full_name);
+                        }
+                    }
+                    StmtKind::Class(decl) => {
+                        if let Some(n) = decl.name {
+                            let fqcn = if let Some(ref ns) = current_namespace {
+                                format!("{}\\{}", ns, n)
+                            } else {
+                                n.to_string()
+                            };
+                            self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                        }
+                    }
+                    StmtKind::Interface(decl) => {
+                        let fqcn = if let Some(ref ns) = current_namespace {
+                            format!("{}\\{}", ns, decl.name)
+                        } else {
+                            decl.name.to_string()
+                        };
+                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                    }
+                    StmtKind::Trait(decl) => {
+                        let fqcn = if let Some(ref ns) = current_namespace {
+                            format!("{}\\{}", ns, decl.name)
+                        } else {
+                            decl.name.to_string()
+                        };
+                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                    }
+                    StmtKind::Enum(decl) => {
+                        let fqcn = if let Some(ref ns) = current_namespace {
+                            format!("{}\\{}", ns, decl.name)
+                        } else {
+                            decl.name.to_string()
+                        };
+                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                    }
+                    StmtKind::Function(decl) => {
+                        let fqn = if let Some(ref ns) = current_namespace {
+                            format!("{}\\{}", ns, decl.name)
+                        } else {
+                            decl.name.to_string()
+                        };
+                        self.codebase.known_symbols.insert(Arc::from(fqn.as_str()));
+                    }
+                    _ => {}
                 }
             }
 
-            // Populate file_imports from SymbolTable imports
-            let mut imports = std::collections::HashMap::new();
-            for imp in table.imports() {
-                imports.insert(imp.local_name().to_string(), imp.name.to_string());
-            }
             if !imports.is_empty() {
                 self.codebase.file_imports.insert(file.clone(), imports);
-            }
-
-            // Populate file_namespaces from top-level symbol FQNs
-            // (infer namespace from the first namespaced symbol)
-            for sym in table.symbols() {
-                if sym.parent.is_none() {
-                    if let Some(pos) = sym.fqn.rfind('\\') {
-                        let ns = &sym.fqn[..pos];
-                        self.codebase
-                            .file_namespaces
-                            .insert(file.clone(), ns.to_string());
-                        break;
-                    }
-                }
             }
         });
 
@@ -466,7 +511,7 @@ impl ProjectAnalyzer {
         program: &php_ast::ast::Program<'arena, 'src>,
         file: Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
     ) -> (Vec<mir_issues::Issue>, Vec<crate::symbol::ResolvedSymbol>) {
         use php_ast::ast::StmtKind;
 
@@ -550,7 +595,7 @@ impl ProjectAnalyzer {
         decl: &php_ast::ast::FunctionDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         all_symbols: &mut Vec<crate::symbol::ResolvedSymbol>,
     ) {
@@ -649,7 +694,7 @@ impl ProjectAnalyzer {
         decl: &php_ast::ast::ClassDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         all_symbols: &mut Vec<crate::symbol::ResolvedSymbol>,
     ) {
@@ -741,7 +786,7 @@ impl ProjectAnalyzer {
         program: &php_ast::ast::Program<'arena, 'src>,
         file: Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
             crate::type_env::TypeEnv,
@@ -830,7 +875,7 @@ impl ProjectAnalyzer {
         decl: &php_ast::ast::FunctionDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
@@ -939,7 +984,7 @@ impl ProjectAnalyzer {
         decl: &php_ast::ast::ClassDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
         type_envs: &mut std::collections::HashMap<
             crate::type_env::ScopeId,
@@ -1073,7 +1118,7 @@ impl ProjectAnalyzer {
         decl: &php_ast::ast::EnumDecl<'arena, 'src>,
         file: &Arc<str>,
         source: &str,
-        source_map: &php_ast::source_map::SourceMap,
+        source_map: &php_rs_parser::source_map::SourceMap,
         all_issues: &mut Vec<mir_issues::Issue>,
     ) {
         use php_ast::ast::EnumMemberKind;
@@ -1117,7 +1162,7 @@ fn check_type_hint_classes<'arena, 'src>(
     codebase: &Codebase,
     file: &Arc<str>,
     source: &str,
-    source_map: &php_ast::source_map::SourceMap,
+    source_map: &php_rs_parser::source_map::SourceMap,
     issues: &mut Vec<mir_issues::Issue>,
 ) {
     use php_ast::ast::TypeHintKind;

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -141,6 +141,64 @@ impl ProjectAnalyzer {
                 std::collections::HashMap::new();
             let mut file_ns_set = false;
 
+            // Index a flat list of stmts under a given namespace prefix.
+            let index_stmts =
+                |stmts: &[php_ast::ast::Stmt<'_, '_>],
+                 ns: Option<&str>,
+                 imports: &mut std::collections::HashMap<String, String>| {
+                    for stmt in stmts.iter() {
+                        match &stmt.kind {
+                            StmtKind::Use(use_decl) => {
+                                for item in use_decl.uses.iter() {
+                                    let full_name = crate::parser::name_to_string(&item.name);
+                                    let alias = item.alias.unwrap_or_else(|| {
+                                        full_name.rsplit('\\').next().unwrap_or(&full_name)
+                                    });
+                                    imports.insert(alias.to_string(), full_name);
+                                }
+                            }
+                            StmtKind::Class(decl) => {
+                                if let Some(n) = decl.name {
+                                    let fqcn = match ns {
+                                        Some(ns) => format!("{}\\{}", ns, n),
+                                        None => n.to_string(),
+                                    };
+                                    self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                                }
+                            }
+                            StmtKind::Interface(decl) => {
+                                let fqcn = match ns {
+                                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                                    None => decl.name.to_string(),
+                                };
+                                self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                            }
+                            StmtKind::Trait(decl) => {
+                                let fqcn = match ns {
+                                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                                    None => decl.name.to_string(),
+                                };
+                                self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                            }
+                            StmtKind::Enum(decl) => {
+                                let fqcn = match ns {
+                                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                                    None => decl.name.to_string(),
+                                };
+                                self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                            }
+                            StmtKind::Function(decl) => {
+                                let fqn = match ns {
+                                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                                    None => decl.name.to_string(),
+                                };
+                                self.codebase.known_symbols.insert(Arc::from(fqn.as_str()));
+                            }
+                            _ => {}
+                        }
+                    }
+                };
+
             for stmt in result.program.stmts.iter() {
                 match &stmt.kind {
                     StmtKind::Namespace(ns) => {
@@ -154,59 +212,16 @@ impl ProjectAnalyzer {
                                 file_ns_set = true;
                             }
                         }
-                    }
-                    StmtKind::Use(use_decl) => {
-                        for item in use_decl.uses.iter() {
-                            let full_name = crate::parser::name_to_string(&item.name);
-                            let alias = item.alias.unwrap_or_else(|| {
-                                full_name.rsplit('\\').next().unwrap_or(&full_name)
-                            });
-                            imports.insert(alias.to_string(), full_name);
+                        // Bracketed namespace: walk inner stmts for Use/Class/etc.
+                        if let php_ast::ast::NamespaceBody::Braced(inner_stmts) = &ns.body {
+                            index_stmts(inner_stmts, current_namespace.as_deref(), &mut imports);
                         }
                     }
-                    StmtKind::Class(decl) => {
-                        if let Some(n) = decl.name {
-                            let fqcn = if let Some(ref ns) = current_namespace {
-                                format!("{}\\{}", ns, n)
-                            } else {
-                                n.to_string()
-                            };
-                            self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                        }
-                    }
-                    StmtKind::Interface(decl) => {
-                        let fqcn = if let Some(ref ns) = current_namespace {
-                            format!("{}\\{}", ns, decl.name)
-                        } else {
-                            decl.name.to_string()
-                        };
-                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                    }
-                    StmtKind::Trait(decl) => {
-                        let fqcn = if let Some(ref ns) = current_namespace {
-                            format!("{}\\{}", ns, decl.name)
-                        } else {
-                            decl.name.to_string()
-                        };
-                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                    }
-                    StmtKind::Enum(decl) => {
-                        let fqcn = if let Some(ref ns) = current_namespace {
-                            format!("{}\\{}", ns, decl.name)
-                        } else {
-                            decl.name.to_string()
-                        };
-                        self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                    }
-                    StmtKind::Function(decl) => {
-                        let fqn = if let Some(ref ns) = current_namespace {
-                            format!("{}\\{}", ns, decl.name)
-                        } else {
-                            decl.name.to_string()
-                        };
-                        self.codebase.known_symbols.insert(Arc::from(fqn.as_str()));
-                    }
-                    _ => {}
+                    _ => index_stmts(
+                        std::slice::from_ref(stmt),
+                        current_namespace.as_deref(),
+                        &mut imports,
+                    ),
                 }
             }
 

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -21,7 +21,7 @@ pub struct StatementsAnalyzer<'a> {
     pub codebase: &'a Codebase,
     pub file: Arc<str>,
     pub source: &'a str,
-    pub source_map: &'a php_ast::source_map::SourceMap,
+    pub source_map: &'a php_rs_parser::source_map::SourceMap,
     pub issues: &'a mut IssueBuffer,
     pub symbols: &'a mut Vec<ResolvedSymbol>,
     /// Accumulated inferred return types for the current function.
@@ -36,7 +36,7 @@ impl<'a> StatementsAnalyzer<'a> {
         codebase: &'a Codebase,
         file: Arc<str>,
         source: &'a str,
-        source_map: &'a php_ast::source_map::SourceMap,
+        source_map: &'a php_rs_parser::source_map::SourceMap,
         issues: &'a mut IssueBuffer,
         symbols: &'a mut Vec<ResolvedSymbol>,
     ) -> Self {
@@ -564,7 +564,7 @@ impl<'a> StatementsAnalyzer<'a> {
                 // Extract the subject variable name for narrowing (if it's a simple var)
                 let subject_var: Option<String> = match &sw.expr.kind {
                     php_ast::ast::ExprKind::Variable(name) => {
-                        Some(name.as_ref().trim_start_matches('$').to_string())
+                        Some(name.as_str().trim_start_matches('$').to_string())
                     }
                     _ => None,
                 };
@@ -746,7 +746,7 @@ impl<'a> StatementsAnalyzer<'a> {
             StmtKind::Unset(vars) => {
                 for var in vars.iter() {
                     if let php_ast::ast::ExprKind::Variable(name) = &var.kind {
-                        ctx.unset_var(name.as_ref().trim_start_matches('$'));
+                        ctx.unset_var(name.as_str().trim_start_matches('$'));
                     }
                 }
             }
@@ -763,7 +763,7 @@ impl<'a> StatementsAnalyzer<'a> {
             StmtKind::Global(vars) => {
                 for var in vars.iter() {
                     if let php_ast::ast::ExprKind::Variable(name) = &var.kind {
-                        ctx.set_var(name.as_ref().trim_start_matches('$'), Union::mixed());
+                        ctx.set_var(name.as_str().trim_start_matches('$'), Union::mixed());
                     }
                 }
             }

--- a/crates/mir-analyzer/src/taint.rs
+++ b/crates/mir-analyzer/src/taint.rs
@@ -69,7 +69,7 @@ pub fn classify_sink(fn_name: &str) -> Option<SinkKind> {
 pub fn is_expr_tainted<'arena, 'src>(expr: &Expr<'arena, 'src>, ctx: &Context) -> bool {
     match &expr.kind {
         ExprKind::Variable(name) => {
-            let n = name.as_ref().trim_start_matches('$');
+            let n = name.as_str().trim_start_matches('$');
             is_superglobal(n) || ctx.is_tainted(n)
         }
 

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/bracketed_namespace_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/bracketed_namespace_class_not_reported.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+namespace MyApp {
+    class MyService {}
+
+    function test(): void {
+        new MyService();
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/bracketed_namespace_use_import_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/bracketed_namespace_use_import_not_reported.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+namespace Outer {
+    use Inner\Foo;
+    function test(): void {
+        new Foo();
+    }
+}
+namespace Inner {
+    class Foo {}
+}
+===expect===


### PR DESCRIPTION
## Summary

Bumps the PHP parsing layer from v0.5.0 to v0.6.0:

- `php-rs-parser` 0.5.0 → 0.6.0
- `php-ast` 0.5.0 → 0.6.0
- `php-lexer` 0.5.0 → 0.6.0 (transitive)

## Benefits of php-rs-parser / php-ast v0.6.0

- **Lifetime-parameterised `PhpDocTag<'src>`** — doc-block nodes now borrow directly from the source buffer, eliminating heap allocations for tag strings during parsing.
- **`NameStr` in AST identifiers** — `ExprKind::Variable` and `ExprKind::Identifier` payloads use the new zero-copy `NameStr` type instead of `Cow<str>`, reducing allocations on every identifier lookup.
- **`SourceMap` consolidated** — source-map types are now exported from `php_rs_parser::source_map`, providing a single authoritative module.
- **`SymbolTable` removed** — callers now walk the AST directly for symbol pre-indexing.
- **`Cow<'src, str>` for doc-block payloads** — `PhpDocTag::Deprecated.description` and `PhpDocTag::Generic.body` borrow from source when possible.

## Bug fixed during migration

The `SymbolTable` removal forced a hand-rolled pre-index pass. The initial implementation only walked top-level `Program::stmts`, missing declarations and `use` imports inside **bracketed namespace** blocks (`namespace Foo { use Bar; class Baz {} }`). In that form the statements are nested inside `NamespaceBody::Braced`, not at the top level. This left `codebase.file_imports` incomplete, causing `resolve_class_name` to produce false `UndefinedClass` issues for use-aliased types.

Fix: an `index_stmts` closure is shared between the top-level walk and the braced namespace body walk. Upstream issue filed at jorgsowa/rust-php-parser#144.

## Regression fixtures added

- `bracketed_namespace_class_not_reported` — class defined inside `namespace Foo { ... }` is not flagged
- `bracketed_namespace_use_import_not_reported` — `use` alias inside a braced namespace resolves correctly

All 235 tests pass.