### PR TITLE
fix: use identifier span for property access symbols and track nullsafe accesses

### DIFF
--- a/crates/mir-analyzer/src/composer.rs
+++ b/crates/mir-analyzer/src/composer.rs
@@ -81,7 +81,7 @@ fn parse_vendor_entries(root: &Path) -> Vec<(String, PathBuf)> {
         }
     }
 
-    entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
     entries
 }
 
@@ -128,7 +128,7 @@ impl Psr4Map {
             }
         }
 
-        project_entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        project_entries.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
         let vendor_entries = parse_vendor_entries(root);
 

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1132,35 +1132,34 @@ impl<'a> ExpressionAnalyzer<'a> {
     ) -> Union {
         for atomic in &obj_ty.types {
             match atomic {
-                Atomic::TNamedObject { fqcn, .. } => {
-                    if self.codebase.classes.contains_key(fqcn.as_ref()) {
-                        if let Some(prop) = self.codebase.get_property(fqcn.as_ref(), prop_name) {
-                            // Record reference for dead-code detection (M18)
-                            self.codebase.mark_property_referenced_at(
-                                fqcn,
-                                prop_name,
-                                self.file.clone(),
-                                span.start,
-                                span.end,
-                            );
-                            return prop.ty.clone().unwrap_or_else(Union::mixed);
-                        }
-                        // Only emit UndefinedProperty if all ancestors are known and no __get magic.
-                        if !self.codebase.has_unknown_ancestor(fqcn.as_ref())
-                            && !self.codebase.has_magic_get(fqcn.as_ref())
-                        {
-                            self.emit(
-                                IssueKind::UndefinedProperty {
-                                    class: fqcn.to_string(),
-                                    property: prop_name.to_string(),
-                                },
-                                Severity::Warning,
-                                span,
-                            );
-                        }
-                        return Union::mixed();
+                Atomic::TNamedObject { fqcn, .. }
+                    if self.codebase.classes.contains_key(fqcn.as_ref()) =>
+                {
+                    if let Some(prop) = self.codebase.get_property(fqcn.as_ref(), prop_name) {
+                        // Record reference for dead-code detection (M18)
+                        self.codebase.mark_property_referenced_at(
+                            fqcn,
+                            prop_name,
+                            self.file.clone(),
+                            span.start,
+                            span.end,
+                        );
+                        return prop.ty.clone().unwrap_or_else(Union::mixed);
                     }
-                    // Class not in codebase (external/vendor) — skip silently.
+                    // Only emit UndefinedProperty if all ancestors are known and no __get magic.
+                    if !self.codebase.has_unknown_ancestor(fqcn.as_ref())
+                        && !self.codebase.has_magic_get(fqcn.as_ref())
+                    {
+                        self.emit(
+                            IssueKind::UndefinedProperty {
+                                class: fqcn.to_string(),
+                                property: prop_name.to_string(),
+                            },
+                            Severity::Warning,
+                            span,
+                        );
+                    }
+                    return Union::mixed();
                 }
                 Atomic::TMixed => return Union::mixed(),
                 _ => {}

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -636,12 +636,14 @@ impl<'a> ExpressionAnalyzer<'a> {
                 if prop_name == "<dynamic>" {
                     return Union::mixed();
                 }
-                let resolved = self.resolve_property_type(&obj_ty, &prop_name, expr.span);
+                // Use pa.property.span (the identifier only), not the full expression span,
+                // so the LSP highlights just the property name (e.g. `count` in `$c->count`).
+                let resolved = self.resolve_property_type(&obj_ty, &prop_name, pa.property.span);
                 // Record property access symbol for each named object in the receiver type
                 for atomic in &obj_ty.types {
                     if let Atomic::TNamedObject { fqcn, .. } = atomic {
                         self.record_symbol(
-                            expr.span,
+                            pa.property.span,
                             SymbolKind::PropertyAccess {
                                 class: fqcn.clone(),
                                 property: Arc::from(prop_name.as_str()),
@@ -663,8 +665,25 @@ impl<'a> ExpressionAnalyzer<'a> {
                 }
                 // ?-> strips null from receiver
                 let non_null_ty = obj_ty.remove_null();
-                let mut prop_ty = self.resolve_property_type(&non_null_ty, &prop_name, expr.span);
+                // Use pa.property.span (the identifier only), not the full expression span,
+                // so the LSP highlights just the property name (e.g. `val` in `$b?->val`).
+                let mut prop_ty =
+                    self.resolve_property_type(&non_null_ty, &prop_name, pa.property.span);
                 prop_ty.add_type(Atomic::TNull); // result is nullable because receiver may be null
+                                                 // Record symbol so symbol_at() resolves ?-> accesses the same way as ->.
+                for atomic in &non_null_ty.types {
+                    if let Atomic::TNamedObject { fqcn, .. } = atomic {
+                        self.record_symbol(
+                            pa.property.span,
+                            SymbolKind::PropertyAccess {
+                                class: fqcn.clone(),
+                                property: Arc::from(prop_name.as_str()),
+                            },
+                            prop_ty.clone(),
+                        );
+                        break;
+                    }
+                }
                 prop_ty
             }
 

--- a/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
@@ -8,4 +8,4 @@ function test(): void {
     echo $f->nonexistent;
 }
 ===expect===
-UndefinedProperty: $f->nonexistent
+UndefinedProperty: nonexistent

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -73,6 +73,100 @@ fn function_call_span_covers_only_name() {
 }
 
 #[test]
+fn method_call_span_covers_only_name() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                                          = 6 bytes
+    // "class Svc { public function run(): void {} }\n"   = 45 bytes  (offset 6)
+    // "function caller(): void { $s = new Svc(); $s->run(); }\n"
+    //                                             ^-- 'run' starts at offset 97
+    let src = "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n";
+    let file = write(&dir, "h.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Svc::run")
+        .expect("Svc::run should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 3-byte identifier "run", not the full call
+    assert_eq!(
+        end - start,
+        3,
+        "span should cover only 'run' (3 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
+fn property_access_span_covers_only_name() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                                          = 6 bytes
+    // "class Counter { public int $count = 0; }\n"      = 41 bytes  (offset 6)
+    // "function read(Counter $c): int { return $c->count; }\n"
+    //                                              ^-- 'count' starts at offset 91
+    let src = "<?php\nclass Counter { public int $count = 0; }\nfunction read(Counter $c): int { return $c->count; }\n";
+    let file = write(&dir, "i.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Counter::count")
+        .expect("Counter::count should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 5-byte identifier "count", not the full "$c->count"
+    assert_eq!(
+        end - start,
+        5,
+        "span should cover only 'count' (5 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
+fn nullsafe_property_access_records_reference_location() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                                     = 6 bytes
+    // "class Box { public int $val = 0; }\n"        = 35 bytes  (offset 6)
+    // "function read(?Box $b): void { $b?->val; }\n"
+    //                                        ^-- 'val' starts at offset 77
+    let src =
+        "<?php\nclass Box { public int $val = 0; }\nfunction read(?Box $b): void { $b?->val; }\n";
+    let file = write(&dir, "j.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Box::val")
+        .expect("Box::val should be in symbol_reference_locations after $b?->val");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 3-byte identifier "val", not "$b?->val"
+    assert_eq!(
+        end - start,
+        3,
+        "span should cover only 'val' (3 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
 fn method_call_records_reference_location() {
     let dir = TempDir::new().unwrap();
     let file = write(

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -435,3 +435,70 @@ fn full_flow_cursor_to_reference_locations() {
         "two calls to ping() should produce two reference locations"
     );
 }
+
+#[test]
+fn symbol_at_finds_property_access() {
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Counter { public int $count = 0; }\nfunction read(Counter $c): int { return $c->count; }\n";
+    let file = write(&dir, "m.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Point cursor at 'count' in '$c->count'
+    let offset = src.find("->count").unwrap() as u32 + 2; // +2 skips '->'
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should find a symbol at $c->count");
+
+    assert!(
+        matches!(&sym.kind, SymbolKind::PropertyAccess { property, .. } if property.as_ref() == "count"),
+        "expected PropertyAccess(count), got {:?}",
+        sym.kind
+    );
+
+    // Verify the full LSP flow: cursor → key → reference locations
+    let key = sym.codebase_key().expect("PropertyAccess must have a key");
+    assert_eq!(key, "Counter::count");
+    let locs = analyzer.codebase().get_reference_locations(&key);
+    assert_eq!(
+        locs.len(),
+        1,
+        "one property access should produce one reference location"
+    );
+}
+
+#[test]
+fn symbol_at_finds_nullsafe_property_access() {
+    let dir = TempDir::new().unwrap();
+    let src =
+        "<?php\nclass Box { public int $val = 0; }\nfunction read(?Box $b): void { $b?->val; }\n";
+    let file = write(&dir, "n.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Point cursor at 'val' in '$b?->val'
+    let offset = src.find("?->val").unwrap() as u32 + 3; // +3 skips '?->'
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should find a symbol at $b?->val");
+
+    assert!(
+        matches!(&sym.kind, SymbolKind::PropertyAccess { property, .. } if property.as_ref() == "val"),
+        "expected PropertyAccess(val) for nullsafe access, got {:?}",
+        sym.kind
+    );
+
+    // Verify the full LSP flow: cursor → key → reference locations
+    let key = sym.codebase_key().expect("PropertyAccess must have a key");
+    assert_eq!(key, "Box::val");
+    let locs = analyzer.codebase().get_reference_locations(&key);
+    assert_eq!(
+        locs.len(),
+        1,
+        "one nullsafe property access should produce one reference location"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix `->` property access to use `pa.property.span` instead of the full expression span, so LSP find-references highlights only the property name (e.g. `count` in `$c->count`)
- Fix `?->` nullsafe property access with the same span correction, and add the missing `record_symbol()` call — nullsafe accesses were not being tracked at all
- Update `undefined_property/basic.phpt` fixture to expect just the property name in the diagnostic message

## Test plan

- [ ] `method_call_span_covers_only_name` — span covers only `run` in `$s->run()`
- [ ] `property_access_span_covers_only_name` — span covers only `count` in `$c->count`
- [ ] `nullsafe_property_access_records_reference_location` — `?->` accesses are now tracked
- [ ] `symbol_at_finds_property_access` — `symbol_at()` resolves `$c->count` to `Counter::count`
- [ ] `symbol_at_finds_nullsafe_property_access` — `symbol_at()` resolves `$b?->val` to `Box::val`
- [ ] All existing tests pass (`cargo test --package mir-analyzer`)