### PR TITLE
feat(analyzer): global variable registry for @var-annotated globals

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -258,6 +258,52 @@ impl<'a> DefinitionCollector<'a> {
             let _ = self.visit_stmt(stmt);
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Global variable registry
+    // -----------------------------------------------------------------------
+
+    /// Scan a single statement: if it is `global $x` with a preceding
+    /// `/** @var Type $x */` docblock, register the type in the codebase.
+    fn try_collect_global_var_annotation(&self, stmt: &php_ast::ast::Stmt<'_, '_>) {
+        let php_ast::ast::StmtKind::Global(vars) = &stmt.kind else {
+            return;
+        };
+        let Some(doc_text) = crate::parser::find_preceding_docblock(self.source, stmt.span.start)
+        else {
+            return;
+        };
+        let parsed = crate::parser::DocblockParser::parse(&doc_text);
+        let Some(var_type) = parsed.var_type else {
+            return;
+        };
+        let resolved_ty = self.resolve_union_doc(var_type);
+
+        for var in vars.iter() {
+            if let php_ast::ast::ExprKind::Variable(raw_name) = &var.kind {
+                let name = raw_name.as_str().trim_start_matches('$');
+                // If @var specifies a variable name, only register when it matches.
+                if let Some(ref ann_name) = parsed.var_name {
+                    if ann_name != name {
+                        continue;
+                    }
+                }
+                self.codebase
+                    .register_global_var(&self.file, Arc::from(name), resolved_ty.clone());
+            }
+        }
+    }
+
+    /// Scan a list of statements and register any `@var`-annotated `global`
+    /// declarations. Used for function bodies where the visitor does not recurse.
+    fn scan_stmts_for_global_vars<'arena, 'src>(
+        &self,
+        stmts: &php_ast::ast::ArenaVec<'arena, php_ast::ast::Stmt<'arena, 'src>>,
+    ) {
+        for stmt in stmts.iter() {
+            self.try_collect_global_var_annotation(stmt);
+        }
+    }
 }
 
 impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
@@ -362,6 +408,14 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     .symbol_to_file
                     .insert(Arc::from(fqn.as_str()), self.file.clone());
                 self.codebase.functions.insert(fqn.into(), storage);
+
+                // Scan the function body for `@var`-annotated global declarations.
+                self.scan_stmts_for_global_vars(&decl.body);
+            }
+
+            StmtKind::Global(_) => {
+                // Top-level `global $x` — unusual in PHP but valid.
+                self.try_collect_global_var_annotation(stmt);
             }
 
             StmtKind::Class(decl) => {

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -763,7 +763,14 @@ impl<'a> StatementsAnalyzer<'a> {
             StmtKind::Global(vars) => {
                 for var in vars.iter() {
                     if let php_ast::ast::ExprKind::Variable(name) = &var.kind {
-                        ctx.set_var(name.as_str().trim_start_matches('$'), Union::mixed());
+                        let var_name = name.as_str().trim_start_matches('$');
+                        let ty = self
+                            .codebase
+                            .global_vars
+                            .get(var_name)
+                            .map(|r| r.clone())
+                            .unwrap_or_else(Union::mixed);
+                        ctx.set_var(var_name, ty);
                     }
                 }
             }

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x, $y;
+    $x->bar();
+    $y->bar();
+}
+===expect===
+MixedMethodCall: $y->bar()

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_inside_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_inside_function.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x;
+    $x->bar();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_var_annotated_global_variable.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+/** @var Foo $x */
+global $x;
+$x->bar();
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(): void {
+    /** @var Foo $x */
+    global $x;
+    global $y;
+    $x->bar();
+    $y->bar();
+}
+===expect===
+MixedMethodCall: $y->bar()

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -20,6 +20,13 @@ pub struct Codebase {
     pub functions: DashMap<Arc<str>, FunctionStorage>,
     pub constants: DashMap<Arc<str>, Union>,
 
+    /// Types of `@var`-annotated global variables, collected in Pass 1.
+    /// Key: variable name without the `$` prefix.
+    pub global_vars: DashMap<Arc<str>, Union>,
+    /// Maps file path → variable names declared with `@var` in that file.
+    /// Used by `remove_file_definitions` to purge stale entries on re-analysis.
+    file_global_vars: DashMap<Arc<str>, Vec<Arc<str>>>,
+
     /// Methods referenced during Pass 2 — key format: `"ClassName::methodName"`.
     /// Used by the dead-code detector (M18).
     pub referenced_methods: DashSet<Arc<str>>,
@@ -107,7 +114,28 @@ impl Codebase {
         self.file_imports.remove(file_path);
         self.file_namespaces.remove(file_path);
 
+        // Remove @var-annotated global variables declared in this file
+        if let Some((_, var_names)) = self.file_global_vars.remove(file_path) {
+            for name in var_names {
+                self.global_vars.remove(name.as_ref());
+            }
+        }
+
         self.invalidate_finalization();
+    }
+
+    // -----------------------------------------------------------------------
+    // Global variable registry
+    // -----------------------------------------------------------------------
+
+    /// Record an `@var`-annotated global variable type discovered in Pass 1.
+    /// If the same variable is annotated in multiple files, the last write wins.
+    pub fn register_global_var(&self, file: &Arc<str>, name: Arc<str>, ty: Union) {
+        self.file_global_vars
+            .entry(file.clone())
+            .or_default()
+            .push(name.clone());
+        self.global_vars.insert(name, ty);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `global_vars: DashMap<Arc<str>, Union>` to `Codebase` — a registry of `@var`-annotated global variable types
- Pass 1 (`DefinitionCollector`) now scans `/** @var Type \$x */ global \$x;` patterns at the top level and inside function bodies, storing the resolved type in the registry
- Pass 2 (`StatementsAnalyzer`) looks up each variable in the registry when processing a `global` statement, falling back to `mixed` for unannotated globals
- Incremental re-analysis: a `file_global_vars` index maps file path → variable names so `remove_file_definitions` can purge stale entries before re-collection

## Why a registry instead of a per-callsite post-narrow

A post-narrow approach (the previous closed PR #159) re-applies the `@var` annotation only in the scope where it appears.  The registry collects the type once in Pass 1 and applies it consistently every time the variable is introduced into a local scope via `global` — this is the correct solution and matches how Psalm recommends handling globals (via a configuration registry), but done inline without requiring a separate config file.

## Test plan

- [ ] `does_not_report_var_annotated_global_variable` — top-level `@var` + `global`
- [ ] `does_not_report_var_annotated_global_inside_function` — `@var` + `global` inside a function (the common pattern)
- [ ] `reports_unannotated_global_as_mixed_when_sibling_is_annotated` — bare `global \$y` stays mixed even when a sibling `\$x` has `@var`
- [ ] `does_not_apply_var_annotation_to_wrong_global_variable` — `global \$x, \$y` with annotation on `\$x` only: `\$x` typed, `\$y` stays mixed