### PR TITLE
fix: use identifier span for function/method/static call symbols

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -208,7 +208,7 @@ impl CallAnalyzer {
             };
 
             ea.record_symbol(
-                span,
+                call.name.span,
                 SymbolKind::FunctionCall(func.fqn.clone()),
                 return_ty.clone(),
             );
@@ -592,11 +592,13 @@ impl CallAnalyzer {
         } else {
             result
         };
-        // Record method call symbol using the first named object in the receiver
+        // Record method call symbol using the first named object in the receiver.
+        // Use call.method.span (the identifier only), not the full call span, so
+        // the LSP highlights just the method name.
         for atomic in &obj_ty.types {
             if let Atomic::TNamedObject { fqcn, .. } = atomic {
                 ea.record_symbol(
-                    span,
+                    call.method.span,
                     SymbolKind::MethodCall {
                         class: fqcn.clone(),
                         method: Arc::from(method_name.as_str()),
@@ -643,12 +645,16 @@ impl CallAnalyzer {
         let arg_spans: Vec<Span> = call.args.iter().map(|a| a.span).collect();
 
         if let Some(method) = ea.codebase.get_method(&fqcn, method_name) {
+            // Compute the method name span: class.span covers the class identifier,
+            // then "::" is 2 bytes, then the method name follows.
+            let method_start = call.class.span.end + 2;
+            let method_end = method_start + method_name.len() as u32;
             ea.codebase.mark_method_referenced_at(
                 &fqcn,
                 method_name,
                 ea.file.clone(),
-                span.start,
-                span.end,
+                method_start,
+                method_end,
             );
             // Emit DeprecatedMethodCall if the method is marked @deprecated
             if method.is_deprecated {
@@ -684,8 +690,9 @@ impl CallAnalyzer {
                 .unwrap_or_else(Union::mixed);
             let fqcn_arc: std::sync::Arc<str> = Arc::from(fqcn.as_str());
             let ret = substitute_static_in_return(ret_raw, &fqcn_arc);
+            let method_span = Span::new(method_start, method_end);
             ea.record_symbol(
-                span,
+                method_span,
                 SymbolKind::StaticCall {
                     class: fqcn_arc,
                     method: Arc::from(method_name),

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -282,6 +282,39 @@ fn re_analyze_removes_stale_reference_locations() {
 }
 
 #[test]
+fn static_method_call_span_covers_only_name() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                                                   = 6 bytes
+    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n"
+    //                                                             = 75 bytes (offset 6)
+    // "function caller(): void { Math::sq(3); }\n"
+    //                                    ^-- 'sq' starts at offset 6+75+26 = 107
+    //  "function caller(): void { Math::" = 32 chars → offset 6+75+32 = 113? let's not hardcode
+    let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
+    let file = write(&dir, "static_span.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Math::sq")
+        .expect("Math::sq should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 2-byte identifier "sq", not the full call
+    assert_eq!(
+        end - start,
+        2,
+        "span should cover only 'sq' (2 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
 fn cache_hit_replays_reference_locations() {
     let dir = TempDir::new().unwrap();
     let cache_dir = dir.path().join("cache");

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -284,12 +284,10 @@ fn re_analyze_removes_stale_reference_locations() {
 #[test]
 fn static_method_call_span_covers_only_name() {
     let dir = TempDir::new().unwrap();
-    // "<?php\n"                                                   = 6 bytes
-    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n"
-    //                                                             = 75 bytes (offset 6)
+    // "<?php\n"                                                                    = 6 bytes
+    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n" = 74 bytes
     // "function caller(): void { Math::sq(3); }\n"
-    //                                    ^-- 'sq' starts at offset 6+75+26 = 107
-    //  "function caller(): void { Math::" = 32 chars → offset 6+75+32 = 113? let's not hardcode
+    //                                    ^-- 'sq' starts at byte 6+74+32 = 112
     let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
     let file = write(&dir, "static_span.php", src);
     let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -437,6 +437,128 @@ fn full_flow_cursor_to_reference_locations() {
 }
 
 #[test]
+fn symbol_at_function_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the identifier) must NOT find the function symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "span_fn.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+
+    // span should cover only "greet" (5 bytes), not the full "greet()" call
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        5,
+        "FunctionCall symbol span must be identifier-only (5 bytes for 'greet')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the function symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet")
+        })
+        .count();
+    assert_eq!(found, 0, "cursor at '(' must not match the function symbol");
+}
+
+#[test]
+fn symbol_at_method_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the method identifier) must NOT find the method symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n";
+    let file = write(&dir, "span_method.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run"))
+        .expect("MethodCall(run) must be recorded");
+
+    // span should cover only "run" (3 bytes), not "run()" or "$s->run()"
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        3,
+        "MethodCall symbol span must be identifier-only (3 bytes for 'run')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the method symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run")
+        })
+        .count();
+    assert_eq!(found, 0, "cursor at '(' must not match the method symbol");
+}
+
+#[test]
+fn symbol_at_static_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the static method identifier) must NOT find the symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
+    let file = write(&dir, "span_static.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(
+            |s| matches!(&s.kind, SymbolKind::StaticCall { method, .. } if method.as_ref() == "sq"),
+        )
+        .expect("StaticCall(sq) must be recorded");
+
+    // span should cover only "sq" (2 bytes), not "Math::sq(3)"
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        2,
+        "StaticCall symbol span must be identifier-only (2 bytes for 'sq')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the static call symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::StaticCall { method, .. } if method.as_ref() == "sq")
+        })
+        .count();
+    assert_eq!(
+        found, 0,
+        "cursor at '(' must not match the static call symbol"
+    );
+}
+
+#[test]
 fn symbol_at_finds_property_access() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Counter { public int $count = 0; }\nfunction read(Counter $c): int { return $c->count; }\n";


### PR DESCRIPTION
## Summary

`record_symbol` was called with the full call expression span (including arguments) instead of the identifier-only span. This caused LSP hover and go-to-definition to highlight more code than the symbol name — e.g. `greet()` instead of `greet`, or `$s->run()` instead of `run`.

- **FunctionCall**: use `call.name.span` instead of `expr.span`
- **MethodCall**: use `call.method.span` instead of `expr.span`
- **StaticCall**: compute method span from `class.span.end + 2` (skip `::`); also fix `mark_method_referenced_at` which had the same bug

The static call case is limited by the `php-ast` AST: `StaticMethodCallExpr.method` is a `Cow<str>` with no span, so the span is derived from the class identifier's end offset. The whitespace-around-`::` edge case is tracked in #190.

## Test plan

- [ ] New test `symbol_at_function_call_span_is_identifier_only`: verifies `FunctionCall` symbol span covers only the function name and that a cursor at `(` does not resolve the symbol
- [ ] New test `symbol_at_method_call_span_is_identifier_only`: same for instance method calls
- [ ] New test `symbol_at_static_call_span_is_identifier_only`: same for static method calls
- [ ] New test `static_method_call_span_covers_only_name`: verifies `symbol_reference_locations` span for static calls covers only the method identifier
- [ ] All new tests confirmed to fail against old code and pass with fix
- [ ] Full workspace test suite passes (`cargo test --workspace`)