### PR TITLE
chore(deps): upgrade php-rs-parser and php-ast to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "php-ast"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6d6cac9004e6c4eb89eec5dde2984a66c67c9569d254dff940c83fb81799bc"
+checksum = "a2531f4c82854d4ba443feed007fc749cc88e7e04e35bdf7f1784f803b8537e0"
 dependencies = [
  "bumpalo",
  "serde",
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c8a5d3c7011e478b96d540726000ec9fff680d5d00193aa59282f9ea2bd3a9"
+checksum = "8a759b83ad609f6c2cfb7d29de821668aefc75fc6ed2f479d5248eee1e3e5262"
 dependencies = [
  "memchr",
  "php-ast",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201d9a924e9d17bbf74b070d272685d26234b3ab830ba4d7e612b039c65d6f51"
+checksum = "e6846740c75552a4b091434bc21451c4be5de94b61a1755bbd1aa1c24626a9dc"
 dependencies = [
  "bumpalo",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ mir-codebase   = { path = "crates/mir-codebase",   version = "0.4.1" }
 mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.4.1" }
 
 # PHP parsing
-php-rs-parser = "0.6.2"
-php-ast       = "0.6.2"
+php-rs-parser = "0.7"
+php-ast       = "0.7"
 bumpalo       = { version = "3", features = ["collections"] }
 
 # Data structures

--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -161,7 +161,7 @@ impl CallAnalyzer {
                     arg_names: &call
                         .args
                         .iter()
-                        .map(|a| a.name.as_ref().map(|n| n.to_string()))
+                        .map(|a| a.name.as_ref().map(|n| n.to_string_repr().into_owned()))
                         .collect::<Vec<_>>(),
                     call_span: span,
                     has_spread: call.args.iter().any(|a| a.unpack),
@@ -238,8 +238,7 @@ impl CallAnalyzer {
         let obj_ty = ea.analyze(call.object, ctx);
 
         let method_name = match &call.method.kind {
-            ExprKind::Identifier(name) => (*name).to_string(),
-            ExprKind::Variable(name) => name.as_str().to_string(),
+            ExprKind::Identifier(name) | ExprKind::Variable(name) => name.as_str(),
             _ => return Union::mixed(),
         };
 
@@ -268,7 +267,7 @@ impl CallAnalyzer {
             } else if obj_ty.is_single() {
                 ea.emit(
                     IssueKind::NullMethodCall {
-                        method: method_name.clone(),
+                        method: method_name.to_string(),
                     },
                     Severity::Error,
                     span,
@@ -277,7 +276,7 @@ impl CallAnalyzer {
             } else {
                 ea.emit(
                     IssueKind::PossiblyNullMethodCall {
-                        method: method_name.clone(),
+                        method: method_name.to_string(),
                     },
                     Severity::Info,
                     span,
@@ -289,7 +288,7 @@ impl CallAnalyzer {
         if obj_ty.is_mixed() {
             ea.emit(
                 IssueKind::MixedMethodCall {
-                    method: method_name.clone(),
+                    method: method_name.to_string(),
                 },
                 Severity::Info,
                 span,
@@ -309,13 +308,13 @@ impl CallAnalyzer {
                     // Resolve short names to FQCN — docblock types may not be fully qualified.
                     let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
                     let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
-                    if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
+                    if let Some(method) = ea.codebase.get_method(fqcn, method_name) {
                         // Record reference for dead-code detection (M18).
                         // Use call.method.span (the identifier only), not the full call
                         // span, so the LSP highlights just the method name.
                         ea.codebase.mark_method_referenced_at(
                             fqcn,
-                            &method_name,
+                            method_name,
                             ea.file.clone(),
                             call.method.span.start,
                             call.method.span.end,
@@ -325,7 +324,7 @@ impl CallAnalyzer {
                             ea.emit(
                                 IssueKind::DeprecatedMethodCall {
                                     class: fqcn.to_string(),
-                                    method: method_name.clone(),
+                                    method: method_name.to_string(),
                                 },
                                 Severity::Info,
                                 span,
@@ -338,12 +337,12 @@ impl CallAnalyzer {
                         let arg_names: Vec<Option<String>> = call
                             .args
                             .iter()
-                            .map(|a| a.name.as_ref().map(|n| n.to_string()))
+                            .map(|a| a.name.as_ref().map(|n| n.to_string_repr().into_owned()))
                             .collect();
                         check_args(
                             ea,
                             CheckArgsParams {
-                                fn_name: &method_name,
+                                fn_name: method_name,
                                 params: &method.params,
                                 arg_types: &arg_types,
                                 arg_spans: &arg_spans,
@@ -424,7 +423,7 @@ impl CallAnalyzer {
                             ea.emit(
                                 IssueKind::UndefinedMethod {
                                     class: fqcn.to_string(),
-                                    method: method_name.clone(),
+                                    method: method_name.to_string(),
                                 },
                                 Severity::Error,
                                 span,
@@ -442,13 +441,13 @@ impl CallAnalyzer {
                     // Resolve short names to FQCN — docblock types may not be fully qualified.
                     let fqcn_resolved = ea.codebase.resolve_class_name(&ea.file, fqcn);
                     let fqcn = &std::sync::Arc::from(fqcn_resolved.as_str());
-                    if let Some(method) = ea.codebase.get_method(fqcn, &method_name) {
+                    if let Some(method) = ea.codebase.get_method(fqcn, method_name) {
                         // Record reference for dead-code detection (M18).
                         // Use call.method.span (the identifier only), not the full call
                         // span, so the LSP highlights just the method name.
                         ea.codebase.mark_method_referenced_at(
                             fqcn,
-                            &method_name,
+                            method_name,
                             ea.file.clone(),
                             call.method.span.start,
                             call.method.span.end,
@@ -458,7 +457,7 @@ impl CallAnalyzer {
                             ea.emit(
                                 IssueKind::DeprecatedMethodCall {
                                     class: fqcn.to_string(),
-                                    method: method_name.clone(),
+                                    method: method_name.to_string(),
                                 },
                                 Severity::Info,
                                 span,
@@ -471,12 +470,12 @@ impl CallAnalyzer {
                         let arg_names: Vec<Option<String>> = call
                             .args
                             .iter()
-                            .map(|a| a.name.as_ref().map(|n| n.to_string()))
+                            .map(|a| a.name.as_ref().map(|n| n.to_string_repr().into_owned()))
                             .collect();
                         check_args(
                             ea,
                             CheckArgsParams {
-                                fn_name: &method_name,
+                                fn_name: method_name,
                                 params: &method.params,
                                 arg_types: &arg_types,
                                 arg_spans: &arg_spans,
@@ -557,7 +556,7 @@ impl CallAnalyzer {
                             ea.emit(
                                 IssueKind::UndefinedMethod {
                                     class: fqcn.to_string(),
-                                    method: method_name.clone(),
+                                    method: method_name.to_string(),
                                 },
                                 Severity::Error,
                                 span,
@@ -601,7 +600,7 @@ impl CallAnalyzer {
                     call.method.span,
                     SymbolKind::MethodCall {
                         class: fqcn.clone(),
-                        method: Arc::from(method_name.as_str()),
+                        method: Arc::from(method_name),
                     },
                     final_ty.clone(),
                 );
@@ -621,7 +620,10 @@ impl CallAnalyzer {
         ctx: &mut Context,
         span: Span,
     ) -> Union {
-        let method_name = call.method.as_ref();
+        let method_name = match &call.method.kind {
+            ExprKind::Identifier(name) | ExprKind::Variable(name) => name.as_str(),
+            _ => return Union::mixed(),
+        };
 
         let fqcn = match &call.class.kind {
             ExprKind::Identifier(name) => ea.codebase.resolve_class_name(&ea.file, name.as_ref()),
@@ -670,7 +672,7 @@ impl CallAnalyzer {
             let arg_names: Vec<Option<String>> = call
                 .args
                 .iter()
-                .map(|a| a.name.as_ref().map(|n| n.to_string()))
+                .map(|a| a.name.as_ref().map(|n| n.to_string_repr().into_owned()))
                 .collect();
             check_args(
                 ea,

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -530,7 +530,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                 let arg_names: Vec<Option<String>> = n
                     .args
                     .iter()
-                    .map(|a| a.name.as_ref().map(|nm| nm.to_string()))
+                    .map(|a| a.name.as_ref().map(|nm| nm.to_string_repr().into_owned()))
                     .collect();
 
                 let class_ty = match &n.class.kind {
@@ -694,7 +694,7 @@ impl<'a> ExpressionAnalyzer<'a> {
 
             ExprKind::ClassConstAccess(cca) => {
                 // Foo::CONST or Foo::class
-                if cca.member.as_ref() == "class" {
+                if cca.member.name_str() == Some("class") {
                     // Resolve the class name so Foo::class gives the correct FQCN string
                     let fqcn = if let ExprKind::Identifier(id) = &cca.class.kind {
                         let resolved = self.codebase.resolve_class_name(&self.file, id.as_ref());


### PR DESCRIPTION
## Summary

Upgrades `php-rs-parser` 0.6.2 → 0.7 and `php-ast` 0.6.2 → 0.7 (with `php-lexer` 0.6.2 → 0.7 as a transitive dependency).

## API changes in php-ast 0.7

**`Name` lost `Display`/`ToString`**

The old implicit `.to_string()` is replaced by an explicit choice:
- `to_string_repr()` — source representation (preserves `\` prefix, joins qualified parts)
- `join_parts()` — parts joined without prefix
- `src_repr(src)` — zero-copy borrow of the exact source slice

Used for named-argument collection: `n.to_string_repr().into_owned()`.

**`StaticMethodCallExpr::method` changed from `Cow<str>` to `&Expr`**

Follows the shape of `MethodCallExpr` and carries a `.span`, resolving the span-tracking gap noted in jorgsowa/rust-php-parser#195.
Method name is now extracted via `ExprKind::Identifier/Variable` pattern match; unrecognised expression kinds return `Union::mixed()`.

**`ClassConstAccess::member` is now `&Expr`**

The `Foo::class` check is updated from `.as_ref() == "class"` to `.name_str() == Some("class")` using the new `Expr::name_str()` helper.

## Cleanup

- `method_name` in `analyze_method_call` and `analyze_static_method_call` is now `&str` borrowed directly from the arena (no allocation at the match site)
- `Variable` arm added to `analyze_static_method_call`, consistent with `analyze_method_call` — `Foo::$method()` yields `Union::mixed()`

## Follow-up

jorgsowa/rust-php-parser#203 proposes splitting `StaticMethodCall` into static/dynamic variants (mirroring `ClassConstAccess`/`ClassConstAccessDynamic`) so the type system encodes analysability rather than requiring a runtime guard.