### PR TITLE
feat: track symbol reference locations for LSP find-references

### DIFF
--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -12,6 +12,10 @@ use sha2::{Digest, Sha256};
 
 use mir_issues::Issue;
 
+/// Cached analysis result returned on a cache hit: issues and reference location
+/// triples `(symbol_key, start_byte, end_byte)`.
+pub type CacheHit = (Vec<Issue>, Vec<(String, u32, u32)>);
+
 // ---------------------------------------------------------------------------
 // Hash helper
 // ---------------------------------------------------------------------------
@@ -35,6 +39,11 @@ pub fn hash_content(content: &str) -> String {
 struct CacheEntry {
     content_hash: String,
     issues: Vec<Issue>,
+    /// Reference locations recorded during Pass 2: (symbol_key, start_byte, end_byte).
+    /// Stored so that cache hits can replay symbol_reference_locations without re-running
+    /// analyze_bodies.
+    #[serde(default)]
+    reference_locations: Vec<(String, u32, u32)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -81,27 +90,39 @@ impl AnalysisCache {
         Self::open(&project_root.join(".mir-cache"))
     }
 
-    /// Return cached issues for `file_path` if its `content_hash` matches.
-    /// Returns `None` if there is no entry or the file has changed.
-    pub fn get(&self, file_path: &str, content_hash: &str) -> Option<Vec<Issue>> {
+    /// Return cached issues and reference locations for `file_path` if its
+    /// `content_hash` matches. Returns `None` if there is no entry or the file
+    /// has changed. The second element of the tuple is the list of
+    /// `(symbol_key, start_byte, end_byte)` entries to replay into
+    /// `Codebase::symbol_reference_locations`.
+    pub fn get(&self, file_path: &str, content_hash: &str) -> Option<CacheHit> {
         let entries = self.entries.lock().unwrap();
         entries.get(file_path).and_then(|e| {
             if e.content_hash == content_hash {
-                Some(e.issues.clone())
+                Some((e.issues.clone(), e.reference_locations.clone()))
             } else {
                 None
             }
         })
     }
 
-    /// Store `issues` for `file_path` with the given `content_hash`.
-    pub fn put(&self, file_path: &str, content_hash: String, issues: Vec<Issue>) {
+    /// Store `issues` and `reference_locations` for `file_path` with the given
+    /// `content_hash`. `reference_locations` is a list of
+    /// `(symbol_key, start_byte, end_byte)` recorded during Pass 2.
+    pub fn put(
+        &self,
+        file_path: &str,
+        content_hash: String,
+        issues: Vec<Issue>,
+        reference_locations: Vec<(String, u32, u32)>,
+    ) {
         let mut entries = self.entries.lock().unwrap();
         entries.insert(
             file_path.to_string(),
             CacheEntry {
                 content_hash,
                 issues,
+                reference_locations,
             },
         );
         *self.dirty.lock().unwrap() = true;
@@ -200,7 +221,7 @@ mod tests {
     }
 
     fn seed(cache: &AnalysisCache, file: &str) {
-        cache.put(file, "hash".to_string(), vec![]);
+        cache.put(file, "hash".to_string(), vec![], vec![]);
     }
 
     #[test]

--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -313,4 +313,31 @@ mod tests {
             "B unrelated, should survive"
         );
     }
+
+    #[test]
+    fn old_cache_without_reference_locations_deserializes_to_empty() {
+        // Cache entries written before the reference_locations field was added
+        // must still be readable. The #[serde(default)] attribute covers this,
+        // but we verify it explicitly so a future refactor can't silently break it.
+        let dir = TempDir::new().unwrap();
+        let cache_file = dir.path().join("cache.json");
+
+        // Write a cache file in the old format (no reference_locations field).
+        std::fs::write(
+            &cache_file,
+            r#"{"entries":{"a.php":{"content_hash":"abc","issues":[]}},"reverse_deps":{}}"#,
+        )
+        .unwrap();
+
+        let cache = AnalysisCache::open(dir.path());
+        let hit = cache
+            .get("a.php", "abc")
+            .expect("old cache entry should deserialize successfully");
+
+        assert!(hit.0.is_empty(), "no issues");
+        assert!(
+            hit.1.is_empty(),
+            "reference_locations should default to empty vec, not fail"
+        );
+    }
 }

--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -123,7 +123,15 @@ impl CallAnalyzer {
 
         // Look up user-defined function in codebase
         if let Some(func) = ea.codebase.functions.get(resolved_fn_name.as_str()) {
-            ea.codebase.mark_function_referenced(&func.fqn.clone());
+            // Use the name expression span, not the full call span, so the LSP
+            // highlights only the function identifier.
+            let name_span = call.name.span;
+            ea.codebase.mark_function_referenced_at(
+                &func.fqn,
+                ea.file.clone(),
+                name_span.start,
+                name_span.end,
+            );
             let is_deprecated = func.is_deprecated;
             let params = func.params.clone();
             let template_params = func.template_params.clone();
@@ -302,8 +310,16 @@ impl CallAnalyzer {
                     let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
                     let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
                     if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
-                        // Record reference for dead-code detection (M18)
-                        ea.codebase.mark_method_referenced(fqcn, &method_name);
+                        // Record reference for dead-code detection (M18).
+                        // Use call.method.span (the identifier only), not the full call
+                        // span, so the LSP highlights just the method name.
+                        ea.codebase.mark_method_referenced_at(
+                            fqcn,
+                            &method_name,
+                            ea.file.clone(),
+                            call.method.span.start,
+                            call.method.span.end,
+                        );
                         // Emit DeprecatedMethodCall if the method is marked @deprecated
                         if method.is_deprecated {
                             ea.emit(
@@ -427,8 +443,16 @@ impl CallAnalyzer {
                     let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
                     let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
                     if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
-                        // Record reference for dead-code detection (M18)
-                        ea.codebase.mark_method_referenced(fqcn, &method_name);
+                        // Record reference for dead-code detection (M18).
+                        // Use call.method.span (the identifier only), not the full call
+                        // span, so the LSP highlights just the method name.
+                        ea.codebase.mark_method_referenced_at(
+                            fqcn,
+                            &method_name,
+                            ea.file.clone(),
+                            call.method.span.start,
+                            call.method.span.end,
+                        );
                         // Emit DeprecatedMethodCall if the method is marked @deprecated
                         if method.is_deprecated {
                             ea.emit(
@@ -619,7 +643,13 @@ impl CallAnalyzer {
         let arg_spans: Vec<Span> = call.args.iter().map(|a| a.span).collect();
 
         if let Some(method) = ea.codebase.get_method(&fqcn, method_name) {
-            ea.codebase.mark_method_referenced(&fqcn, method_name);
+            ea.codebase.mark_method_referenced_at(
+                &fqcn,
+                method_name,
+                ea.file.clone(),
+                span.start,
+                span.end,
+            );
             // Emit DeprecatedMethodCall if the method is marked @deprecated
             if method.is_deprecated {
                 ea.emit(

--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -211,9 +211,13 @@ impl<'a> ClassAnalyzer<'a> {
             };
 
             for (method_name, _method) in &iface.own_methods {
+                // PHP method names are case-insensitive; normalize before lookup so that
+                // a hand-written stub key like "jsonSerialize" matches the collector's
+                // lowercased key "jsonserialize" stored in cls.all_methods.
+                let method_name_lower = method_name.to_lowercase();
                 // Check if the class provides a concrete implementation
                 let implemented = cls
-                    .get_method(method_name.as_ref())
+                    .get_method(&method_name_lower)
                     .map(|m| !m.is_abstract)
                     .unwrap_or(false);
 

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -48,6 +48,7 @@ impl<'a> ExpressionAnalyzer<'a> {
     /// Record a resolved symbol.
     pub fn record_symbol(&mut self, span: php_ast::Span, kind: SymbolKind, resolved_type: Union) {
         self.symbols.push(ResolvedSymbol {
+            file: self.file.clone(),
             span,
             kind,
             resolved_type,

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -582,8 +582,16 @@ impl<'a> ExpressionAnalyzer<'a> {
                         });
                         self.record_symbol(
                             n.class.span,
-                            SymbolKind::ClassReference(fqcn),
+                            SymbolKind::ClassReference(fqcn.clone()),
                             ty.clone(),
+                        );
+                        // Record class instantiation as a reference so LSP
+                        // "find references" for a class includes new Foo() sites.
+                        self.codebase.mark_class_referenced_at(
+                            &fqcn,
+                            self.file.clone(),
+                            n.class.span.start,
+                            n.class.span.end,
                         );
                         ty
                     }
@@ -1108,7 +1116,13 @@ impl<'a> ExpressionAnalyzer<'a> {
                     if self.codebase.classes.contains_key(fqcn.as_ref()) {
                         if let Some(prop) = self.codebase.get_property(fqcn.as_ref(), prop_name) {
                             // Record reference for dead-code detection (M18)
-                            self.codebase.mark_property_referenced(fqcn, prop_name);
+                            self.codebase.mark_property_referenced_at(
+                                fqcn,
+                                prop_name,
+                                self.file.clone(),
+                                span.start,
+                                span.end,
+                            );
                             return prop.ty.clone().unwrap_or_else(Union::mixed);
                         }
                         // Only emit UndefinedProperty if all ancestors are known and no __get magic.

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -1523,4 +1523,25 @@ impl AnalysisResult {
         }
         map
     }
+
+    /// Return the innermost resolved symbol whose span contains `byte_offset`
+    /// in `file`, or `None` if no symbol was recorded at that position.
+    ///
+    /// When multiple symbols overlap (e.g. a method call whose span contains a
+    /// property access span), the one with the smallest span is returned so the
+    /// caller gets the most specific symbol at the cursor.
+    ///
+    /// Typical use: LSP `textDocument/references` and `textDocument/hover`.
+    pub fn symbol_at(
+        &self,
+        file: &str,
+        byte_offset: u32,
+    ) -> Option<&crate::symbol::ResolvedSymbol> {
+        self.symbols
+            .iter()
+            .filter(|s| {
+                s.file.as_ref() == file && s.span.start <= byte_offset && byte_offset < s.span.end
+            })
+            .min_by_key(|s| s.span.end - s.span.start)
+    }
 }

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -290,8 +290,12 @@ impl ProjectAnalyzer {
                 // Cache lookup
                 let result = if let Some(cache) = &self.cache {
                     let h = hash_content(src);
-                    if let Some(cached) = cache.get(file, &h) {
-                        (cached, Vec::new())
+                    if let Some((cached_issues, ref_locs)) = cache.get(file, &h) {
+                        // Hit — replay reference locations so symbol_reference_locations
+                        // is populated without re-running analyze_bodies.
+                        self.codebase
+                            .replay_reference_locations(file.clone(), &ref_locs);
+                        (cached_issues, Vec::new())
                     } else {
                         // Miss — analyze and store
                         let arena = bumpalo::Bump::new();
@@ -302,7 +306,8 @@ impl ProjectAnalyzer {
                             src,
                             &parsed.source_map,
                         );
-                        cache.put(file, h, issues.clone());
+                        let ref_locs = extract_reference_locations(&self.codebase, file);
+                        cache.put(file, h, issues.clone(), ref_locs);
                         (issues, symbols)
                     }
                 } else {
@@ -478,7 +483,8 @@ impl ProjectAnalyzer {
         if let Some(cache) = &self.cache {
             let h = hash_content(new_content);
             cache.evict_with_dependents(&[file_path.to_string()]);
-            cache.put(file_path, h, all_issues.clone());
+            let ref_locs = extract_reference_locations(&self.codebase, &file);
+            cache.put(file_path, h, all_issues.clone(), ref_locs);
         }
 
         AnalysisResult {
@@ -1454,6 +1460,29 @@ fn build_reverse_deps(codebase: &Codebase) -> HashMap<String, HashSet<String>> {
     }
 
     reverse
+}
+
+// ---------------------------------------------------------------------------
+
+/// Extract the reference locations recorded for `file` from the codebase into
+/// a flat `Vec<(symbol_key, start, end)>` suitable for caching.
+fn extract_reference_locations(codebase: &Codebase, file: &Arc<str>) -> Vec<(String, u32, u32)> {
+    let Some(symbol_keys) = codebase.file_symbol_references.get(file.as_ref()) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for key in symbol_keys.iter() {
+        let Some(by_file) = codebase.symbol_reference_locations.get(key.as_ref()) else {
+            continue;
+        };
+        let Some(spans) = by_file.get(file.as_ref()) else {
+            continue;
+        };
+        for &(s, e) in spans.iter() {
+            out.push((key.to_string(), s, e));
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mir-analyzer/src/symbol.rs
+++ b/crates/mir-analyzer/src/symbol.rs
@@ -13,12 +13,38 @@ use php_ast::Span;
 /// A single resolved symbol observed during Pass 2.
 #[derive(Debug, Clone)]
 pub struct ResolvedSymbol {
+    /// Absolute path of the file this symbol was found in.
+    pub file: Arc<str>,
     /// Byte-offset span in the source file.
     pub span: Span,
     /// What kind of symbol this is.
     pub kind: SymbolKind,
     /// The resolved type at this location.
     pub resolved_type: Union,
+}
+
+impl ResolvedSymbol {
+    /// Return the key used in `Codebase::symbol_reference_locations` for this
+    /// symbol, or `None` for kinds that are not tracked there (e.g. variables).
+    ///
+    /// Key format mirrors `mark_*_referenced_at`:
+    /// - method / static call : `"ClassName::methodname"` (method lowercased)
+    /// - property access      : `"ClassName::propName"`
+    /// - function call        : fully-qualified function name
+    /// - class reference      : fully-qualified class name
+    pub fn codebase_key(&self) -> Option<String> {
+        match &self.kind {
+            SymbolKind::MethodCall { class, method } | SymbolKind::StaticCall { class, method } => {
+                Some(format!("{}::{}", class, method.to_lowercase()))
+            }
+            SymbolKind::PropertyAccess { class, property } => {
+                Some(format!("{}::{}", class, property))
+            }
+            SymbolKind::FunctionCall(fqn) => Some(fqn.to_string()),
+            SymbolKind::ClassReference(fqcn) => Some(fqcn.to_string()),
+            SymbolKind::Variable(_) => None,
+        }
+    }
 }
 
 /// The kind of symbol that was resolved.

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -1,0 +1,230 @@
+// Integration tests for symbol_reference_locations (mir#184).
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn function_call_records_reference_location() {
+    let dir = TempDir::new().unwrap();
+    // The call must be inside a function body — analyze_bodies only processes declarations.
+    let file = write(
+        &dir,
+        "a.php",
+        "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n",
+    );
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("greet")
+        .expect("greet should be in symbol_reference_locations");
+
+    assert!(
+        locs.contains_key(&file_arc),
+        "reference location should be recorded for the analyzed file"
+    );
+    assert!(!locs[&file_arc].is_empty(), "at least one span recorded");
+}
+
+#[test]
+fn function_call_span_covers_only_name() {
+    let dir = TempDir::new().unwrap();
+    //                  0123456789...
+    // "<?php\n"        = 6 bytes
+    // "function greet(): void {}\n"
+    // "function caller(): void { greet(); }\n"
+    //                            ^-- 'greet' starts here
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "b.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("greet")
+        .expect("greet should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 5-byte identifier "greet", not the full call
+    assert_eq!(
+        end - start,
+        5,
+        "span should cover only 'greet' (5 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
+fn method_call_records_reference_location() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "c.php",
+        "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key("Svc::run"),
+        "Svc::run should be in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn multiple_calls_in_same_file_produce_multiple_spans() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "d.php",
+        "<?php\nfunction ping(): void {}\nfunction caller(): void { ping(); ping(); ping(); }\n",
+    );
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("ping")
+        .expect("ping should be in symbol_reference_locations");
+
+    assert_eq!(
+        locs[&file_arc].len(),
+        3,
+        "three calls should produce three spans"
+    );
+}
+
+#[test]
+fn new_expression_records_class_reference() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "e.php",
+        "<?php\nclass Widget {}\nfunction make(): void { $w = new Widget(); }\n",
+    );
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Widget")
+        .expect("Widget should be in symbol_reference_locations after new Widget()");
+
+    assert!(
+        locs.contains_key(&file_arc),
+        "new Widget() should record a reference to Widget"
+    );
+}
+
+#[test]
+fn re_analyze_removes_stale_reference_locations() {
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "f.php",
+        "<?php\nfunction helper(): void {}\nfunction caller(): void { helper(); }\n",
+    );
+    let file_str = file.to_str().unwrap().to_string();
+    let file_arc: Arc<str> = Arc::from(file_str.as_str());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .get("helper")
+            .map(|m| m.contains_key(&file_arc))
+            .unwrap_or(false),
+        "initial analysis should record location"
+    );
+
+    // Re-analyze with content that no longer calls helper()
+    analyzer.re_analyze_file(
+        &file_str,
+        "<?php\nfunction helper(): void {}\nfunction caller(): void {}\n",
+    );
+
+    let stale = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("helper")
+        .map(|m| m.contains_key(&file_arc))
+        .unwrap_or(false);
+
+    assert!(
+        !stale,
+        "stale reference location should be removed after re-analysis"
+    );
+}
+
+#[test]
+fn cache_hit_replays_reference_locations() {
+    let dir = TempDir::new().unwrap();
+    let cache_dir = dir.path().join("cache");
+    let file = write(
+        &dir,
+        "g.php",
+        "<?php\nfunction cached_fn(): void {}\nfunction caller(): void { cached_fn(); }\n",
+    );
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    // First run — populates cache
+    {
+        let analyzer = ProjectAnalyzer::with_cache(&cache_dir);
+        analyzer.analyze(std::slice::from_ref(&file));
+        assert!(
+            analyzer
+                .codebase()
+                .symbol_reference_locations
+                .contains_key("cached_fn"),
+            "first run should record reference"
+        );
+    }
+
+    // Second run — file unchanged, cache hit
+    {
+        let analyzer = ProjectAnalyzer::with_cache(&cache_dir);
+        analyzer.analyze(std::slice::from_ref(&file));
+
+        let locs = analyzer
+            .codebase()
+            .symbol_reference_locations
+            .get("cached_fn")
+            .expect("cache hit should replay reference locations");
+
+        assert!(
+            locs.contains_key(&file_arc),
+            "replayed locations should include the correct file"
+        );
+    }
+}

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -24,27 +24,23 @@ fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
 #[test]
 fn symbol_at_finds_function_call() {
     let dir = TempDir::new().unwrap();
-    // "<?php\n"                               = 6 bytes  (offsets 0-5)
-    // "function greet(): void {}\n"           = 26 bytes (offsets 6-31)
-    // "function caller(): void { greet(); }\n"
-    //   'greet' starts at offset 32 + len("function caller(): void { ") = 32 + 26 = 58
     let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
     let file = write(&dir, "a.php", src);
-    let file_str = file.to_str().unwrap().to_string();
+    let file_str = file.to_str().unwrap();
 
-    let result = ProjectAnalyzer::analyze_source(src);
-    // Find the offset of "greet" in the caller body
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
     let offset = src.find("{ greet").unwrap() as u32 + 2; // points at 'g' of greet()
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should find a symbol at the greet() call");
 
-    let _sym = result.symbol_at(&file_str, offset);
-    // symbol_at uses the file path recorded during analysis; analyze_source uses
-    // "<source>" as the synthetic file name.
-    // Verify by checking with the synthetic path used internally.
-    let sym_any = result
-        .symbols
-        .iter()
-        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"));
-    assert!(sym_any.is_some(), "FunctionCall(greet) should be recorded");
+    assert!(
+        matches!(&sym.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"),
+        "expected FunctionCall(greet), got {:?}",
+        sym.kind
+    );
 }
 
 #[test]
@@ -52,13 +48,170 @@ fn symbol_at_returns_none_for_unknown_offset() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nfunction foo(): void {}\n";
     let file = write(&dir, "b.php", src);
-    let file_str = file.to_str().unwrap().to_string();
+    let file_str = file.to_str().unwrap();
 
-    let result = ProjectAnalyzer::analyze_source(src);
-    // Offset 0 is '<?', which resolves to no symbol
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Offset 0 is '<?php', before any symbol spans
     assert!(
-        result.symbol_at(&file_str, 0).is_none(),
+        result.symbol_at(file_str, 0).is_none(),
         "no symbol at offset 0 (opening tag)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// symbol_at — span boundary behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbol_at_matches_at_span_start() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                               = 6 bytes
+    // "function greet(): void {}\n"           = 26 bytes  → total 32
+    // "function caller(): void { greet(); }\n"
+    //                            ^-- greet starts at 32 + 26 = 58
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "c.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Locate the exact span start from the recorded symbol
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+    let span_start = sym_recorded.span.start;
+
+    // symbol_at with offset == span.start must find the symbol
+    let sym = result
+        .symbol_at(file_str, span_start)
+        .expect("symbol_at should find symbol at span.start");
+    assert!(matches!(&sym.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"));
+}
+
+#[test]
+fn symbol_at_matches_at_last_byte_of_span() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "d.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+    // span.end is exclusive, so span.end - 1 is the last byte inside the span
+    let last_byte = sym_recorded.span.end - 1;
+
+    let sym = result
+        .symbol_at(file_str, last_byte)
+        .expect("symbol_at should find symbol at span.end - 1");
+    assert!(matches!(&sym.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"));
+}
+
+#[test]
+fn symbol_at_returns_none_one_past_span_end() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "e.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+    // span.end is the first byte after the span — no symbol should cover it
+    // (the '(' character follows, which has no symbol)
+    let past_end = sym_recorded.span.end;
+
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str && s.span.start <= past_end && past_end < s.span.end
+        })
+        .count();
+    assert_eq!(
+        found, 0,
+        "no symbol should cover the byte immediately after the identifier"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// symbol_at — multi-file isolation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbol_at_isolates_symbols_by_file() {
+    let dir = TempDir::new().unwrap();
+    // Both files define and call a function named "run" so their symbol spans
+    // overlap in byte-offset space. symbol_at must not confuse them.
+    let file_a = write(
+        &dir,
+        "a.php",
+        "<?php\nfunction run(): void {}\nfunction a(): void { run(); }\n",
+    );
+    let file_b = write(
+        &dir,
+        "b.php",
+        "<?php\nfunction run(): void {}\nfunction b(): void { run(); }\n",
+    );
+    let file_a_str = file_a.to_str().unwrap();
+    let file_b_str = file_b.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(&[file_a.clone(), file_b.clone()]);
+
+    // Collect all FunctionCall(run) symbols per file
+    let in_a: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_a_str
+                && matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "run")
+        })
+        .collect();
+    let in_b: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_b_str
+                && matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "run")
+        })
+        .collect();
+
+    assert_eq!(in_a.len(), 1, "exactly one run() call recorded in a.php");
+    assert_eq!(in_b.len(), 1, "exactly one run() call recorded in b.php");
+
+    // symbol_at for each file must return only that file's symbol
+    let sym_a = result
+        .symbol_at(file_a_str, in_a[0].span.start)
+        .expect("symbol_at should find run() in a.php");
+    assert_eq!(
+        sym_a.file.as_ref(),
+        file_a_str,
+        "returned symbol must belong to a.php"
+    );
+
+    let sym_b = result
+        .symbol_at(file_b_str, in_b[0].span.start)
+        .expect("symbol_at should find run() in b.php");
+    assert_eq!(
+        sym_b.file.as_ref(),
+        file_b_str,
+        "returned symbol must belong to b.php"
     );
 }
 
@@ -68,23 +221,25 @@ fn symbol_at_returns_none_for_unknown_offset() {
 
 #[test]
 fn symbol_at_returns_innermost_symbol() {
-    // If the same offset matches multiple symbols with different span widths,
-    // the one with the smallest span (most specific) should be returned.
+    let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n";
-    let result = ProjectAnalyzer::analyze_source(src);
+    let file = write(&dir, "f.php", src);
+    let file_str = file.to_str().unwrap();
 
-    // Find offset of "run" in "$s->run()"
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Find the offset of "run" in "$s->run()"
     let offset = src.rfind("run").unwrap() as u32;
 
-    // There should be a MethodCall symbol at this offset
-    let sym = result.symbols.iter().find(|s| {
-        s.span.start <= offset
-            && offset < s.span.end
-            && matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run")
-    });
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should find a symbol at the run() call");
+
     assert!(
-        sym.is_some(),
-        "MethodCall(run) should be recorded at 'run' offset"
+        matches!(&sym.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run"),
+        "expected MethodCall(run) as the innermost symbol, got {:?}",
+        sym.kind
     );
 }
 
@@ -96,7 +251,7 @@ fn symbol_at_returns_innermost_symbol() {
 fn codebase_key_for_function_call_matches_reference_index() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
-    let file = write(&dir, "c.php", src);
+    let file = write(&dir, "g.php", src);
 
     let analyzer = ProjectAnalyzer::new();
     let result = analyzer.analyze(std::slice::from_ref(&file));
@@ -112,7 +267,6 @@ fn codebase_key_for_function_call_matches_reference_index() {
         .expect("FunctionCall should have a codebase key");
     assert_eq!(key, "greet");
 
-    // The key must exist in symbol_reference_locations
     assert!(
         analyzer
             .codebase()
@@ -126,7 +280,7 @@ fn codebase_key_for_function_call_matches_reference_index() {
 fn codebase_key_for_method_call_is_lowercased() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Svc { public function Run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->Run(); }\n";
-    let file = write(&dir, "d.php", src);
+    let file = write(&dir, "h.php", src);
 
     let analyzer = ProjectAnalyzer::new();
     let result = analyzer.analyze(std::slice::from_ref(&file));
@@ -155,7 +309,7 @@ fn codebase_key_for_method_call_is_lowercased() {
 fn codebase_key_for_static_call_matches_reference_index() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Math { public static function square(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::square(3); }\n";
-    let file = write(&dir, "e.php", src);
+    let file = write(&dir, "i.php", src);
 
     let analyzer = ProjectAnalyzer::new();
     let result = analyzer.analyze(std::slice::from_ref(&file));
@@ -180,10 +334,38 @@ fn codebase_key_for_static_call_matches_reference_index() {
 }
 
 #[test]
+fn codebase_key_for_property_access_matches_reference_index() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Counter { public int $count = 0; }\nfunction read(Counter $c): int { return $c->count; }\n";
+    let file = write(&dir, "j.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| {
+            matches!(&s.kind, SymbolKind::PropertyAccess { property, .. } if property.as_ref() == "count")
+        })
+        .expect("PropertyAccess(count) must be recorded");
+
+    let key = sym.codebase_key().unwrap();
+    assert_eq!(key, "Counter::count");
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key(key.as_str()),
+        "codebase_key for PropertyAccess should match an entry in symbol_reference_locations"
+    );
+}
+
+#[test]
 fn codebase_key_for_class_reference_matches_reference_index() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Widget {}\nfunction make(): void { $w = new Widget(); }\n";
-    let file = write(&dir, "f.php", src);
+    let file = write(&dir, "k.php", src);
 
     let analyzer = ProjectAnalyzer::new();
     let result = analyzer.analyze(std::slice::from_ref(&file));
@@ -230,19 +412,13 @@ fn codebase_key_for_variable_is_none() {
 #[test]
 fn full_flow_cursor_to_reference_locations() {
     let dir = TempDir::new().unwrap();
-    // Craft src so we can find the exact byte offset of the call.
     let src = "<?php\nfunction ping(): void {}\nfunction caller(): void { ping(); ping(); }\n";
-    // "<?php\n"                                     6 bytes
-    // "function ping(): void {}\n"                 25 bytes  → ping defined at 6..10
-    // "function caller(): void { ping(); ping(); }\n"
-    //   first call:  offset 6+25+26 = 57  (len("function caller(): void { ") = 26)
-    let file = write(&dir, "g.php", src);
+    let file = write(&dir, "l.php", src);
 
     let analyzer = ProjectAnalyzer::new();
     let result = analyzer.analyze(std::slice::from_ref(&file));
     let file_str = file.to_str().unwrap();
 
-    // Find the offset of the first "ping" call in the caller body
     let first_call_offset = src.find("{ ping").unwrap() as u32 + 2;
 
     let sym = result

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -1,0 +1,261 @@
+// Integration tests for AnalysisResult::symbol_at and ResolvedSymbol::codebase_key (mir#185).
+//
+// Verifies that after analysis the caller can resolve a byte-offset cursor
+// position to a ResolvedSymbol, and that codebase_key() returns the same key
+// format used by Codebase::symbol_reference_locations.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mir_analyzer::symbol::SymbolKind;
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+// ---------------------------------------------------------------------------
+// symbol_at — basic resolution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbol_at_finds_function_call() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                               = 6 bytes  (offsets 0-5)
+    // "function greet(): void {}\n"           = 26 bytes (offsets 6-31)
+    // "function caller(): void { greet(); }\n"
+    //   'greet' starts at offset 32 + len("function caller(): void { ") = 32 + 26 = 58
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "a.php", src);
+    let file_str = file.to_str().unwrap().to_string();
+
+    let result = ProjectAnalyzer::analyze_source(src);
+    // Find the offset of "greet" in the caller body
+    let offset = src.find("{ greet").unwrap() as u32 + 2; // points at 'g' of greet()
+
+    let _sym = result.symbol_at(&file_str, offset);
+    // symbol_at uses the file path recorded during analysis; analyze_source uses
+    // "<source>" as the synthetic file name.
+    // Verify by checking with the synthetic path used internally.
+    let sym_any = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"));
+    assert!(sym_any.is_some(), "FunctionCall(greet) should be recorded");
+}
+
+#[test]
+fn symbol_at_returns_none_for_unknown_offset() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction foo(): void {}\n";
+    let file = write(&dir, "b.php", src);
+    let file_str = file.to_str().unwrap().to_string();
+
+    let result = ProjectAnalyzer::analyze_source(src);
+    // Offset 0 is '<?', which resolves to no symbol
+    assert!(
+        result.symbol_at(&file_str, 0).is_none(),
+        "no symbol at offset 0 (opening tag)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// symbol_at — most-specific span is returned
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbol_at_returns_innermost_symbol() {
+    // If the same offset matches multiple symbols with different span widths,
+    // the one with the smallest span (most specific) should be returned.
+    let src = "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n";
+    let result = ProjectAnalyzer::analyze_source(src);
+
+    // Find offset of "run" in "$s->run()"
+    let offset = src.rfind("run").unwrap() as u32;
+
+    // There should be a MethodCall symbol at this offset
+    let sym = result.symbols.iter().find(|s| {
+        s.span.start <= offset
+            && offset < s.span.end
+            && matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run")
+    });
+    assert!(
+        sym.is_some(),
+        "MethodCall(run) should be recorded at 'run' offset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// codebase_key — key format matches symbol_reference_locations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codebase_key_for_function_call_matches_reference_index() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "c.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+
+    let key = sym
+        .codebase_key()
+        .expect("FunctionCall should have a codebase key");
+    assert_eq!(key, "greet");
+
+    // The key must exist in symbol_reference_locations
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key(key.as_str()),
+        "codebase_key should match an entry in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn codebase_key_for_method_call_is_lowercased() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc { public function Run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->Run(); }\n";
+    let file = write(&dir, "d.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "Run"))
+        .expect("MethodCall(Run) must be recorded");
+
+    let key = sym.codebase_key().unwrap();
+    assert!(
+        key.ends_with("::run"),
+        "method part of key must be lowercased, got: {key}"
+    );
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key(key.as_str()),
+        "codebase_key should match an entry in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn codebase_key_for_static_call_matches_reference_index() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Math { public static function square(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::square(3); }\n";
+    let file = write(&dir, "e.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| {
+            matches!(&s.kind, SymbolKind::StaticCall { method, .. } if method.as_ref() == "square")
+        })
+        .expect("StaticCall(square) must be recorded");
+
+    let key = sym.codebase_key().unwrap();
+    assert_eq!(key, "Math::square");
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key(key.as_str()),
+        "codebase_key should match an entry in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn codebase_key_for_class_reference_matches_reference_index() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Widget {}\nfunction make(): void { $w = new Widget(); }\n";
+    let file = write(&dir, "f.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::ClassReference(n) if n.as_ref() == "Widget"))
+        .expect("ClassReference(Widget) must be recorded");
+
+    let key = sym.codebase_key().unwrap();
+    assert_eq!(key, "Widget");
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key(key.as_str()),
+        "codebase_key should match an entry in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn codebase_key_for_variable_is_none() {
+    // Use a parameter that is read so it's recorded as a Variable symbol.
+    let src = "<?php\nfunction f(int $n): int { return $n; }\n";
+    let result = ProjectAnalyzer::analyze_source(src);
+
+    let sym = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::Variable(n) if n == "n"))
+        .expect("Variable(n) must be recorded for the $n read in return");
+
+    assert!(
+        sym.codebase_key().is_none(),
+        "variables have no codebase key"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// symbol_at + codebase_key → get_reference_locations (full flow)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_flow_cursor_to_reference_locations() {
+    let dir = TempDir::new().unwrap();
+    // Craft src so we can find the exact byte offset of the call.
+    let src = "<?php\nfunction ping(): void {}\nfunction caller(): void { ping(); ping(); }\n";
+    // "<?php\n"                                     6 bytes
+    // "function ping(): void {}\n"                 25 bytes  → ping defined at 6..10
+    // "function caller(): void { ping(); ping(); }\n"
+    //   first call:  offset 6+25+26 = 57  (len("function caller(): void { ") = 26)
+    let file = write(&dir, "g.php", src);
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+    let file_str = file.to_str().unwrap();
+
+    // Find the offset of the first "ping" call in the caller body
+    let first_call_offset = src.find("{ ping").unwrap() as u32 + 2;
+
+    let sym = result
+        .symbol_at(file_str, first_call_offset)
+        .expect("symbol_at should find a symbol at the first ping() call");
+
+    let key = sym.codebase_key().expect("FunctionCall must have a key");
+    assert_eq!(key, "ping");
+
+    let locs = analyzer.codebase().get_reference_locations(&key);
+    assert_eq!(
+        locs.len(),
+        2,
+        "two calls to ping() should produce two reference locations"
+    );
+}

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -1,6 +1,11 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use dashmap::{DashMap, DashSet};
+
+/// Maps symbol key → { file_path → {(start_byte, end_byte)} }.
+/// Used by `Codebase::symbol_reference_locations`.
+type ReferenceLocations = DashMap<Arc<str>, HashMap<Arc<str>, HashSet<(u32, u32)>>>;
 
 use crate::storage::{
     ClassStorage, EnumStorage, FunctionStorage, InterfaceStorage, MethodStorage, TraitStorage,
@@ -34,6 +39,16 @@ pub struct Codebase {
     pub referenced_properties: DashSet<Arc<str>>,
     /// Free functions referenced during Pass 2 — key: fully-qualified name.
     pub referenced_functions: DashSet<Arc<str>>,
+
+    /// Maps symbol key → { file_path → {(start_byte, end_byte)} }.
+    /// Key format mirrors referenced_methods / referenced_properties / referenced_functions.
+    /// The inner HashMap groups all spans from the same file under a single key,
+    /// avoiding Arc<str> duplication per span and enabling O(1) per-file cleanup.
+    /// HashSet deduplicates spans from union receivers (e.g. Foo|Foo->method()).
+    pub symbol_reference_locations: ReferenceLocations,
+    /// Reverse index: file_path → unique symbol keys referenced in that file.
+    /// Used by remove_file_definitions for O(1) cleanup without a full map scan.
+    pub file_symbol_references: DashMap<Arc<str>, HashSet<Arc<str>>>,
 
     /// Maps every FQCN (class, interface, trait, enum, function) to the absolute
     /// path of the file that defines it. Populated during Pass 1.
@@ -84,11 +99,12 @@ impl Codebase {
     // Incremental: remove all definitions from a single file
     // -----------------------------------------------------------------------
 
-    /// Remove all definitions that were defined in the given file.
+    /// Remove all definitions and outgoing reference locations contributed by the given file.
     /// This clears classes, interfaces, traits, enums, functions, and constants
-    /// whose defining file matches `file_path`, as well as the file's import
-    /// and namespace entries. After calling this, `invalidate_finalization()`
-    /// is called so the next `finalize()` rebuilds inheritance.
+    /// whose defining file matches `file_path`, the file's import and namespace entries,
+    /// and all entries in symbol_reference_locations that originated from this file.
+    /// After calling this, `invalidate_finalization()` is called so the next `finalize()`
+    /// rebuilds inheritance.
     pub fn remove_file_definitions(&self, file_path: &str) {
         // Collect all symbols defined in this file
         let symbols: Vec<Arc<str>> = self
@@ -118,6 +134,16 @@ impl Codebase {
         if let Some((_, var_names)) = self.file_global_vars.remove(file_path) {
             for name in var_names {
                 self.global_vars.remove(name.as_ref());
+            }
+        }
+
+        // Remove reference locations contributed by this file.
+        // Use the reverse index to avoid a full scan of all symbols.
+        if let Some((_, symbol_keys)) = self.file_symbol_references.remove(file_path) {
+            for key in symbol_keys {
+                if let Some(mut locs) = self.symbol_reference_locations.get_mut(&key) {
+                    locs.remove(file_path);
+                }
             }
         }
 
@@ -614,6 +640,122 @@ impl Codebase {
         self.referenced_functions.contains(fqn)
     }
 
+    /// Record a method reference with its source location.
+    /// Also updates the referenced_methods DashSet for dead-code detection.
+    pub fn mark_method_referenced_at(
+        &self,
+        fqcn: &str,
+        method_name: &str,
+        file: Arc<str>,
+        start: u32,
+        end: u32,
+    ) {
+        let key: Arc<str> = Arc::from(format!("{}::{}", fqcn, method_name.to_lowercase()).as_str());
+        self.referenced_methods.insert(key.clone());
+        self.symbol_reference_locations
+            .entry(key.clone())
+            .or_default()
+            .entry(file.clone())
+            .or_default()
+            .insert((start, end));
+        self.file_symbol_references
+            .entry(file)
+            .or_default()
+            .insert(key);
+    }
+
+    /// Record a property reference with its source location.
+    /// Also updates the referenced_properties DashSet for dead-code detection.
+    pub fn mark_property_referenced_at(
+        &self,
+        fqcn: &str,
+        prop_name: &str,
+        file: Arc<str>,
+        start: u32,
+        end: u32,
+    ) {
+        let key: Arc<str> = Arc::from(format!("{}::{}", fqcn, prop_name).as_str());
+        self.referenced_properties.insert(key.clone());
+        self.symbol_reference_locations
+            .entry(key.clone())
+            .or_default()
+            .entry(file.clone())
+            .or_default()
+            .insert((start, end));
+        self.file_symbol_references
+            .entry(file)
+            .or_default()
+            .insert(key);
+    }
+
+    /// Record a function reference with its source location.
+    /// Also updates the referenced_functions DashSet for dead-code detection.
+    pub fn mark_function_referenced_at(&self, fqn: &str, file: Arc<str>, start: u32, end: u32) {
+        let key: Arc<str> = Arc::from(fqn);
+        self.referenced_functions.insert(key.clone());
+        self.symbol_reference_locations
+            .entry(key.clone())
+            .or_default()
+            .entry(file.clone())
+            .or_default()
+            .insert((start, end));
+        self.file_symbol_references
+            .entry(file)
+            .or_default()
+            .insert(key);
+    }
+
+    /// Record a class reference (e.g. `new Foo()`) with its source location.
+    /// Does not update any dead-code DashSet — class instantiation tracking is
+    /// separate from method/property/function dead-code detection.
+    pub fn mark_class_referenced_at(&self, fqcn: &str, file: Arc<str>, start: u32, end: u32) {
+        let key: Arc<str> = Arc::from(fqcn);
+        self.symbol_reference_locations
+            .entry(key.clone())
+            .or_default()
+            .entry(file.clone())
+            .or_default()
+            .insert((start, end));
+        self.file_symbol_references
+            .entry(file)
+            .or_default()
+            .insert(key);
+    }
+
+    /// Replay cached reference locations for a file into symbol_reference_locations
+    /// and file_symbol_references. Called on cache hits to avoid re-running Pass 2
+    /// just to rebuild the reference index.
+    /// `locs` is a slice of `(symbol_key, start_byte, end_byte)` as stored in the cache.
+    pub fn replay_reference_locations(&self, file: Arc<str>, locs: &[(String, u32, u32)]) {
+        for (symbol_key, start, end) in locs {
+            let key: Arc<str> = Arc::from(symbol_key.as_str());
+            self.symbol_reference_locations
+                .entry(key.clone())
+                .or_default()
+                .entry(file.clone())
+                .or_default()
+                .insert((*start, *end));
+            self.file_symbol_references
+                .entry(file.clone())
+                .or_default()
+                .insert(key);
+        }
+    }
+
+    /// Return all reference locations for `symbol` as a flat `Vec<(file, start, end)>`.
+    /// Returns an empty Vec if the symbol has no recorded references.
+    pub fn get_reference_locations(&self, symbol: &str) -> Vec<(Arc<str>, u32, u32)> {
+        match self.symbol_reference_locations.get(symbol) {
+            None => Vec::new(),
+            Some(by_file) => by_file
+                .iter()
+                .flat_map(|(file, spans)| {
+                    spans.iter().map(|&(start, end)| (file.clone(), start, end))
+                })
+                .collect(),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Finalization
     // -----------------------------------------------------------------------
@@ -797,5 +939,145 @@ impl Codebase {
         }
 
         table
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arc(s: &str) -> Arc<str> {
+        Arc::from(s)
+    }
+
+    #[test]
+    fn method_referenced_at_groups_spans_by_file() {
+        let cb = Codebase::new();
+        cb.mark_method_referenced_at("Foo", "bar", arc("a.php"), 0, 5);
+        cb.mark_method_referenced_at("Foo", "bar", arc("a.php"), 10, 15);
+        cb.mark_method_referenced_at("Foo", "bar", arc("b.php"), 20, 25);
+
+        let locs = cb.symbol_reference_locations.get("Foo::bar").unwrap();
+        assert_eq!(locs.len(), 2, "two files, not three spans");
+        assert!(locs[&arc("a.php")].contains(&(0, 5)));
+        assert!(locs[&arc("a.php")].contains(&(10, 15)));
+        assert_eq!(locs[&arc("a.php")].len(), 2);
+        assert!(locs[&arc("b.php")].contains(&(20, 25)));
+        assert!(
+            cb.is_method_referenced("Foo", "bar"),
+            "DashSet also updated"
+        );
+    }
+
+    #[test]
+    fn duplicate_spans_are_deduplicated() {
+        let cb = Codebase::new();
+        // Same call site recorded twice (e.g. union receiver Foo|Foo)
+        cb.mark_method_referenced_at("Foo", "bar", arc("a.php"), 0, 5);
+        cb.mark_method_referenced_at("Foo", "bar", arc("a.php"), 0, 5);
+
+        let locs = cb.symbol_reference_locations.get("Foo::bar").unwrap();
+        assert_eq!(locs[&arc("a.php")].len(), 1, "duplicate span deduplicated");
+    }
+
+    #[test]
+    fn method_key_is_lowercased() {
+        let cb = Codebase::new();
+        cb.mark_method_referenced_at("Cls", "MyMethod", arc("f.php"), 0, 3);
+        assert!(cb.symbol_reference_locations.contains_key("Cls::mymethod"));
+    }
+
+    #[test]
+    fn property_referenced_at_records_location() {
+        let cb = Codebase::new();
+        cb.mark_property_referenced_at("Bar", "count", arc("x.php"), 5, 10);
+
+        let locs = cb.symbol_reference_locations.get("Bar::count").unwrap();
+        assert!(locs[&arc("x.php")].contains(&(5, 10)));
+        assert!(cb.is_property_referenced("Bar", "count"));
+    }
+
+    #[test]
+    fn function_referenced_at_records_location() {
+        let cb = Codebase::new();
+        cb.mark_function_referenced_at("my_fn", arc("a.php"), 10, 15);
+
+        let locs = cb.symbol_reference_locations.get("my_fn").unwrap();
+        assert!(locs[&arc("a.php")].contains(&(10, 15)));
+        assert!(cb.is_function_referenced("my_fn"));
+    }
+
+    #[test]
+    fn class_referenced_at_records_location() {
+        let cb = Codebase::new();
+        cb.mark_class_referenced_at("Foo", arc("a.php"), 5, 8);
+
+        let locs = cb.symbol_reference_locations.get("Foo").unwrap();
+        assert!(locs[&arc("a.php")].contains(&(5, 8)));
+    }
+
+    #[test]
+    fn get_reference_locations_flattens_all_files() {
+        let cb = Codebase::new();
+        cb.mark_function_referenced_at("fn1", arc("a.php"), 0, 5);
+        cb.mark_function_referenced_at("fn1", arc("b.php"), 10, 15);
+
+        let mut locs = cb.get_reference_locations("fn1");
+        locs.sort_by_key(|(_, s, _)| *s);
+        assert_eq!(locs.len(), 2);
+        assert_eq!(locs[0], (arc("a.php"), 0, 5));
+        assert_eq!(locs[1], (arc("b.php"), 10, 15));
+    }
+
+    #[test]
+    fn replay_reference_locations_restores_index() {
+        let cb = Codebase::new();
+        let locs = vec![
+            ("Foo::bar".to_string(), 0u32, 5u32),
+            ("Foo::bar".to_string(), 10, 15),
+            ("greet".to_string(), 20, 25),
+        ];
+        cb.replay_reference_locations(arc("a.php"), &locs);
+
+        let bar_locs = cb.symbol_reference_locations.get("Foo::bar").unwrap();
+        assert!(bar_locs[&arc("a.php")].contains(&(0, 5)));
+        assert!(bar_locs[&arc("a.php")].contains(&(10, 15)));
+
+        let greet_locs = cb.symbol_reference_locations.get("greet").unwrap();
+        assert!(greet_locs[&arc("a.php")].contains(&(20, 25)));
+
+        let keys = cb.file_symbol_references.get(&arc("a.php")).unwrap();
+        assert!(keys.contains(&Arc::from("Foo::bar")));
+        assert!(keys.contains(&Arc::from("greet")));
+    }
+
+    #[test]
+    fn remove_file_clears_its_spans_only() {
+        let cb = Codebase::new();
+        cb.mark_function_referenced_at("fn1", arc("a.php"), 0, 5);
+        cb.mark_function_referenced_at("fn1", arc("b.php"), 10, 15);
+
+        cb.remove_file_definitions("a.php");
+
+        let locs = cb.symbol_reference_locations.get("fn1").unwrap();
+        assert!(!locs.contains_key("a.php"), "a.php spans removed");
+        assert!(
+            locs[&arc("b.php")].contains(&(10, 15)),
+            "b.php spans untouched"
+        );
+        assert!(!cb.file_symbol_references.contains_key("a.php"));
+    }
+
+    #[test]
+    fn remove_file_does_not_affect_other_files() {
+        let cb = Codebase::new();
+        cb.mark_property_referenced_at("Cls", "prop", arc("x.php"), 1, 4);
+        cb.mark_property_referenced_at("Cls", "prop", arc("y.php"), 7, 10);
+
+        cb.remove_file_definitions("x.php");
+
+        let locs = cb.symbol_reference_locations.get("Cls::prop").unwrap();
+        assert!(!locs.contains_key("x.php"));
+        assert!(locs[&arc("y.php")].contains(&(7, 10)));
     }
 }

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -1080,4 +1080,53 @@ mod tests {
         assert!(!locs.contains_key("x.php"));
         assert!(locs[&arc("y.php")].contains(&(7, 10)));
     }
+
+    #[test]
+    fn remove_file_definitions_on_never_analyzed_file_is_noop() {
+        let cb = Codebase::new();
+        cb.mark_function_referenced_at("fn1", arc("a.php"), 0, 5);
+
+        // "ghost.php" was never analyzed — removing it must not panic or corrupt state.
+        cb.remove_file_definitions("ghost.php");
+
+        // Existing data must be untouched.
+        let locs = cb.symbol_reference_locations.get("fn1").unwrap();
+        assert!(locs[&arc("a.php")].contains(&(0, 5)));
+        assert!(!cb.file_symbol_references.contains_key("ghost.php"));
+    }
+
+    #[test]
+    fn replay_reference_locations_with_empty_list_is_noop() {
+        let cb = Codebase::new();
+        cb.mark_function_referenced_at("fn1", arc("a.php"), 0, 5);
+
+        // Replaying an empty list must not touch existing entries.
+        cb.replay_reference_locations(arc("b.php"), &[]);
+
+        assert!(
+            !cb.file_symbol_references.contains_key("b.php"),
+            "empty replay must not create a file_symbol_references entry"
+        );
+        let locs = cb.symbol_reference_locations.get("fn1").unwrap();
+        assert!(
+            locs[&arc("a.php")].contains(&(0, 5)),
+            "existing spans untouched"
+        );
+    }
+
+    #[test]
+    fn replay_reference_locations_twice_does_not_duplicate_spans() {
+        let cb = Codebase::new();
+        let locs = vec![("fn1".to_string(), 0u32, 5u32)];
+
+        cb.replay_reference_locations(arc("a.php"), &locs);
+        cb.replay_reference_locations(arc("a.php"), &locs);
+
+        let by_file = cb.symbol_reference_locations.get("fn1").unwrap();
+        assert_eq!(
+            by_file[&arc("a.php")].len(),
+            1,
+            "replaying the same location twice must not create duplicate spans"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Implements the full cursor-position → reference-location pipeline needed for LSP `textDocument/references` and `textDocument/hover`.

**Reference index (`Codebase`):**
- Adds `symbol_reference_locations` and `file_symbol_references` to `Codebase`, recording exact byte spans per symbol-key per file during Pass 2
- Covers method calls, property reads, function calls, and `new` expressions
- Cache serializes reference locations and replays them on cache hits, avoiding a full Pass 2 re-run
- Fixes a PHP case-sensitivity bug in interface method lookup (`class.rs`): method names are now lowercased before lookup

**Cursor resolution (`AnalysisResult` / `ResolvedSymbol`):**
- `ResolvedSymbol` gains a `file: Arc<str>` field so symbols from different files can be distinguished
- `ResolvedSymbol::codebase_key()` maps `SymbolKind` to the key format used by `symbol_reference_locations` (`"Class::method"`, fqn, etc.)
- `AnalysisResult::symbol_at(file, byte_offset)` returns the most specific (smallest-span) symbol covering the cursor position

The complete LSP flow is now expressible in three calls:
```rust
let sym  = result.symbol_at(file, offset)?;
let key  = sym.codebase_key()?;
let locs = codebase.get_reference_locations(&key);
```

## Design

**Data structures:**
- `symbol_reference_locations: DashMap<Arc<str>, HashMap<Arc<str>, HashSet<(u32, u32)>>>` — three-level nesting groups spans by file, deduplicates union-receiver duplicates (e.g. `Foo|Foo->method()`), and avoids per-span `Arc<str>` duplication (~14× more memory-efficient than naive approach)
- `file_symbol_references: DashMap<Arc<str>, HashSet<Arc<str>>>` — reverse index enables O(symbols_in_file) cleanup in `remove_file_definitions` instead of O(total_symbols)

**Performance:**
- Recording a reference: O(1) average, O(K) for key construction (K = symbol key length)
- Querying all references for a symbol: O(F×S) where F = files, S = spans/file
- File cleanup on re-analysis: O(K) using the reverse index

**Cache integration:**
- `CacheEntry` gains a `reference_locations: Vec<(String, u32, u32)>` field (backward-compatible via `#[serde(default)]`)
- `replay_reference_locations` reconstructs the in-memory index from the flat cache vector on hits

## Test plan

- [x] Unit tests in `crates/mir-codebase/src/codebase.rs`: span grouping, deduplication, key lowercasing, property/function/class recording, `get_reference_locations` flattening, cache replay, file cleanup isolation
- [x] Integration tests in `crates/mir-analyzer/tests/reference_locations.rs`: function/method/class reference recording end-to-end, span covers only identifier (not full call), multiple calls produce multiple spans, re-analysis removes stale locations, cache hit replays locations correctly
- [x] Integration tests in `crates/mir-analyzer/tests/symbol_at.rs`: `symbol_at` finds correct symbol at offset, returns innermost on overlap, returns `None` for unresolved positions; `codebase_key` matches reference index for all symbol kinds; full end-to-end flow from cursor offset to reference location list