### PR TITLE
fix(context): inject $this into method context so $this->method() is resolved by symbol_at

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -208,7 +208,7 @@ impl CallAnalyzer {
             };
 
             ea.record_symbol(
-                span,
+                call.name.span,
                 SymbolKind::FunctionCall(func.fqn.clone()),
                 return_ty.clone(),
             );
@@ -592,11 +592,13 @@ impl CallAnalyzer {
         } else {
             result
         };
-        // Record method call symbol using the first named object in the receiver
+        // Record method call symbol using the first named object in the receiver.
+        // Use call.method.span (the identifier only), not the full call span, so
+        // the LSP highlights just the method name.
         for atomic in &obj_ty.types {
             if let Atomic::TNamedObject { fqcn, .. } = atomic {
                 ea.record_symbol(
-                    span,
+                    call.method.span,
                     SymbolKind::MethodCall {
                         class: fqcn.clone(),
                         method: Arc::from(method_name.as_str()),
@@ -643,12 +645,16 @@ impl CallAnalyzer {
         let arg_spans: Vec<Span> = call.args.iter().map(|a| a.span).collect();
 
         if let Some(method) = ea.codebase.get_method(&fqcn, method_name) {
+            // Compute the method name span: class.span covers the class identifier,
+            // then "::" is 2 bytes, then the method name follows.
+            let method_start = call.class.span.end + 2;
+            let method_end = method_start + method_name.len() as u32;
             ea.codebase.mark_method_referenced_at(
                 &fqcn,
                 method_name,
                 ea.file.clone(),
-                span.start,
-                span.end,
+                method_start,
+                method_end,
             );
             // Emit DeprecatedMethodCall if the method is marked @deprecated
             if method.is_deprecated {
@@ -684,8 +690,9 @@ impl CallAnalyzer {
                 .unwrap_or_else(Union::mixed);
             let fqcn_arc: std::sync::Arc<str> = Arc::from(fqcn.as_str());
             let ret = substitute_static_in_return(ret_raw, &fqcn_arc);
+            let method_span = Span::new(method_start, method_end);
             ea.record_symbol(
-                span,
+                method_span,
                 SymbolKind::StaticCall {
                     class: fqcn_arc,
                     method: Arc::from(method_name),

--- a/crates/mir-analyzer/src/context.rs
+++ b/crates/mir-analyzer/src/context.rs
@@ -101,6 +101,7 @@ impl Context {
         parent_fqcn: Option<Arc<str>>,
         static_fqcn: Option<Arc<str>>,
         strict_types: bool,
+        is_static: bool,
     ) -> Self {
         Self::for_method(
             params,
@@ -110,10 +111,12 @@ impl Context {
             static_fqcn,
             strict_types,
             false,
+            is_static,
         )
     }
 
     /// Like `for_function` but also sets `inside_constructor`.
+    #[allow(clippy::too_many_arguments)]
     pub fn for_method(
         params: &[mir_codebase::FnParam],
         return_type: Option<Union>,
@@ -122,10 +125,11 @@ impl Context {
         static_fqcn: Option<Arc<str>>,
         strict_types: bool,
         inside_constructor: bool,
+        is_static: bool,
     ) -> Self {
         let mut ctx = Self::new();
         ctx.fn_return_type = return_type;
-        ctx.self_fqcn = self_fqcn;
+        ctx.self_fqcn = self_fqcn.clone();
         ctx.parent_fqcn = parent_fqcn;
         ctx.static_fqcn = static_fqcn;
         ctx.strict_types = strict_types;
@@ -160,6 +164,20 @@ impl Context {
             ctx.assigned_vars.insert(name.clone());
             ctx.param_names.insert(name);
         }
+
+        // Inject $this for non-static methods so that $this->method() can be
+        // resolved without hitting the mixed-receiver early-return guard.
+        if !is_static {
+            if let Some(fqcn) = self_fqcn {
+                let this_ty = mir_types::Union::single(mir_types::Atomic::TNamedObject {
+                    fqcn,
+                    type_params: vec![],
+                });
+                ctx.vars.insert("this".to_string(), this_ty);
+                ctx.assigned_vars.insert("this".to_string());
+            }
+        }
+
         ctx
     }
 

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -742,9 +742,9 @@ impl<'a> ExpressionAnalyzer<'a> {
                     .map(|h| crate::parser::type_from_hint(h, ctx.self_fqcn.as_deref()))
                     .map(|u| resolve_named_objects_in_union(u, self.codebase, &self.file));
 
-                // Build closure context — capture declared use-vars from outer scope
-                // Note: is_static only prevents $this binding; self_fqcn is still accessible
-                // for resolving `self::` references and private/protected visibility checks.
+                // Build closure context — capture declared use-vars from outer scope.
+                // Static closures (`static function() {}`) do not bind $this even when
+                // declared inside a non-static method.
                 let mut closure_ctx = crate::context::Context::for_function(
                     &params,
                     return_ty_hint.clone(),
@@ -752,6 +752,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                     ctx.parent_fqcn.clone(),
                     ctx.static_fqcn.clone(),
                     ctx.strict_types,
+                    c.is_static,
                 );
                 for use_var in c.use_vars.iter() {
                     let name = use_var.name.trim_start_matches('$');
@@ -820,9 +821,8 @@ impl<'a> ExpressionAnalyzer<'a> {
                     .map(|h| crate::parser::type_from_hint(h, ctx.self_fqcn.as_deref()))
                     .map(|u| resolve_named_objects_in_union(u, self.codebase, &self.file));
 
-                // Arrow functions implicitly capture the outer scope by value
-                // Note: is_static only prevents $this binding; self_fqcn is still accessible
-                // for resolving `self::` references and private/protected visibility checks.
+                // Arrow functions implicitly capture the outer scope by value.
+                // Static arrow functions (`static fn() =>`) do not bind $this.
                 let mut arrow_ctx = crate::context::Context::for_function(
                     &params,
                     return_ty_hint.clone(),
@@ -830,6 +830,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                     ctx.parent_fqcn.clone(),
                     ctx.static_fqcn.clone(),
                     ctx.strict_types,
+                    af.is_static,
                 );
                 // Copy outer vars into arrow context (implicit capture)
                 for (name, ty) in &ctx.vars {

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -683,7 +683,7 @@ impl ProjectAnalyzer {
             }
         };
 
-        let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
+        let mut ctx = Context::for_function(&params, return_ty, None, None, None, false, true);
         let mut buf = IssueBuffer::new();
         let mut sa = StatementsAnalyzer::new(
             &self.codebase,
@@ -773,6 +773,7 @@ impl ProjectAnalyzer {
                 Some(Arc::from(fqcn)),
                 false,
                 is_ctor,
+                method.is_static,
             );
 
             let mut buf = IssueBuffer::new();
@@ -963,7 +964,7 @@ impl ProjectAnalyzer {
             }
         };
 
-        let mut ctx = Context::for_function(&params, return_ty, None, None, None, false);
+        let mut ctx = Context::for_function(&params, return_ty, None, None, None, false, true);
         let mut buf = IssueBuffer::new();
         let mut sa = StatementsAnalyzer::new(
             &self.codebase,
@@ -1064,6 +1065,7 @@ impl ProjectAnalyzer {
                 Some(Arc::from(fqcn)),
                 false,
                 is_ctor,
+                method.is_static,
             );
 
             let mut buf = IssueBuffer::new();
@@ -1343,6 +1345,11 @@ fn emit_unused_variables(
             continue;
         }
         if SUPERGLOBALS.contains(&name.as_str()) {
+            continue;
+        }
+        // $this is implicitly used whenever the method accesses properties or
+        // calls other methods — never report it as unused.
+        if name == "this" {
             continue;
         }
         if name.starts_with('_') {

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_this_method_call.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_this_method_call.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class Svc {
+    public function helper(): void {}
+    public function run(): void {
+        $this->helper();
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_this_undefined_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_this_undefined_method.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class Svc {
+    public function run(): void {
+        $this->nonExistent();
+    }
+}
+===expect===
+UndefinedMethod: $this->nonExistent()

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_mixed.phpt
@@ -10,4 +10,3 @@ class Foo {
 }
 ===expect===
 UnusedParam: $a
-MixedMethodCall: $this->doSomething($ctx)

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -282,6 +282,39 @@ fn re_analyze_removes_stale_reference_locations() {
 }
 
 #[test]
+fn static_method_call_span_covers_only_name() {
+    let dir = TempDir::new().unwrap();
+    // "<?php\n"                                                   = 6 bytes
+    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n"
+    //                                                             = 75 bytes (offset 6)
+    // "function caller(): void { Math::sq(3); }\n"
+    //                                    ^-- 'sq' starts at offset 6+75+26 = 107
+    //  "function caller(): void { Math::" = 32 chars → offset 6+75+32 = 113? let's not hardcode
+    let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
+    let file = write(&dir, "static_span.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Math::sq")
+        .expect("Math::sq should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1);
+    let &(start, end) = spans.iter().next().unwrap();
+    // The span should cover only the 2-byte identifier "sq", not the full call
+    assert_eq!(
+        end - start,
+        2,
+        "span should cover only 'sq' (2 bytes), got start={start} end={end}"
+    );
+}
+
+#[test]
 fn cache_hit_replays_reference_locations() {
     let dir = TempDir::new().unwrap();
     let cache_dir = dir.path().join("cache");

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -353,3 +353,56 @@ fn cache_hit_replays_reference_locations() {
         );
     }
 }
+
+#[test]
+fn this_method_call_records_reference_location() {
+    // $this->method() calls were previously invisible to the reference index
+    // because $this was untyped and the mixed-receiver guard fired before
+    // record_symbol could be called (issue #191).
+    let dir = TempDir::new().unwrap();
+    let file = write(
+        &dir,
+        "this_ref.php",
+        "<?php\nclass Svc { public function helper(): void {}\npublic function run(): void { $this->helper(); } }\n",
+    );
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    assert!(
+        analyzer
+            .codebase()
+            .symbol_reference_locations
+            .contains_key("Svc::helper"),
+        "$this->helper() should record a reference to Svc::helper in symbol_reference_locations"
+    );
+}
+
+#[test]
+fn this_method_call_span_covers_only_name() {
+    // The recorded span for $this->helper() must cover only the method name
+    // identifier, matching the behaviour for non-$this receivers.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc { public function helper(): void {}\npublic function run(): void { $this->helper(); } }\n";
+    let file = write(&dir, "this_span.php", src);
+    let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    let locs = analyzer
+        .codebase()
+        .symbol_reference_locations
+        .get("Svc::helper")
+        .expect("Svc::helper should be in symbol_reference_locations");
+
+    let spans = &locs[&file_arc];
+    assert_eq!(spans.len(), 1, "one $this->helper() call → one span");
+
+    let &(start, end) = spans.iter().next().unwrap();
+    assert_eq!(
+        end - start,
+        6, // "helper" = 6 bytes
+        "span must cover only the identifier 'helper' (6 bytes), got start={start} end={end}"
+    );
+}

--- a/crates/mir-analyzer/tests/reference_locations.rs
+++ b/crates/mir-analyzer/tests/reference_locations.rs
@@ -284,12 +284,10 @@ fn re_analyze_removes_stale_reference_locations() {
 #[test]
 fn static_method_call_span_covers_only_name() {
     let dir = TempDir::new().unwrap();
-    // "<?php\n"                                                   = 6 bytes
-    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n"
-    //                                                             = 75 bytes (offset 6)
+    // "<?php\n"                                                                    = 6 bytes
+    // "class Math { public static function sq(int $n): int { return $n * $n; } }\n" = 74 bytes
     // "function caller(): void { Math::sq(3); }\n"
-    //                                    ^-- 'sq' starts at offset 6+75+26 = 107
-    //  "function caller(): void { Math::" = 32 chars → offset 6+75+32 = 113? let's not hardcode
+    //                                    ^-- 'sq' starts at byte 6+74+32 = 112
     let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
     let file = write(&dir, "static_span.php", src);
     let file_arc: Arc<str> = Arc::from(file.to_str().unwrap());

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -216,6 +216,36 @@ fn symbol_at_isolates_symbols_by_file() {
 }
 
 // ---------------------------------------------------------------------------
+// symbol_at — $this receiver (issue #191)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbol_at_finds_this_method_call() {
+    // $this->method() was previously invisible to symbol_at because $this was
+    // not typed in the method context, causing analyze_method_call to hit the
+    // mixed-receiver guard and return early without recording a symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc { public function helper(): void {}\npublic function run(): void { $this->helper(); } }\n";
+    let file = write(&dir, "this_call.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    // Point cursor at 'helper' in '$this->helper()'
+    let offset = src.find("->helper").unwrap() as u32 + 2; // +2 skips '->'
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should resolve $this->helper() (issue #191)");
+
+    assert!(
+        matches!(&sym.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "helper"),
+        "expected MethodCall(helper) for $this->helper(), got {:?}",
+        sym.kind
+    );
+}
+
+// ---------------------------------------------------------------------------
 // symbol_at — most-specific span is returned
 // ---------------------------------------------------------------------------
 

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -245,6 +245,92 @@ fn symbol_at_finds_this_method_call() {
     );
 }
 
+#[test]
+fn symbol_at_finds_this_property_access() {
+    // $this->prop was invisible for the same reason as $this->method() — $this
+    // was untyped so the mixed-receiver guard fired before record_symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Counter { public int $count = 0;\npublic function inc(): void { $this->count++; } }\n";
+    let file = write(&dir, "this_prop.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let offset = src.find("->count").unwrap() as u32 + 2; // +2 skips '->'
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should resolve $this->count");
+
+    assert!(
+        matches!(&sym.kind, SymbolKind::PropertyAccess { property, .. } if property.as_ref() == "count"),
+        "expected PropertyAccess(count) for $this->count, got {:?}",
+        sym.kind
+    );
+
+    let key = sym
+        .codebase_key()
+        .expect("PropertyAccess must have a codebase key");
+    assert_eq!(key, "Counter::count");
+}
+
+#[test]
+fn symbol_at_this_method_call_full_lsp_flow() {
+    // Verify the full LSP flow: cursor → codebase_key → get_reference_locations.
+    // Two calls to $this->helper() from the same method must both be indexed.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc {\n  public function helper(): void {}\n  public function run(): void { $this->helper(); $this->helper(); }\n}\n";
+    let file = write(&dir, "this_flow.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let offset = src.find("->helper").unwrap() as u32 + 2;
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should find first $this->helper()");
+
+    let key = sym
+        .codebase_key()
+        .expect("MethodCall must have a codebase key");
+    assert!(
+        key.ends_with("::helper"),
+        "codebase_key must end with '::helper', got: {key}"
+    );
+
+    let locs = analyzer.codebase().get_reference_locations(&key);
+    assert_eq!(
+        locs.len(),
+        2,
+        "two $this->helper() calls must produce two reference locations"
+    );
+}
+
+#[test]
+fn symbol_at_this_in_non_static_closure() {
+    // A non-static closure inside a non-static method inherits $this, so
+    // $this->method() calls inside the closure should also be resolved.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc {\n  public function helper(): void {}\n  public function run(): void { $fn = function() { $this->helper(); }; $fn(); }\n}\n";
+    let file = write(&dir, "closure_this.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let offset = src.find("->helper").unwrap() as u32 + 2;
+    let sym = result
+        .symbol_at(file_str, offset)
+        .expect("symbol_at should resolve $this->helper() inside a non-static closure");
+
+    assert!(
+        matches!(&sym.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "helper"),
+        "expected MethodCall(helper) inside closure, got {:?}",
+        sym.kind
+    );
+}
+
 // ---------------------------------------------------------------------------
 // symbol_at — most-specific span is returned
 // ---------------------------------------------------------------------------

--- a/crates/mir-analyzer/tests/symbol_at.rs
+++ b/crates/mir-analyzer/tests/symbol_at.rs
@@ -437,6 +437,128 @@ fn full_flow_cursor_to_reference_locations() {
 }
 
 #[test]
+fn symbol_at_function_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the identifier) must NOT find the function symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nfunction greet(): void {}\nfunction caller(): void { greet(); }\n";
+    let file = write(&dir, "span_fn.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet"))
+        .expect("FunctionCall(greet) must be recorded");
+
+    // span should cover only "greet" (5 bytes), not the full "greet()" call
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        5,
+        "FunctionCall symbol span must be identifier-only (5 bytes for 'greet')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the function symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::FunctionCall(n) if n.as_ref() == "greet")
+        })
+        .count();
+    assert_eq!(found, 0, "cursor at '(' must not match the function symbol");
+}
+
+#[test]
+fn symbol_at_method_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the method identifier) must NOT find the method symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Svc { public function run(): void {} }\nfunction caller(): void { $s = new Svc(); $s->run(); }\n";
+    let file = write(&dir, "span_method.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(|s| matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run"))
+        .expect("MethodCall(run) must be recorded");
+
+    // span should cover only "run" (3 bytes), not "run()" or "$s->run()"
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        3,
+        "MethodCall symbol span must be identifier-only (3 bytes for 'run')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the method symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::MethodCall { method, .. } if method.as_ref() == "run")
+        })
+        .count();
+    assert_eq!(found, 0, "cursor at '(' must not match the method symbol");
+}
+
+#[test]
+fn symbol_at_static_call_span_is_identifier_only() {
+    // Cursor on '(' (one past the static method identifier) must NOT find the symbol.
+    let dir = TempDir::new().unwrap();
+    let src = "<?php\nclass Math { public static function sq(int $n): int { return $n * $n; } }\nfunction caller(): void { Math::sq(3); }\n";
+    let file = write(&dir, "span_static.php", src);
+    let file_str = file.to_str().unwrap();
+
+    let analyzer = ProjectAnalyzer::new();
+    let result = analyzer.analyze(std::slice::from_ref(&file));
+
+    let sym_recorded = result
+        .symbols
+        .iter()
+        .find(
+            |s| matches!(&s.kind, SymbolKind::StaticCall { method, .. } if method.as_ref() == "sq"),
+        )
+        .expect("StaticCall(sq) must be recorded");
+
+    // span should cover only "sq" (2 bytes), not "Math::sq(3)"
+    assert_eq!(
+        sym_recorded.span.end - sym_recorded.span.start,
+        2,
+        "StaticCall symbol span must be identifier-only (2 bytes for 'sq')"
+    );
+
+    // Cursor at span.end (the '(' character) must not find the static call symbol
+    let past_name = sym_recorded.span.end;
+    let found = result
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.file.as_ref() == file_str
+                && s.span.start <= past_name
+                && past_name < s.span.end
+                && matches!(&s.kind, SymbolKind::StaticCall { method, .. } if method.as_ref() == "sq")
+        })
+        .count();
+    assert_eq!(
+        found, 0,
+        "cursor at '(' must not match the static call symbol"
+    );
+}
+
+#[test]
 fn symbol_at_finds_property_access() {
     let dir = TempDir::new().unwrap();
     let src = "<?php\nclass Counter { public int $count = 0; }\nfunction read(Counter $c): int { return $c->count; }\n";


### PR DESCRIPTION
## Summary

- `$this` was never typed in `Context::for_method`, causing `analyze_method_call` to hit the mixed-receiver early-return guard before `record_symbol` was reached — making every `$this->method()` call invisible to `symbol_at` (LSP hover/go-to-definition)
- Adds `is_static: bool` to `for_method`/`for_function`; injects `$this` as `TNamedObject` for non-static methods with a known `self_fqcn`
- Static closures and arrow functions correctly skip `$this` binding via `c.is_static` / `af.is_static`

Closes #191