### PR TITLE
fix(analyzer): respect @var annotation on global statement

### DIFF
--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -89,6 +89,19 @@ impl<'a> StatementsAnalyzer<'a> {
                         }
                     }
                 }
+
+                // Post-narrow: `@var Type $varname` before `global $varname` — the Global
+                // handler unconditionally sets the variable to mixed, so re-apply the
+                // annotation after it runs.
+                if let php_ast::ast::StmtKind::Global(vars) = &stmt.kind {
+                    for var in vars.iter() {
+                        if let php_ast::ast::ExprKind::Variable(name) = &var.kind {
+                            if name.as_str().trim_start_matches('$') == var_name.as_str() {
+                                ctx.set_var(var_name.as_str(), var_ty.clone());
+                            }
+                        }
+                    }
+                }
             }
 
             if !suppressions.is_empty() {

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x, $y;
+    $x->bar();
+    $y->bar();
+}
+===expect===
+MixedMethodCall: $y->bar()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_inside_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_inside_function.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x;
+    $x->bar();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_variable.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+/** @var Foo $x */
+global $x;
+$x->bar();
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x;
+    global $y;
+    $x->bar();
+    $y->bar();
+}
+===expect===
+MixedMethodCall: $y->bar()


### PR DESCRIPTION
## Summary

- `/** @var T $foo */ global $foo;` was emitting `MixedMethodCall` on any subsequent call to `$foo->method()` because the `StmtKind::Global` handler unconditionally overwrote the variable type with `mixed`, discarding the `@var` pre-narrow
- Fixed by extending the post-narrow block (which already handled assignments) to also re-apply the annotation after a `global` statement
- Works for `global $x;`, `global $x, $y;` (only the annotated variable is re-typed), and `global` inside function bodies

## Test plan

- [ ] `does_not_report_var_annotated_global_variable` — top-level `@var` + `global`
- [ ] `does_not_report_var_annotated_global_inside_function` — same inside a function (the common pattern)
- [ ] `reports_unannotated_global_as_mixed_when_sibling_is_annotated` — bare `global $y` stays `mixed` even when a sibling `$x` has `@var`
- [ ] `does_not_apply_var_annotation_to_wrong_global_variable` — `global $x, $y` with annotation on `$x` only: `$x` is typed, `$y` stays `mixed`