### PR TITLE
feat(analyzer): Pass 1 definition cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +512,7 @@ dependencies = [
 name = "mir-analyzer"
 version = "0.5.0"
 dependencies = [
+ "bincode",
  "bumpalo",
  "indexmap",
  "mir-codebase",
@@ -940,10 +961,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ miette = { version = "7", features = ["fancy"] }
 
 # Hashing / caching
 sha2    = "0.11"
-bincode = "2"
+bincode = { version = "2", features = ["serde"] }
 
 [profile.release]
 lto           = "thin"

--- a/crates/mir-analyzer/Cargo.toml
+++ b/crates/mir-analyzer/Cargo.toml
@@ -21,6 +21,7 @@ thiserror     = { workspace = true }
 sha2          = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
+bincode       = { workspace = true }
 quick-xml     = "0.36"
 
 [dev-dependencies]

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -811,7 +811,8 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     } else {
                         item.name.into()
                     };
-                    self.codebase.constants.insert(fqn, Union::mixed());
+                    self.codebase
+                        .register_constant(&self.file, fqn, Union::mixed());
                 }
             }
 
@@ -830,7 +831,11 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                             if let Some(name_arg) = call.args.first() {
                                 if let php_ast::ast::ExprKind::String(name) = &name_arg.value.kind {
                                     let fqn: Arc<str> = Arc::from(&**name);
-                                    self.codebase.constants.insert(fqn, Union::mixed());
+                                    self.codebase.register_constant(
+                                        &self.file,
+                                        fqn,
+                                        Union::mixed(),
+                                    );
                                 }
                             }
                         }

--- a/crates/mir-analyzer/src/lib.rs
+++ b/crates/mir-analyzer/src/lib.rs
@@ -8,6 +8,7 @@ pub mod expr;
 pub mod generic;
 pub mod narrowing;
 pub mod parser;
+pub mod pass1_cache;
 pub mod project;
 pub mod stmt;
 pub mod stubs;

--- a/crates/mir-analyzer/src/pass1_cache.rs
+++ b/crates/mir-analyzer/src/pass1_cache.rs
@@ -11,10 +11,6 @@
 //!   derived `all_methods` / `all_parents` fields in `ClassStorage` are
 //!   intentionally empty.  `finalize()` recomputes them from the replayed
 //!   data exactly as it does for freshly-parsed files.
-//! * Global PHP constants (`StmtKind::Const` / `define()`) are not
-//!   included in snapshots because `DefinitionCollector` does not add them
-//!   to `symbol_to_file`; this matches the existing behaviour of
-//!   `Codebase::remove_file_definitions`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -52,6 +48,8 @@ pub struct Pass1Snapshot {
     pub functions: Vec<(Arc<str>, FunctionStorage)>,
     /// `@var`-annotated global variables defined in this file.
     pub global_vars: Vec<(Arc<str>, Union)>,
+    /// Global PHP constants (`const FOO = 1` / `define('FOO', 1)`) defined in this file.
+    pub constants: Vec<(Arc<str>, Union)>,
     /// Parse errors emitted for this file.
     pub parse_errors: Vec<Issue>,
     /// Issues from definition collection (typically empty).
@@ -99,6 +97,9 @@ impl Pass1Snapshot {
         }
         for (name, ty) in &self.global_vars {
             codebase.register_global_var(file, name.clone(), ty.clone());
+        }
+        for (name, ty) in &self.constants {
+            codebase.register_constant(file, name.clone(), ty.clone());
         }
     }
 }
@@ -161,6 +162,17 @@ pub fn build_snapshot(
         })
         .collect();
 
+    let const_names = codebase.file_constants_for_file(file);
+    let constants: Vec<(Arc<str>, Union)> = const_names
+        .iter()
+        .filter_map(|name| {
+            codebase
+                .constants
+                .get(name.as_ref())
+                .map(|ty| (name.clone(), ty.clone()))
+        })
+        .collect();
+
     Pass1Snapshot {
         content_hash,
         namespace,
@@ -171,20 +183,10 @@ pub fn build_snapshot(
         enums,
         functions,
         global_vars,
+        constants,
         parse_errors,
         definition_issues,
     }
-}
-
-// ---------------------------------------------------------------------------
-// Pass1Status
-// ---------------------------------------------------------------------------
-
-/// Whether a file was a Pass 1 cache hit or miss.
-pub enum Pass1Status {
-    Hit,
-    /// Cache miss — carries the SHA-256 content hash for snapshot building.
-    Miss(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +207,7 @@ pub struct Pass1Cache {
 impl Pass1Cache {
     /// Open (or create) a cache backed by `{cache_dir}/pass1.bin`.
     pub fn open(cache_dir: &Path) -> Self {
+        std::fs::create_dir_all(cache_dir).ok();
         let cache_path = cache_dir.join("pass1.bin");
         let entries = Self::load_from_disk(&cache_path);
         Self {
@@ -246,20 +249,41 @@ impl Pass1Cache {
             .write()
             .unwrap()
             .insert(file.to_string(), snapshot);
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty.store(true, Ordering::Release);
+    }
+
+    /// Remove cache entries for files that no longer exist on disk.
+    /// Called automatically by `flush()` to prevent unbounded cache growth.
+    fn gc_unreachable(&self) {
+        let to_remove: Vec<String> = {
+            let entries = self.entries.read().unwrap();
+            entries
+                .keys()
+                .filter(|path| !std::path::Path::new(path).exists())
+                .cloned()
+                .collect()
+        };
+        if !to_remove.is_empty() {
+            let mut entries = self.entries.write().unwrap();
+            for path in to_remove {
+                entries.remove(&path);
+            }
+            self.dirty.store(true, Ordering::Release);
+        }
     }
 
     /// Persist the in-memory cache to `{cache_dir}/pass1.bin`.
     /// No-op when nothing has changed since the last flush.
     pub fn flush(&self) {
-        if !self.dirty.load(Ordering::Relaxed) {
+        self.gc_unreachable();
+        if !self.dirty.load(Ordering::Acquire) {
             return;
         }
         let config = bincode::config::standard();
         let entries = self.entries.read().unwrap();
         if let Ok(bytes) = bincode::serde::encode_to_vec(&*entries, config) {
             std::fs::write(&self.cache_path, bytes).ok();
-            self.dirty.store(false, Ordering::Relaxed);
+            self.dirty.store(false, Ordering::Release);
         }
     }
 }

--- a/crates/mir-analyzer/src/pass1_cache.rs
+++ b/crates/mir-analyzer/src/pass1_cache.rs
@@ -110,14 +110,15 @@ impl Pass1Snapshot {
 
 /// Construct a `Pass1Snapshot` for `file` from the codebase after Pass 1.
 ///
-/// `fqcns` is every FQCN defined in this file — obtained from the reverse
-/// of `Codebase::symbol_to_file`.  Must be called after the parallel Pass 1
-/// completes but **before** `Codebase::finalize()`.
+/// `symbol_keys` is every FQN defined in this file (classes, interfaces, traits,
+/// enums, and functions) — obtained from the reverse of `Codebase::symbol_to_file`.
+/// Must be called after the parallel Pass 1 completes but **before**
+/// `Codebase::finalize()`.
 pub fn build_snapshot(
     codebase: &Codebase,
     file: &Arc<str>,
     content_hash: String,
-    fqcns: &[Arc<str>],
+    symbol_keys: &[Arc<str>],
     parse_errors: Vec<Issue>,
     definition_issues: Vec<Issue>,
 ) -> Pass1Snapshot {
@@ -137,22 +138,22 @@ pub fn build_snapshot(
     let mut enums = Vec::new();
     let mut functions = Vec::new();
 
-    for fqcn in fqcns {
-        if let Some(s) = codebase.classes.get(fqcn.as_ref()) {
-            classes.push((fqcn.clone(), s.clone()));
-        } else if let Some(s) = codebase.interfaces.get(fqcn.as_ref()) {
-            interfaces.push((fqcn.clone(), s.clone()));
-        } else if let Some(s) = codebase.traits.get(fqcn.as_ref()) {
-            traits.push((fqcn.clone(), s.clone()));
-        } else if let Some(s) = codebase.enums.get(fqcn.as_ref()) {
-            enums.push((fqcn.clone(), s.clone()));
-        } else if let Some(s) = codebase.functions.get(fqcn.as_ref()) {
-            functions.push((fqcn.clone(), s.clone()));
+    for key in symbol_keys {
+        if let Some(s) = codebase.classes.get(key.as_ref()) {
+            classes.push((key.clone(), s.clone()));
+        } else if let Some(s) = codebase.interfaces.get(key.as_ref()) {
+            interfaces.push((key.clone(), s.clone()));
+        } else if let Some(s) = codebase.traits.get(key.as_ref()) {
+            traits.push((key.clone(), s.clone()));
+        } else if let Some(s) = codebase.enums.get(key.as_ref()) {
+            enums.push((key.clone(), s.clone()));
+        } else if let Some(s) = codebase.functions.get(key.as_ref()) {
+            functions.push((key.clone(), s.clone()));
         }
     }
 
-    let gvar_names = codebase.file_global_vars_for_file(file);
-    let global_vars: Vec<(Arc<str>, Union)> = gvar_names
+    let global_var_names = codebase.file_global_vars_for_file(file);
+    let global_vars: Vec<(Arc<str>, Union)> = global_var_names
         .iter()
         .filter_map(|name| {
             codebase
@@ -254,7 +255,7 @@ impl Pass1Cache {
 
     /// Remove cache entries for files that no longer exist on disk.
     /// Called automatically by `flush()` to prevent unbounded cache growth.
-    fn gc_unreachable(&self) {
+    fn evict_deleted_files(&self) {
         let to_remove: Vec<String> = {
             let entries = self.entries.read().unwrap();
             entries
@@ -279,12 +280,13 @@ impl Pass1Cache {
         if !self.dirty.load(Ordering::Acquire) {
             return;
         }
-        self.gc_unreachable();
+        self.evict_deleted_files();
         let config = bincode::config::standard();
         let entries = self.entries.read().unwrap();
         if let Ok(bytes) = bincode::serde::encode_to_vec(&*entries, config) {
-            std::fs::write(&self.cache_path, bytes).ok();
-            self.dirty.store(false, Ordering::Release);
+            if std::fs::write(&self.cache_path, &bytes).is_ok() {
+                self.dirty.store(false, Ordering::Release);
+            }
         }
     }
 }

--- a/crates/mir-analyzer/src/pass1_cache.rs
+++ b/crates/mir-analyzer/src/pass1_cache.rs
@@ -274,11 +274,12 @@ impl Pass1Cache {
 
     /// Persist the in-memory cache to `{cache_dir}/pass1.bin`.
     /// No-op when nothing has changed since the last flush.
+    /// When a write is needed, also runs GC to evict entries for deleted files.
     pub fn flush(&self) {
-        self.gc_unreachable();
         if !self.dirty.load(Ordering::Acquire) {
             return;
         }
+        self.gc_unreachable();
         let config = bincode::config::standard();
         let entries = self.entries.read().unwrap();
         if let Ok(bytes) = bincode::serde::encode_to_vec(&*entries, config) {

--- a/crates/mir-analyzer/src/pass1_cache.rs
+++ b/crates/mir-analyzer/src/pass1_cache.rs
@@ -1,0 +1,265 @@
+//! Per-file Pass 1 definition cache.
+//!
+//! Snapshots all definitions produced by the combined pre-index +
+//! definition-collection pass and persists them to `{cache_dir}/pass1.bin`
+//! using bincode.  On subsequent runs, unchanged files skip parsing and
+//! definition collection entirely.
+//!
+//! # Correctness notes
+//!
+//! * Snapshots are built **before** `Codebase::finalize()` so that the
+//!   derived `all_methods` / `all_parents` fields in `ClassStorage` are
+//!   intentionally empty.  `finalize()` recomputes them from the replayed
+//!   data exactly as it does for freshly-parsed files.
+//! * Global PHP constants (`StmtKind::Const` / `define()`) are not
+//!   included in snapshots because `DefinitionCollector` does not add them
+//!   to `symbol_to_file`; this matches the existing behaviour of
+//!   `Codebase::remove_file_definitions`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+use mir_codebase::storage::{
+    ClassStorage, EnumStorage, FunctionStorage, InterfaceStorage, TraitStorage,
+};
+use mir_codebase::Codebase;
+use mir_issues::Issue;
+use mir_types::Union;
+
+// ---------------------------------------------------------------------------
+// Pass1Snapshot
+// ---------------------------------------------------------------------------
+
+/// All Pass 1 definitions produced for a single PHP file.
+///
+/// Serialized to/from disk; replayed into the codebase on a cache hit to skip
+/// parsing and definition collection for that file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pass1Snapshot {
+    pub content_hash: String,
+    /// Declared namespace, from the pre-index pass.
+    pub namespace: Option<String>,
+    /// `use`-alias imports, from the pre-index pass.
+    pub imports: HashMap<String, String>,
+    pub classes: Vec<(Arc<str>, ClassStorage)>,
+    pub interfaces: Vec<(Arc<str>, InterfaceStorage)>,
+    pub traits: Vec<(Arc<str>, TraitStorage)>,
+    pub enums: Vec<(Arc<str>, EnumStorage)>,
+    pub functions: Vec<(Arc<str>, FunctionStorage)>,
+    /// `@var`-annotated global variables defined in this file.
+    pub global_vars: Vec<(Arc<str>, Union)>,
+    /// Parse errors emitted for this file.
+    pub parse_errors: Vec<Issue>,
+    /// Issues from definition collection (typically empty).
+    pub definition_issues: Vec<Issue>,
+}
+
+impl Pass1Snapshot {
+    /// Write all stored definitions back into `codebase`.
+    ///
+    /// Call this before `Codebase::finalize()` so that derived fields
+    /// (`all_methods`, `all_parents`) are recomputed from the replayed data.
+    pub fn replay(&self, codebase: &Codebase, file: &Arc<str>) {
+        if let Some(ref ns) = self.namespace {
+            codebase.file_namespaces.insert(file.clone(), ns.clone());
+        }
+        if !self.imports.is_empty() {
+            codebase
+                .file_imports
+                .insert(file.clone(), self.imports.clone());
+        }
+        for (fqcn, s) in &self.classes {
+            codebase.known_symbols.insert(fqcn.clone());
+            codebase.symbol_to_file.insert(fqcn.clone(), file.clone());
+            codebase.classes.insert(fqcn.clone(), s.clone());
+        }
+        for (fqcn, s) in &self.interfaces {
+            codebase.known_symbols.insert(fqcn.clone());
+            codebase.symbol_to_file.insert(fqcn.clone(), file.clone());
+            codebase.interfaces.insert(fqcn.clone(), s.clone());
+        }
+        for (fqcn, s) in &self.traits {
+            codebase.known_symbols.insert(fqcn.clone());
+            codebase.symbol_to_file.insert(fqcn.clone(), file.clone());
+            codebase.traits.insert(fqcn.clone(), s.clone());
+        }
+        for (fqcn, s) in &self.enums {
+            codebase.known_symbols.insert(fqcn.clone());
+            codebase.symbol_to_file.insert(fqcn.clone(), file.clone());
+            codebase.enums.insert(fqcn.clone(), s.clone());
+        }
+        for (fqn, s) in &self.functions {
+            codebase.known_symbols.insert(fqn.clone());
+            codebase.symbol_to_file.insert(fqn.clone(), file.clone());
+            codebase.functions.insert(fqn.clone(), s.clone());
+        }
+        for (name, ty) in &self.global_vars {
+            codebase.register_global_var(file, name.clone(), ty.clone());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// build_snapshot
+// ---------------------------------------------------------------------------
+
+/// Construct a `Pass1Snapshot` for `file` from the codebase after Pass 1.
+///
+/// `fqcns` is every FQCN defined in this file — obtained from the reverse
+/// of `Codebase::symbol_to_file`.  Must be called after the parallel Pass 1
+/// completes but **before** `Codebase::finalize()`.
+pub fn build_snapshot(
+    codebase: &Codebase,
+    file: &Arc<str>,
+    content_hash: String,
+    fqcns: &[Arc<str>],
+    parse_errors: Vec<Issue>,
+    definition_issues: Vec<Issue>,
+) -> Pass1Snapshot {
+    let namespace = codebase
+        .file_namespaces
+        .get(file.as_ref())
+        .map(|n| n.clone());
+    let imports = codebase
+        .file_imports
+        .get(file.as_ref())
+        .map(|i| i.clone())
+        .unwrap_or_default();
+
+    let mut classes = Vec::new();
+    let mut interfaces = Vec::new();
+    let mut traits = Vec::new();
+    let mut enums = Vec::new();
+    let mut functions = Vec::new();
+
+    for fqcn in fqcns {
+        if let Some(s) = codebase.classes.get(fqcn.as_ref()) {
+            classes.push((fqcn.clone(), s.clone()));
+        } else if let Some(s) = codebase.interfaces.get(fqcn.as_ref()) {
+            interfaces.push((fqcn.clone(), s.clone()));
+        } else if let Some(s) = codebase.traits.get(fqcn.as_ref()) {
+            traits.push((fqcn.clone(), s.clone()));
+        } else if let Some(s) = codebase.enums.get(fqcn.as_ref()) {
+            enums.push((fqcn.clone(), s.clone()));
+        } else if let Some(s) = codebase.functions.get(fqcn.as_ref()) {
+            functions.push((fqcn.clone(), s.clone()));
+        }
+    }
+
+    let gvar_names = codebase.file_global_vars_for_file(file);
+    let global_vars: Vec<(Arc<str>, Union)> = gvar_names
+        .iter()
+        .filter_map(|name| {
+            codebase
+                .global_vars
+                .get(name.as_ref())
+                .map(|ty| (name.clone(), ty.clone()))
+        })
+        .collect();
+
+    Pass1Snapshot {
+        content_hash,
+        namespace,
+        imports,
+        classes,
+        interfaces,
+        traits,
+        enums,
+        functions,
+        global_vars,
+        parse_errors,
+        definition_issues,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass1Status
+// ---------------------------------------------------------------------------
+
+/// Whether a file was a Pass 1 cache hit or miss.
+pub enum Pass1Status {
+    Hit,
+    /// Cache miss — carries the SHA-256 content hash for snapshot building.
+    Miss(String),
+}
+
+// ---------------------------------------------------------------------------
+// Pass1Cache
+// ---------------------------------------------------------------------------
+
+/// Disk-backed store for per-file Pass 1 snapshots.
+///
+/// Uses `RwLock<HashMap>` so that many rayon threads can perform cache lookups
+/// concurrently, while the single-threaded post-processing step writes new
+/// snapshots exclusively after the parallel pass completes.
+pub struct Pass1Cache {
+    cache_path: PathBuf,
+    entries: RwLock<HashMap<String, Pass1Snapshot>>,
+    dirty: AtomicBool,
+}
+
+impl Pass1Cache {
+    /// Open (or create) a cache backed by `{cache_dir}/pass1.bin`.
+    pub fn open(cache_dir: &Path) -> Self {
+        let cache_path = cache_dir.join("pass1.bin");
+        let entries = Self::load_from_disk(&cache_path);
+        Self {
+            cache_path,
+            entries: RwLock::new(entries),
+            dirty: AtomicBool::new(false),
+        }
+    }
+
+    fn load_from_disk(path: &Path) -> HashMap<String, Pass1Snapshot> {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(_) => return HashMap::new(),
+        };
+        let config = bincode::config::standard();
+        match bincode::serde::decode_from_slice::<HashMap<String, Pass1Snapshot>, _>(&bytes, config)
+        {
+            Ok((map, _)) => map,
+            // Corrupt or format-changed cache — start fresh.
+            Err(_) => HashMap::new(),
+        }
+    }
+
+    /// Return a snapshot if `file` is cached with a matching `content_hash`.
+    pub fn get(&self, file: &str, content_hash: &str) -> Option<Pass1Snapshot> {
+        let entries = self.entries.read().unwrap();
+        entries.get(file).and_then(|s| {
+            if s.content_hash == content_hash {
+                Some(s.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Store a snapshot, replacing any previous entry for `file`.
+    pub fn put(&self, file: &str, snapshot: Pass1Snapshot) {
+        self.entries
+            .write()
+            .unwrap()
+            .insert(file.to_string(), snapshot);
+        self.dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Persist the in-memory cache to `{cache_dir}/pass1.bin`.
+    /// No-op when nothing has changed since the last flush.
+    pub fn flush(&self) {
+        if !self.dirty.load(Ordering::Relaxed) {
+            return;
+        }
+        let config = bincode::config::standard();
+        let entries = self.entries.read().unwrap();
+        if let Ok(bytes) = bincode::serde::encode_to_vec(&*entries, config) {
+            std::fs::write(&self.cache_path, bytes).ok();
+            self.dirty.store(false, Ordering::Relaxed);
+        }
+    }
+}

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -301,29 +301,32 @@ impl ProjectAnalyzer {
         // Persist new Pass 1 snapshots for cache misses (before finalize() so that
         // the derived all_methods/all_parents fields are still empty in the snapshot).
         if let Some(p1_cache) = &self.pass1_cache {
-            // Build reverse index: defining-file → [fqcns defined there].
-            let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
-            for entry in self.codebase.symbol_to_file.iter() {
-                file_to_fqcns
-                    .entry(entry.value().clone())
-                    .or_default()
-                    .push(entry.key().clone());
-            }
-            for ((file, _src), (per_file_parse_errors, def_issues, maybe_hash)) in
-                file_data.iter().zip(pass1_results.iter())
-            {
-                if let Some(hash) = maybe_hash {
-                    let empty: Vec<Arc<str>> = Vec::new();
-                    let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
-                    let snapshot = crate::pass1_cache::build_snapshot(
-                        &self.codebase,
-                        file,
-                        hash.clone(),
-                        fqcns,
-                        per_file_parse_errors.clone(),
-                        def_issues.clone(),
-                    );
-                    p1_cache.put(file.as_ref(), snapshot);
+            // Only build the reverse index when there is at least one miss.
+            let has_misses = pass1_results.iter().any(|(_, _, h)| h.is_some());
+            if has_misses {
+                let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+                for entry in self.codebase.symbol_to_file.iter() {
+                    file_to_fqcns
+                        .entry(entry.value().clone())
+                        .or_default()
+                        .push(entry.key().clone());
+                }
+                for ((file, _src), (per_file_parse_errors, def_issues, maybe_hash)) in
+                    file_data.iter().zip(pass1_results.iter())
+                {
+                    if let Some(hash) = maybe_hash {
+                        let empty: Vec<Arc<str>> = Vec::new();
+                        let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                        let snapshot = crate::pass1_cache::build_snapshot(
+                            &self.codebase,
+                            file,
+                            hash.clone(),
+                            fqcns,
+                            per_file_parse_errors.clone(),
+                            def_issues.clone(),
+                        );
+                        p1_cache.put(file.as_ref(), snapshot);
+                    }
                 }
             }
             p1_cache.flush();
@@ -558,12 +561,31 @@ impl ProjectAnalyzer {
         );
         all_issues.extend(body_issues);
 
-        // 5. Update cache if present
+        // 5. Update caches if present
+        let content_hash = hash_content(new_content);
+        if let Some(p1_cache) = &self.pass1_cache {
+            let fqcns: Vec<Arc<str>> = self
+                .codebase
+                .symbol_to_file
+                .iter()
+                .filter(|e| e.value().as_ref() == file_path)
+                .map(|e| e.key().clone())
+                .collect();
+            let snapshot = crate::pass1_cache::build_snapshot(
+                &self.codebase,
+                &file,
+                content_hash.clone(),
+                &fqcns,
+                vec![],
+                vec![],
+            );
+            p1_cache.put(file_path, snapshot);
+            p1_cache.flush();
+        }
         if let Some(cache) = &self.cache {
-            let h = hash_content(new_content);
             cache.evict_with_dependents(&[file_path.to_string()]);
             let ref_locs = extract_reference_locations(&self.codebase, &file);
-            cache.put(file_path, h, all_issues.clone(), ref_locs);
+            cache.put(file_path, content_hash, all_issues.clone(), ref_locs);
         }
 
         AnalysisResult {
@@ -1224,26 +1246,29 @@ impl ProjectAnalyzer {
             .collect();
 
         if let Some(p1_cache) = &self.pass1_cache {
-            let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
-            for entry in self.codebase.symbol_to_file.iter() {
-                file_to_fqcns
-                    .entry(entry.value().clone())
-                    .or_default()
-                    .push(entry.key().clone());
-            }
-            for ((file, _src), maybe_hash) in file_data.iter().zip(miss_hashes.iter()) {
-                if let Some(hash) = maybe_hash {
-                    let empty: Vec<Arc<str>> = Vec::new();
-                    let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
-                    let snapshot = crate::pass1_cache::build_snapshot(
-                        &self.codebase,
-                        file,
-                        hash.clone(),
-                        fqcns,
-                        vec![],
-                        vec![],
-                    );
-                    p1_cache.put(file.as_ref(), snapshot);
+            let has_misses = miss_hashes.iter().any(|h| h.is_some());
+            if has_misses {
+                let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+                for entry in self.codebase.symbol_to_file.iter() {
+                    file_to_fqcns
+                        .entry(entry.value().clone())
+                        .or_default()
+                        .push(entry.key().clone());
+                }
+                for ((file, _src), maybe_hash) in file_data.iter().zip(miss_hashes.iter()) {
+                    if let Some(hash) = maybe_hash {
+                        let empty: Vec<Arc<str>> = Vec::new();
+                        let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                        let snapshot = crate::pass1_cache::build_snapshot(
+                            &self.codebase,
+                            file,
+                            hash.clone(),
+                            fqcns,
+                            vec![],
+                            vec![],
+                        );
+                        p1_cache.put(file.as_ref(), snapshot);
+                    }
                 }
             }
             p1_cache.flush();

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -14,6 +14,17 @@ use mir_types::Union;
 use crate::collector::DefinitionCollector;
 
 // ---------------------------------------------------------------------------
+// Per-file Pass 1 closure outcome
+// ---------------------------------------------------------------------------
+
+/// Per-file result produced by the Pass 1 parallel closure.
+///
+/// Fields: `(parse_errors, definition_issues, is_cache_miss)`.
+/// `is_cache_miss` is `true` when the file was freshly parsed and a snapshot
+/// must be stored; `false` on a cache hit or when no pass1 cache is active.
+type FilePass1Outcome = (Vec<Issue>, Vec<Issue>, bool);
+
+// ---------------------------------------------------------------------------
 // ProjectAnalyzer
 // ---------------------------------------------------------------------------
 
@@ -49,15 +60,9 @@ impl ProjectAnalyzer {
 
     /// Create a `ProjectAnalyzer` with a disk-backed cache stored under `cache_dir`.
     pub fn with_cache(cache_dir: &Path) -> Self {
-        Self {
-            codebase: Arc::new(Codebase::new()),
-            cache: Some(AnalysisCache::open(cache_dir)),
-            on_file_done: None,
-            psr4: None,
-            stubs_loaded: std::sync::atomic::AtomicBool::new(false),
-            find_dead_code: false,
-            pass1_cache: Some(crate::pass1_cache::Pass1Cache::open(cache_dir)),
-        }
+        let mut analyzer = Self::new();
+        analyzer.enable_cache(cache_dir);
+        analyzer
     }
 
     /// Create a `ProjectAnalyzer` from a project root containing `composer.json`.
@@ -102,37 +107,66 @@ impl ProjectAnalyzer {
         }
     }
 
+    /// Pre-index a single file's AST: populate `known_symbols`, `file_namespaces`,
+    /// and `file_imports` in the codebase.
+    ///
+    /// Must be called before `DefinitionCollector` so that FQCN lookups during
+    /// definition collection resolve names against the correct namespace and imports.
+    /// This is the same step that runs inside the parallel Pass 1 closure in
+    /// `analyze()`; extracting it here allows `re_analyze_file()` to keep the
+    /// codebase consistent after incremental edits.
+    fn pre_index_file(&self, file: &Arc<str>, program: &php_ast::ast::Program<'_, '_>) {
+        use php_ast::ast::StmtKind;
+
+        let mut current_namespace: Option<String> = None;
+        let mut imports: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let mut file_ns_set = false;
+
+        for stmt in program.stmts.iter() {
+            match &stmt.kind {
+                StmtKind::Namespace(ns) => {
+                    current_namespace = ns.name.as_ref().map(|n| crate::parser::name_to_string(n));
+                    if !file_ns_set {
+                        if let Some(ref ns_str) = current_namespace {
+                            self.codebase
+                                .file_namespaces
+                                .insert(file.clone(), ns_str.clone());
+                            file_ns_set = true;
+                        }
+                    }
+                    if let php_ast::ast::NamespaceBody::Braced(inner_stmts) = &ns.body {
+                        index_stmts(
+                            &self.codebase,
+                            inner_stmts,
+                            current_namespace.as_deref(),
+                            &mut imports,
+                        );
+                    }
+                }
+                _ => index_stmts(
+                    &self.codebase,
+                    std::slice::from_ref(stmt),
+                    current_namespace.as_deref(),
+                    &mut imports,
+                ),
+            }
+        }
+
+        if !imports.is_empty() {
+            self.codebase.file_imports.insert(file.clone(), imports);
+        }
+    }
+
     /// Run the full analysis pipeline on a set of file paths.
     pub fn analyze(&self, paths: &[PathBuf]) -> AnalysisResult {
         let mut all_issues = Vec::new();
-        let mut parse_errors = Vec::new();
 
         // ---- Load PHP built-in stubs (before Pass 1 so user code can override)
         self.load_stubs();
 
-        // ---- Pre-Pass-2 invalidation: evict dependents of changed files ------
-        // Uses the reverse dep graph persisted from the previous run.
-        if let Some(cache) = &self.cache {
-            let changed: Vec<String> = paths
-                .iter()
-                .filter_map(|p| {
-                    let path_str = p.to_string_lossy().into_owned();
-                    let content = std::fs::read_to_string(p).ok()?;
-                    let h = hash_content(&content);
-                    if cache.get(&path_str, &h).is_none() {
-                        Some(path_str)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            if !changed.is_empty() {
-                cache.evict_with_dependents(&changed);
-            }
-        }
-
-        // ---- Pass 1: read files in parallel ----------------------------------
-        let file_data: Vec<(Arc<str>, String)> = paths
+        // ---- Read all files in parallel (single read shared by all passes) ----
+        let file_sources: Vec<(Arc<str>, String)> = paths
             .par_iter()
             .filter_map(|path| match std::fs::read_to_string(path) {
                 Ok(src) => Some((Arc::from(path.to_string_lossy().as_ref()), src)),
@@ -143,132 +177,64 @@ impl ProjectAnalyzer {
             })
             .collect();
 
+        // ---- Pre-compute content hashes once (shared by pass1, invalidation, pass2) ----
+        // Only computed when at least one cache is active; None otherwise.
+        let hash_needed = self.pass1_cache.is_some() || self.cache.is_some();
+        let content_hashes: Vec<Option<String>> = if hash_needed {
+            file_sources
+                .par_iter()
+                .map(|(_, src)| Some(hash_content(src)))
+                .collect()
+        } else {
+            vec![None; file_sources.len()]
+        };
+
+        // ---- Pre-Pass-2 invalidation: evict dependents of changed files ------
+        // Uses already-read content — no second filesystem read.
+        if let Some(cache) = &self.cache {
+            let changed: Vec<String> = file_sources
+                .iter()
+                .enumerate()
+                .filter_map(|(i, (path, _))| {
+                    let h = content_hashes[i].as_deref()?;
+                    if cache.get(path, h).is_none() {
+                        Some(path.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !changed.is_empty() {
+                cache.evict_with_dependents(&changed);
+            }
+        }
+
         // ---- Pass 1: combined pre-index + definition collection (parallel) -----
-        // Parse each file once; both the FQCN/namespace/import index and the full
-        // definition collection run in the same rayon closure, eliminating the
-        // second sequential parse of every file. DashMap handles concurrent writes.
+        // Parse each file once; the pre-index and definition collection both run
+        // in the same rayon closure. DashMap handles concurrent writes.
         //
         // When the Pass 1 cache is active, unchanged files skip parsing entirely:
-        // the snapshot is replayed and `None` is returned for the content hash.
-        // A cache miss returns `Some(hash)` so a snapshot can be built after the
-        // parallel pass completes.
-        let pass1_results: Vec<(Vec<Issue>, Vec<Issue>, Option<String>)> = file_data
+        // the snapshot is replayed and `is_miss = false` is returned.
+        // A cache miss returns `is_miss = true` so a snapshot is built afterward.
+        let pass1_results: Vec<FilePass1Outcome> = file_sources
             .par_iter()
-            .map(|(file, src)| {
-                // Compute hash only when the pass1 cache is active.
-                let content_hash = self.pass1_cache.as_ref().map(|_| hash_content(src));
+            .enumerate()
+            .map(|(i, (file, src))| {
+                let content_hash = content_hashes[i].as_deref();
 
                 // Cache hit: replay stored definitions and skip parsing.
-                if let (Some(p1_cache), Some(ref hash)) = (&self.pass1_cache, &content_hash) {
-                    if let Some(snapshot) = p1_cache.get(file, hash) {
+                if let (Some(pass1_cache), Some(hash)) = (&self.pass1_cache, content_hash) {
+                    if let Some(snapshot) = pass1_cache.get(file, hash) {
                         snapshot.replay(&self.codebase, file);
-                        return (snapshot.parse_errors, snapshot.definition_issues, None);
+                        return (snapshot.parse_errors, snapshot.definition_issues, false);
                     }
                 }
 
-                use php_ast::ast::StmtKind;
                 let arena = bumpalo::Bump::new();
                 let result = php_rs_parser::parse(&arena, src);
 
-                // --- Pre-index: build FQCN index, file imports, and namespaces ---
-                let mut current_namespace: Option<String> = None;
-                let mut imports: std::collections::HashMap<String, String> =
-                    std::collections::HashMap::new();
-                let mut file_ns_set = false;
-
-                // Index a flat list of stmts under a given namespace prefix.
-                let index_stmts =
-                    |stmts: &[php_ast::ast::Stmt<'_, '_>],
-                     ns: Option<&str>,
-                     imports: &mut std::collections::HashMap<String, String>| {
-                        for stmt in stmts.iter() {
-                            match &stmt.kind {
-                                StmtKind::Use(use_decl) => {
-                                    for item in use_decl.uses.iter() {
-                                        let full_name = crate::parser::name_to_string(&item.name);
-                                        let alias = item.alias.unwrap_or_else(|| {
-                                            full_name.rsplit('\\').next().unwrap_or(&full_name)
-                                        });
-                                        imports.insert(alias.to_string(), full_name);
-                                    }
-                                }
-                                StmtKind::Class(decl) => {
-                                    if let Some(n) = decl.name {
-                                        let fqcn = match ns {
-                                            Some(ns) => format!("{}\\{}", ns, n),
-                                            None => n.to_string(),
-                                        };
-                                        self.codebase
-                                            .known_symbols
-                                            .insert(Arc::from(fqcn.as_str()));
-                                    }
-                                }
-                                StmtKind::Interface(decl) => {
-                                    let fqcn = match ns {
-                                        Some(ns) => format!("{}\\{}", ns, decl.name),
-                                        None => decl.name.to_string(),
-                                    };
-                                    self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                                }
-                                StmtKind::Trait(decl) => {
-                                    let fqcn = match ns {
-                                        Some(ns) => format!("{}\\{}", ns, decl.name),
-                                        None => decl.name.to_string(),
-                                    };
-                                    self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                                }
-                                StmtKind::Enum(decl) => {
-                                    let fqcn = match ns {
-                                        Some(ns) => format!("{}\\{}", ns, decl.name),
-                                        None => decl.name.to_string(),
-                                    };
-                                    self.codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
-                                }
-                                StmtKind::Function(decl) => {
-                                    let fqn = match ns {
-                                        Some(ns) => format!("{}\\{}", ns, decl.name),
-                                        None => decl.name.to_string(),
-                                    };
-                                    self.codebase.known_symbols.insert(Arc::from(fqn.as_str()));
-                                }
-                                _ => {}
-                            }
-                        }
-                    };
-
-                for stmt in result.program.stmts.iter() {
-                    match &stmt.kind {
-                        StmtKind::Namespace(ns) => {
-                            current_namespace =
-                                ns.name.as_ref().map(|n| crate::parser::name_to_string(n));
-                            if !file_ns_set {
-                                if let Some(ref ns_str) = current_namespace {
-                                    self.codebase
-                                        .file_namespaces
-                                        .insert(file.clone(), ns_str.clone());
-                                    file_ns_set = true;
-                                }
-                            }
-                            // Bracketed namespace: walk inner stmts for Use/Class/etc.
-                            if let php_ast::ast::NamespaceBody::Braced(inner_stmts) = &ns.body {
-                                index_stmts(
-                                    inner_stmts,
-                                    current_namespace.as_deref(),
-                                    &mut imports,
-                                );
-                            }
-                        }
-                        _ => index_stmts(
-                            std::slice::from_ref(stmt),
-                            current_namespace.as_deref(),
-                            &mut imports,
-                        ),
-                    }
-                }
-
-                if !imports.is_empty() {
-                    self.codebase.file_imports.insert(file.clone(), imports);
-                }
+                // --- Pre-index: populate known_symbols, file_namespaces, file_imports ---
+                self.pre_index_file(file, &result.program);
 
                 // --- Parse errors ---
                 let file_parse_errors: Vec<Issue> = result
@@ -292,52 +258,47 @@ impl ProjectAnalyzer {
                 // --- Definition collection ---
                 let collector =
                     DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
-                let issues = collector.collect(&result.program);
+                let definition_issues = collector.collect(&result.program);
 
-                (file_parse_errors, issues, content_hash)
+                (file_parse_errors, definition_issues, content_hash.is_some())
             })
             .collect();
 
         // Persist new Pass 1 snapshots for cache misses (before finalize() so that
         // the derived all_methods/all_parents fields are still empty in the snapshot).
-        if let Some(p1_cache) = &self.pass1_cache {
+        if let Some(pass1_cache) = &self.pass1_cache {
             // Only build the reverse index when there is at least one miss.
-            let has_misses = pass1_results.iter().any(|(_, _, h)| h.is_some());
+            let has_misses = pass1_results.iter().any(|(_, _, is_miss)| *is_miss);
             if has_misses {
-                let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
-                for entry in self.codebase.symbol_to_file.iter() {
-                    file_to_fqcns
-                        .entry(entry.value().clone())
-                        .or_default()
-                        .push(entry.key().clone());
-                }
-                for ((file, _src), (per_file_parse_errors, def_issues, maybe_hash)) in
-                    file_data.iter().zip(pass1_results.iter())
-                {
-                    if let Some(hash) = maybe_hash {
-                        let empty: Vec<Arc<str>> = Vec::new();
-                        let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                let symbols_by_file = build_symbols_by_file(&self.codebase);
+                for i in 0..file_sources.len() {
+                    let (file, _) = &file_sources[i];
+                    let (per_file_parse_errors, definition_issues, is_miss) = &pass1_results[i];
+                    if *is_miss {
+                        let hash = content_hashes[i].clone().unwrap_or_default();
+                        let symbol_keys = symbols_by_file
+                            .get(file)
+                            .map(|v| v.as_slice())
+                            .unwrap_or(&[]);
                         let snapshot = crate::pass1_cache::build_snapshot(
                             &self.codebase,
                             file,
-                            hash.clone(),
-                            fqcns,
+                            hash,
+                            symbol_keys,
                             per_file_parse_errors.clone(),
-                            def_issues.clone(),
+                            definition_issues.clone(),
                         );
-                        p1_cache.put(file.as_ref(), snapshot);
+                        pass1_cache.put(file.as_ref(), snapshot);
                     }
                 }
             }
-            p1_cache.flush();
+            pass1_cache.flush();
         }
 
-        for (file_parse_errors, issues, _) in pass1_results {
-            parse_errors.extend(file_parse_errors);
-            all_issues.extend(issues);
+        for (file_parse_errors, definition_issues, _) in pass1_results {
+            all_issues.extend(file_parse_errors);
+            all_issues.extend(definition_issues);
         }
-
-        all_issues.extend(parse_errors);
 
         // ---- Finalize codebase (resolve inheritance, build dispatch tables) --
         self.codebase.finalize();
@@ -355,10 +316,13 @@ impl ProjectAnalyzer {
 
         // ---- Class-level checks (M11) ----------------------------------------
         let analyzed_file_set: std::collections::HashSet<std::sync::Arc<str>> =
-            file_data.iter().map(|(f, _)| f.clone()).collect();
-        let class_issues =
-            crate::class::ClassAnalyzer::with_files(&self.codebase, analyzed_file_set, &file_data)
-                .analyze_all();
+            file_sources.iter().map(|(f, _)| f.clone()).collect();
+        let class_issues = crate::class::ClassAnalyzer::with_files(
+            &self.codebase,
+            analyzed_file_set,
+            &file_sources,
+        )
+        .analyze_all();
         all_issues.extend(class_issues);
 
         // ---- Pass 2: analyze function/method bodies in parallel (M14) --------
@@ -366,12 +330,15 @@ impl ProjectAnalyzer {
         // rayon closure so there is no cross-thread borrow.
         // When a cache is present, files whose content hash matches a stored
         // entry skip re-analysis entirely (M17).
-        let pass2_results: Vec<(Vec<Issue>, Vec<crate::symbol::ResolvedSymbol>)> = file_data
+        let pass2_results: Vec<(Vec<Issue>, Vec<crate::symbol::ResolvedSymbol>)> = file_sources
             .par_iter()
-            .map(|(file, src)| {
-                // Cache lookup
+            .enumerate()
+            .map(|(i, (file, src))| {
+                // Cache lookup — use the precomputed hash to avoid a third hash per file.
                 let result = if let Some(cache) = &self.cache {
-                    let h = hash_content(src);
+                    let h: String = content_hashes[i]
+                        .clone()
+                        .expect("hash always computed when cache is active");
                     if let Some((cached_issues, ref_locs)) = cache.get(file, &h) {
                         // Hit — replay reference locations so symbol_reference_locations
                         // is populated without re-running analyze_bodies.
@@ -445,11 +412,11 @@ impl ProjectAnalyzer {
         use std::collections::HashSet;
 
         let max_depth = 10; // prevent infinite chains
-        let mut loaded: HashSet<String> = HashSet::new();
+        let mut loaded_fqcns: HashSet<String> = HashSet::new();
 
         for _ in 0..max_depth {
-            // Collect all referenced FQCNs that aren't in the codebase
-            let mut to_load: Vec<(String, PathBuf)> = Vec::new();
+            // Collect class/interface FQCNs referenced but not yet in the codebase.
+            let mut pending_files: Vec<(String, PathBuf)> = Vec::new();
 
             for entry in self.codebase.classes.iter() {
                 let cls = entry.value();
@@ -457,9 +424,9 @@ impl ProjectAnalyzer {
                 // Check parent class
                 if let Some(parent) = &cls.parent {
                     let fqcn = parent.as_ref();
-                    if !self.codebase.classes.contains_key(fqcn) && !loaded.contains(fqcn) {
+                    if !self.codebase.classes.contains_key(fqcn) && !loaded_fqcns.contains(fqcn) {
                         if let Some(path) = psr4.resolve(fqcn) {
-                            to_load.push((fqcn.to_string(), path));
+                            pending_files.push((fqcn.to_string(), path));
                         }
                     }
                 }
@@ -469,35 +436,63 @@ impl ProjectAnalyzer {
                     let fqcn = iface.as_ref();
                     if !self.codebase.classes.contains_key(fqcn)
                         && !self.codebase.interfaces.contains_key(fqcn)
-                        && !loaded.contains(fqcn)
+                        && !loaded_fqcns.contains(fqcn)
                     {
                         if let Some(path) = psr4.resolve(fqcn) {
-                            to_load.push((fqcn.to_string(), path));
+                            pending_files.push((fqcn.to_string(), path));
                         }
                     }
                 }
             }
 
-            if to_load.is_empty() {
+            if pending_files.is_empty() {
                 break;
             }
 
             // Load each discovered file (Pass 1 only)
-            for (fqcn, path) in to_load {
-                loaded.insert(fqcn);
+            for (fqcn, path) in pending_files {
+                loaded_fqcns.insert(fqcn);
                 if let Ok(src) = std::fs::read_to_string(&path) {
                     let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
                     let arena = bumpalo::Bump::new();
                     let result = php_rs_parser::parse(&arena, &src);
+                    self.pre_index_file(&file, &result.program);
                     let collector = crate::collector::DefinitionCollector::new(
                         &self.codebase,
-                        file,
+                        file.clone(),
                         &src,
                         &result.source_map,
                     );
                     let issues = collector.collect(&result.program);
                     all_issues.extend(issues);
+
+                    // Cache this lazy-loaded file before re-finalize so that the
+                    // snapshot captures empty all_methods/all_parents (as required).
+                    if let Some(pass1_cache) = &self.pass1_cache {
+                        let content_hash = hash_content(&src);
+                        let symbol_keys: Vec<Arc<str>> = self
+                            .codebase
+                            .symbol_to_file
+                            .iter()
+                            .filter(|e| e.value().as_ref() == file.as_ref())
+                            .map(|e| e.key().clone())
+                            .collect();
+                        let snapshot = crate::pass1_cache::build_snapshot(
+                            &self.codebase,
+                            &file,
+                            content_hash,
+                            &symbol_keys,
+                            vec![],
+                            vec![],
+                        );
+                        pass1_cache.put(file.as_ref(), snapshot);
+                    }
                 }
+            }
+
+            // Flush newly cached lazy-loaded files before re-finalizing.
+            if let Some(pass1_cache) = &self.pass1_cache {
+                pass1_cache.flush();
             }
 
             // Re-finalize to include newly loaded classes in the inheritance graph.
@@ -526,20 +521,29 @@ impl ProjectAnalyzer {
 
         let mut all_issues = Vec::new();
 
-        // Collect parse errors
-        for err in &parsed.errors {
-            all_issues.push(Issue::new(
-                mir_issues::IssueKind::ParseError {
-                    message: err.to_string(),
-                },
-                mir_issues::Location {
-                    file: file.clone(),
-                    line: 1,
-                    col_start: 0,
-                    col_end: 0,
-                },
-            ));
-        }
+        // Collect parse errors — kept separate so they can be stored in the snapshot.
+        let parse_errors: Vec<Issue> = parsed
+            .errors
+            .iter()
+            .map(|err| {
+                Issue::new(
+                    mir_issues::IssueKind::ParseError {
+                        message: err.to_string(),
+                    },
+                    mir_issues::Location {
+                        file: file.clone(),
+                        line: 1,
+                        col_start: 0,
+                        col_end: 0,
+                    },
+                )
+            })
+            .collect();
+
+        // Re-run the pre-index step so file_namespaces and file_imports are
+        // repopulated. Without this, name resolution in Pass 2 falls back to
+        // global scope and the cached snapshot stores empty namespace/imports.
+        self.pre_index_file(&file, &parsed.program);
 
         let collector = DefinitionCollector::new(
             &self.codebase,
@@ -547,24 +551,17 @@ impl ProjectAnalyzer {
             new_content,
             &parsed.source_map,
         );
-        all_issues.extend(collector.collect(&parsed.program));
+        let definition_issues = collector.collect(&parsed.program);
 
-        // 3. Re-finalize (invalidation already done by remove_file_definitions)
-        self.codebase.finalize();
+        all_issues.extend(parse_errors.iter().cloned());
+        all_issues.extend(definition_issues.iter().cloned());
 
-        // 4. Run Pass 2 on this file
-        let (body_issues, symbols) = self.analyze_bodies(
-            &parsed.program,
-            file.clone(),
-            new_content,
-            &parsed.source_map,
-        );
-        all_issues.extend(body_issues);
-
-        // 5. Update caches if present
+        // 3. Persist Pass 1 snapshot before finalize() so that the derived
+        //    all_methods/all_parents fields in ClassStorage are still empty,
+        //    matching the invariant documented in pass1_cache.rs.
         let content_hash = hash_content(new_content);
-        if let Some(p1_cache) = &self.pass1_cache {
-            let fqcns: Vec<Arc<str>> = self
+        if let Some(pass1_cache) = &self.pass1_cache {
+            let symbol_keys: Vec<Arc<str>> = self
                 .codebase
                 .symbol_to_file
                 .iter()
@@ -575,13 +572,27 @@ impl ProjectAnalyzer {
                 &self.codebase,
                 &file,
                 content_hash.clone(),
-                &fqcns,
-                vec![],
-                vec![],
+                &symbol_keys,
+                parse_errors,
+                definition_issues,
             );
-            p1_cache.put(file_path, snapshot);
-            p1_cache.flush();
+            pass1_cache.put(file_path, snapshot);
+            pass1_cache.flush();
         }
+
+        // 4. Re-finalize (invalidation already done by remove_file_definitions)
+        self.codebase.finalize();
+
+        // 5. Run Pass 2 on this file
+        let (body_issues, symbols) = self.analyze_bodies(
+            &parsed.program,
+            file.clone(),
+            new_content,
+            &parsed.source_map,
+        );
+        all_issues.extend(body_issues);
+
+        // 6. Update Pass 2 cache if present
         if let Some(cache) = &self.cache {
             cache.evict_with_dependents(&[file_path.to_string()]);
             let ref_locs = extract_reference_locations(&self.codebase, &file);
@@ -1216,9 +1227,7 @@ impl ProjectAnalyzer {
     /// Pass 1 only: collect type definitions from `paths` into the codebase without
     /// analyzing method bodies or emitting issues. Used to load vendor types.
     pub fn collect_types_only(&self, paths: &[PathBuf]) {
-        use std::collections::HashMap;
-
-        let file_data: Vec<(Arc<str>, String)> = paths
+        let file_sources: Vec<(Arc<str>, String)> = paths
             .par_iter()
             .filter_map(|path| {
                 let src = std::fs::read_to_string(path).ok()?;
@@ -1226,18 +1235,20 @@ impl ProjectAnalyzer {
             })
             .collect();
 
-        let miss_hashes: Vec<Option<String>> = file_data
+        // None = cache hit (replayed) or no cache configured; Some(hash) = cache miss (freshly parsed).
+        let content_hashes: Vec<Option<String>> = file_sources
             .par_iter()
             .map(|(file, src)| {
                 let content_hash = self.pass1_cache.as_ref().map(|_| hash_content(src));
-                if let (Some(p1_cache), Some(ref hash)) = (&self.pass1_cache, &content_hash) {
-                    if let Some(snapshot) = p1_cache.get(file, hash) {
+                if let (Some(pass1_cache), Some(ref hash)) = (&self.pass1_cache, &content_hash) {
+                    if let Some(snapshot) = pass1_cache.get(file, hash) {
                         snapshot.replay(&self.codebase, file);
                         return None;
                     }
                 }
                 let arena = bumpalo::Bump::new();
                 let result = php_rs_parser::parse(&arena, src);
+                self.pre_index_file(file, &result.program);
                 let collector =
                     DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
                 let _ = collector.collect(&result.program);
@@ -1245,33 +1256,29 @@ impl ProjectAnalyzer {
             })
             .collect();
 
-        if let Some(p1_cache) = &self.pass1_cache {
-            let has_misses = miss_hashes.iter().any(|h| h.is_some());
+        if let Some(pass1_cache) = &self.pass1_cache {
+            let has_misses = content_hashes.iter().any(|h| h.is_some());
             if has_misses {
-                let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
-                for entry in self.codebase.symbol_to_file.iter() {
-                    file_to_fqcns
-                        .entry(entry.value().clone())
-                        .or_default()
-                        .push(entry.key().clone());
-                }
-                for ((file, _src), maybe_hash) in file_data.iter().zip(miss_hashes.iter()) {
-                    if let Some(hash) = maybe_hash {
-                        let empty: Vec<Arc<str>> = Vec::new();
-                        let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                let symbols_by_file = build_symbols_by_file(&self.codebase);
+                for ((file, _src), content_hash) in file_sources.iter().zip(content_hashes.iter()) {
+                    if let Some(hash) = content_hash {
+                        let symbol_keys = symbols_by_file
+                            .get(file)
+                            .map(|v| v.as_slice())
+                            .unwrap_or(&[]);
                         let snapshot = crate::pass1_cache::build_snapshot(
                             &self.codebase,
                             file,
                             hash.clone(),
-                            fqcns,
+                            symbol_keys,
                             vec![],
                             vec![],
                         );
-                        p1_cache.put(file.as_ref(), snapshot);
+                        pass1_cache.put(file.as_ref(), snapshot);
                     }
                 }
             }
-            p1_cache.flush();
+            pass1_cache.flush();
         }
     }
 
@@ -1550,8 +1557,88 @@ pub(crate) fn collect_php_files(dir: &Path, out: &mut Vec<PathBuf>) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// build_reverse_deps
+// build_symbols_by_file / build_reverse_deps
 // ---------------------------------------------------------------------------
+
+/// Index a flat list of statements under a given namespace prefix.
+///
+/// Populates `codebase.known_symbols` with every class/interface/trait/enum/function
+/// name and collects `use`-alias declarations into `imports`.  Called once per
+/// namespace block during the pre-index step.
+fn index_stmts(
+    codebase: &Codebase,
+    stmts: &[php_ast::ast::Stmt<'_, '_>],
+    ns: Option<&str>,
+    imports: &mut std::collections::HashMap<String, String>,
+) {
+    use php_ast::ast::StmtKind;
+    for stmt in stmts.iter() {
+        match &stmt.kind {
+            StmtKind::Use(use_decl) => {
+                for item in use_decl.uses.iter() {
+                    let full_name = crate::parser::name_to_string(&item.name);
+                    let alias = item
+                        .alias
+                        .unwrap_or_else(|| full_name.rsplit('\\').next().unwrap_or(&full_name));
+                    imports.insert(alias.to_string(), full_name);
+                }
+            }
+            StmtKind::Class(decl) => {
+                if let Some(n) = decl.name {
+                    let fqcn = match ns {
+                        Some(ns) => format!("{}\\{}", ns, n),
+                        None => n.to_string(),
+                    };
+                    codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+                }
+            }
+            StmtKind::Interface(decl) => {
+                let fqcn = match ns {
+                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                    None => decl.name.to_string(),
+                };
+                codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+            }
+            StmtKind::Trait(decl) => {
+                let fqcn = match ns {
+                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                    None => decl.name.to_string(),
+                };
+                codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+            }
+            StmtKind::Enum(decl) => {
+                let fqcn = match ns {
+                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                    None => decl.name.to_string(),
+                };
+                codebase.known_symbols.insert(Arc::from(fqcn.as_str()));
+            }
+            StmtKind::Function(decl) => {
+                let fqn = match ns {
+                    Some(ns) => format!("{}\\{}", ns, decl.name),
+                    None => decl.name.to_string(),
+                };
+                codebase.known_symbols.insert(Arc::from(fqn.as_str()));
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Invert `Codebase::symbol_to_file` into a `file → Vec<symbol>` map.
+///
+/// Only covers symbols tracked in `symbol_to_file` (classes, interfaces, traits,
+/// enums, functions) — not constants or global variables, which have their own
+/// per-file reverse indices in `Codebase`.
+fn build_symbols_by_file(codebase: &Codebase) -> HashMap<Arc<str>, Vec<Arc<str>>> {
+    let mut map: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+    for entry in codebase.symbol_to_file.iter() {
+        map.entry(entry.value().clone())
+            .or_default()
+            .push(entry.key().clone());
+    }
+    map
+}
 
 /// Build a reverse dependency graph from the codebase after Pass 1.
 ///

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -80,6 +80,13 @@ impl ProjectAnalyzer {
         Ok((analyzer, map))
     }
 
+    /// Enable disk-backed caching for both Pass 1 and Pass 2.
+    /// Must be called before `analyze()` to take effect.
+    pub fn enable_cache(&mut self, cache_dir: &std::path::Path) {
+        self.cache = Some(crate::cache::AnalysisCache::open(cache_dir));
+        self.pass1_cache = Some(crate::pass1_cache::Pass1Cache::open(cache_dir));
+    }
+
     /// Expose codebase for external use (e.g., pre-loading stubs from CLI).
     pub fn codebase(&self) -> &Arc<Codebase> {
         &self.codebase
@@ -1187,18 +1194,60 @@ impl ProjectAnalyzer {
     /// Pass 1 only: collect type definitions from `paths` into the codebase without
     /// analyzing method bodies or emitting issues. Used to load vendor types.
     pub fn collect_types_only(&self, paths: &[PathBuf]) {
-        paths.par_iter().for_each(|path| {
-            let Ok(src) = std::fs::read_to_string(path) else {
-                return;
-            };
-            let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
-            let arena = bumpalo::Bump::new();
-            let result = php_rs_parser::parse(&arena, &src);
-            let collector =
-                DefinitionCollector::new(&self.codebase, file, &src, &result.source_map);
-            // Ignore any issues emitted during vendor collection
-            let _ = collector.collect(&result.program);
-        });
+        use std::collections::HashMap;
+
+        let file_data: Vec<(Arc<str>, String)> = paths
+            .par_iter()
+            .filter_map(|path| {
+                let src = std::fs::read_to_string(path).ok()?;
+                Some((Arc::from(path.to_string_lossy().as_ref()), src))
+            })
+            .collect();
+
+        let miss_hashes: Vec<Option<String>> = file_data
+            .par_iter()
+            .map(|(file, src)| {
+                let content_hash = self.pass1_cache.as_ref().map(|_| hash_content(src));
+                if let (Some(p1_cache), Some(ref hash)) = (&self.pass1_cache, &content_hash) {
+                    if let Some(snapshot) = p1_cache.get(file, hash) {
+                        snapshot.replay(&self.codebase, file);
+                        return None;
+                    }
+                }
+                let arena = bumpalo::Bump::new();
+                let result = php_rs_parser::parse(&arena, src);
+                let collector =
+                    DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
+                let _ = collector.collect(&result.program);
+                content_hash
+            })
+            .collect();
+
+        if let Some(p1_cache) = &self.pass1_cache {
+            let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+            for entry in self.codebase.symbol_to_file.iter() {
+                file_to_fqcns
+                    .entry(entry.value().clone())
+                    .or_default()
+                    .push(entry.key().clone());
+            }
+            for ((file, _src), maybe_hash) in file_data.iter().zip(miss_hashes.iter()) {
+                if let Some(hash) = maybe_hash {
+                    let empty: Vec<Arc<str>> = Vec::new();
+                    let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                    let snapshot = crate::pass1_cache::build_snapshot(
+                        &self.codebase,
+                        file,
+                        hash.clone(),
+                        fqcns,
+                        vec![],
+                        vec![],
+                    );
+                    p1_cache.put(file.as_ref(), snapshot);
+                }
+            }
+            p1_cache.flush();
+        }
     }
 
     /// Check type hints in enum methods for undefined classes.

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -29,6 +29,9 @@ pub struct ProjectAnalyzer {
     stubs_loaded: std::sync::atomic::AtomicBool,
     /// When true, run dead code detection at the end of analysis.
     pub find_dead_code: bool,
+    /// Optional Pass 1 definition cache — when `Some`, unchanged files skip
+    /// parsing and definition collection on subsequent runs.
+    pass1_cache: Option<crate::pass1_cache::Pass1Cache>,
 }
 
 impl ProjectAnalyzer {
@@ -40,6 +43,7 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            pass1_cache: None,
         }
     }
 
@@ -52,6 +56,7 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            pass1_cache: Some(crate::pass1_cache::Pass1Cache::open(cache_dir)),
         }
     }
 
@@ -70,6 +75,7 @@ impl ProjectAnalyzer {
             psr4: Some(psr4),
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            pass1_cache: None,
         };
         Ok((analyzer, map))
     }
@@ -134,9 +140,25 @@ impl ProjectAnalyzer {
         // Parse each file once; both the FQCN/namespace/import index and the full
         // definition collection run in the same rayon closure, eliminating the
         // second sequential parse of every file. DashMap handles concurrent writes.
-        let pass1_results: Vec<(Vec<Issue>, Vec<Issue>)> = file_data
+        //
+        // When the Pass 1 cache is active, unchanged files skip parsing entirely:
+        // the snapshot is replayed and `None` is returned for the content hash.
+        // A cache miss returns `Some(hash)` so a snapshot can be built after the
+        // parallel pass completes.
+        let pass1_results: Vec<(Vec<Issue>, Vec<Issue>, Option<String>)> = file_data
             .par_iter()
             .map(|(file, src)| {
+                // Compute hash only when the pass1 cache is active.
+                let content_hash = self.pass1_cache.as_ref().map(|_| hash_content(src));
+
+                // Cache hit: replay stored definitions and skip parsing.
+                if let (Some(p1_cache), Some(ref hash)) = (&self.pass1_cache, &content_hash) {
+                    if let Some(snapshot) = p1_cache.get(file, hash) {
+                        snapshot.replay(&self.codebase, file);
+                        return (snapshot.parse_errors, snapshot.definition_issues, None);
+                    }
+                }
+
                 use php_ast::ast::StmtKind;
                 let arena = bumpalo::Bump::new();
                 let result = php_rs_parser::parse(&arena, src);
@@ -265,11 +287,42 @@ impl ProjectAnalyzer {
                     DefinitionCollector::new(&self.codebase, file.clone(), src, &result.source_map);
                 let issues = collector.collect(&result.program);
 
-                (file_parse_errors, issues)
+                (file_parse_errors, issues, content_hash)
             })
             .collect();
 
-        for (file_parse_errors, issues) in pass1_results {
+        // Persist new Pass 1 snapshots for cache misses (before finalize() so that
+        // the derived all_methods/all_parents fields are still empty in the snapshot).
+        if let Some(p1_cache) = &self.pass1_cache {
+            // Build reverse index: defining-file → [fqcns defined there].
+            let mut file_to_fqcns: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+            for entry in self.codebase.symbol_to_file.iter() {
+                file_to_fqcns
+                    .entry(entry.value().clone())
+                    .or_default()
+                    .push(entry.key().clone());
+            }
+            for ((file, _src), (per_file_parse_errors, def_issues, maybe_hash)) in
+                file_data.iter().zip(pass1_results.iter())
+            {
+                if let Some(hash) = maybe_hash {
+                    let empty: Vec<Arc<str>> = Vec::new();
+                    let fqcns = file_to_fqcns.get(file).unwrap_or(&empty);
+                    let snapshot = crate::pass1_cache::build_snapshot(
+                        &self.codebase,
+                        file,
+                        hash.clone(),
+                        fqcns,
+                        per_file_parse_errors.clone(),
+                        def_issues.clone(),
+                    );
+                    p1_cache.put(file.as_ref(), snapshot);
+                }
+            }
+            p1_cache.flush();
+        }
+
+        for (file_parse_errors, issues, _) in pass1_results {
             parse_errors.extend(file_parse_errors);
             all_issues.extend(issues);
         }

--- a/crates/mir-analyzer/tests/pass1_cache.rs
+++ b/crates/mir-analyzer/tests/pass1_cache.rs
@@ -1,0 +1,140 @@
+//! Integration tests for the Pass 1 definition cache.
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+/// Helper: run analysis on `src` with a cache dir.
+/// Returns issues so they can be inspected.
+fn analyze_with_cache(src: &str, cache_dir: &TempDir) -> Vec<mir_analyzer::Issue> {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.php");
+    std::fs::write(&file, src).unwrap();
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.enable_cache(cache_dir.path());
+    analyzer.analyze(&[file]).issues
+}
+
+#[test]
+fn second_run_produces_identical_issues() {
+    // A file that has an undefined-method error (must be inside a function body
+    // so the analyzer walks Pass 2 for that scope).
+    let src = r#"<?php
+class Foo {}
+function test(): void {
+    $f = new Foo();
+    $f->missing();
+}
+"#;
+    let cache_dir = TempDir::new().unwrap();
+    let first = analyze_with_cache(src, &cache_dir);
+    let second = analyze_with_cache(src, &cache_dir);
+
+    assert!(
+        !first.is_empty(),
+        "expected at least one issue on first run"
+    );
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "second run (cache hit) must produce the same number of issues"
+    );
+}
+
+#[test]
+fn file_level_constants_survive_cache_hit() {
+    // Two files: one defines a constant, the other uses it.
+    // On the second run, the first file is a cache hit; the constant must still
+    // be present for the second file's analysis to succeed.
+    let dir = TempDir::new().unwrap();
+    let defines = dir.path().join("defines.php");
+    let uses = dir.path().join("uses.php");
+    std::fs::write(&defines, "<?php\nconst MY_CONST = 42;\n").unwrap();
+    std::fs::write(&uses, "<?php\n/** @var int $x */\n$x = MY_CONST;\n").unwrap();
+
+    let cache_dir = TempDir::new().unwrap();
+
+    // First run: both files are cache misses; fills the cache.
+    let first = {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(&[defines.clone(), uses.clone()]).issues
+    };
+
+    // Second run: defines.php is a cache hit.
+    let second = {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(&[defines.clone(), uses.clone()]).issues
+    };
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "cache hit must not introduce new issues (constants must survive replay)"
+    );
+}
+
+#[test]
+fn changed_file_invalidates_snapshot() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.php");
+    let cache_dir = TempDir::new().unwrap();
+
+    std::fs::write(&file, "<?php\nclass A {}\n").unwrap();
+
+    // First run: populates cache.
+    {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(std::slice::from_ref(&file));
+    }
+
+    // Change the file.
+    std::fs::write(&file, "<?php\nclass B {}\n").unwrap();
+
+    // Second run: stale snapshot must be rejected; class B must be known.
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.enable_cache(cache_dir.path());
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    assert!(
+        analyzer.codebase().classes.contains_key("B"),
+        "class B must be in codebase after file change"
+    );
+    assert!(
+        !analyzer.codebase().classes.contains_key("A"),
+        "stale class A must not appear after file change"
+    );
+}
+
+#[test]
+fn vendor_types_survive_cache_hit() {
+    // Simulate a vendor file that defines a class; project file references it.
+    // Second run: vendor file is a collect_types_only cache hit.
+    let dir = TempDir::new().unwrap();
+    let vendor = dir.path().join("vendor.php");
+    let project = dir.path().join("project.php");
+    let cache_dir = TempDir::new().unwrap();
+
+    std::fs::write(
+        &vendor,
+        "<?php\nclass VendorClass { public function hello(): void {} }\n",
+    )
+    .unwrap();
+    std::fs::write(&project, "<?php\n$v = new VendorClass();\n$v->hello();\n").unwrap();
+
+    let run = |cache_dir: &TempDir| {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.collect_types_only(std::slice::from_ref(&vendor));
+        analyzer.analyze(std::slice::from_ref(&project)).issues
+    };
+
+    let first = run(&cache_dir);
+    let second = run(&cache_dir);
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "vendor cache hit must not lose class definitions"
+    );
+}

--- a/crates/mir-analyzer/tests/pass1_cache.rs
+++ b/crates/mir-analyzer/tests/pass1_cache.rs
@@ -138,3 +138,138 @@ fn vendor_types_survive_cache_hit() {
         "vendor cache hit must not lose class definitions"
     );
 }
+
+#[test]
+fn re_analyze_file_snapshot_used_on_next_run() {
+    // Populate the cache with class A, then re_analyze the same file to class B.
+    // The snapshot written by re_analyze_file must be used as a cache hit on the
+    // next analyze() run, producing class B (not stale class A) in the codebase.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("subject.php");
+    let cache_dir = TempDir::new().unwrap();
+
+    std::fs::write(&file, "<?php\nclass A {}\n").unwrap();
+
+    // First run: cold miss, populates cache with class A.
+    {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(std::slice::from_ref(&file));
+    }
+
+    // Incremental edit: re-analyze in memory with class B content.
+    // This rebuilds the snapshot so the cache entry now describes class B.
+    let new_content = "<?php\nclass B {}\n";
+    {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(std::slice::from_ref(&file)); // warm up codebase
+        analyzer.re_analyze_file(file.to_str().unwrap(), new_content);
+    }
+
+    // Write the new content to disk so the hash matches the re_analyze snapshot.
+    std::fs::write(&file, new_content).unwrap();
+
+    // Next analyze() run: should be a cache hit for the B snapshot written above.
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.enable_cache(cache_dir.path());
+    analyzer.analyze(std::slice::from_ref(&file));
+
+    assert!(
+        analyzer.codebase().classes.contains_key("B"),
+        "class B must be in codebase (snapshot written by re_analyze_file)"
+    );
+    assert!(
+        !analyzer.codebase().classes.contains_key("A"),
+        "stale class A must not appear after re_analyze_file"
+    );
+}
+
+#[test]
+fn vendor_namespace_survives_cache_hit() {
+    // Vendor file declares a namespaced class. On the second run it is a cache
+    // hit; the namespace must be replayed so the class is accessible by its FQN.
+    let dir = TempDir::new().unwrap();
+    let vendor = dir.path().join("vendor.php");
+    let project = dir.path().join("project.php");
+    let cache_dir = TempDir::new().unwrap();
+
+    std::fs::write(
+        &vendor,
+        "<?php\nnamespace Acme;\nclass Widget { public function render(): void {} }\n",
+    )
+    .unwrap();
+    // Reference the class by its FQN so we can verify it is accessible.
+    std::fs::write(
+        &project,
+        "<?php\n$w = new \\Acme\\Widget();\n$w->render();\n",
+    )
+    .unwrap();
+
+    let run = |cache_dir: &TempDir| {
+        let mut analyzer = ProjectAnalyzer::new();
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.collect_types_only(std::slice::from_ref(&vendor));
+        analyzer.analyze(std::slice::from_ref(&project)).issues
+    };
+
+    let first = run(&cache_dir);
+    let second = run(&cache_dir);
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "vendor cache hit must not lose namespaced class (namespace must survive replay)"
+    );
+}
+
+#[test]
+fn lazy_loaded_classes_survive_cache_hit() {
+    // Set up a minimal PSR-4 project: a project file references App\Service,
+    // which lives in src/Service.php and is NOT in the initial analyzed file list.
+    // lazy_load_missing_classes discovers and caches it on the first run.
+    // The second run must use the cached snapshot and still see App\Service.
+    let root = TempDir::new().unwrap();
+
+    // composer.json
+    std::fs::write(
+        root.path().join("composer.json"),
+        r#"{"autoload":{"psr-4":{"App\\":"src/"}}}"#,
+    )
+    .unwrap();
+
+    // src/Service.php — NOT included in the analyzed file list; discovered lazily.
+    let src_dir = root.path().join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        src_dir.join("Service.php"),
+        "<?php\nnamespace App;\nclass Service { public function run(): void {} }\n",
+    )
+    .unwrap();
+
+    // Project file that references App\Service.
+    let project_file = root.path().join("main.php");
+    std::fs::write(
+        &project_file,
+        "<?php\nuse App\\Service;\n$s = new Service();\n$s->run();\n",
+    )
+    .unwrap();
+
+    let cache_dir = TempDir::new().unwrap();
+
+    let run = |cache_dir: &TempDir| {
+        let (mut analyzer, _map) =
+            ProjectAnalyzer::from_composer(root.path()).expect("composer setup");
+        analyzer.enable_cache(cache_dir.path());
+        analyzer.analyze(std::slice::from_ref(&project_file)).issues
+    };
+
+    let first = run(&cache_dir);
+    let second = run(&cache_dir);
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "lazy-loaded class must survive cache hit (App\\Service must be known on second run)"
+    );
+}

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -120,6 +120,10 @@ fn main() {
             if cache_file.exists() {
                 std::fs::remove_file(&cache_file).expect("Failed to remove cache file");
             }
+            let pass1_file = cache_dir.join("pass1.bin");
+            if pass1_file.exists() {
+                std::fs::remove_file(&pass1_file).expect("Failed to remove pass1 cache file");
+            }
             if !cli.quiet {
                 eprintln!("mir: cache cleared ({})", cache_dir.display());
             }
@@ -199,7 +203,7 @@ fn main() {
         // Apply --cache-dir if specified (skip when --no-cache is set)
         if let Some(cache_dir) = &cli.cache_dir {
             if !cli.no_cache {
-                analyzer.cache = Some(mir_analyzer::cache::AnalysisCache::open(cache_dir));
+                analyzer.enable_cache(cache_dir);
             }
         }
 

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -119,14 +119,14 @@ impl Codebase {
             .map(|entry| entry.key().clone())
             .collect();
 
-        // Remove each symbol from its respective map and from symbol_to_file
+        // Remove each symbol from its respective map and from symbol_to_file.
+        // Constants are NOT in symbol_to_file; they are removed below via file_constants.
         for sym in &symbols {
             self.classes.remove(sym.as_ref());
             self.interfaces.remove(sym.as_ref());
             self.traits.remove(sym.as_ref());
             self.enums.remove(sym.as_ref());
             self.functions.remove(sym.as_ref());
-            self.constants.remove(sym.as_ref());
             self.symbol_to_file.remove(sym.as_ref());
             self.known_symbols.remove(sym.as_ref());
         }

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -32,6 +32,11 @@ pub struct Codebase {
     /// Used by `remove_file_definitions` to purge stale entries on re-analysis.
     file_global_vars: DashMap<Arc<str>, Vec<Arc<str>>>,
 
+    /// Global PHP constants (`const FOO = 1` / `define('FOO', 1)`) keyed by value.
+    /// Separate from `constants` to provide a per-file reverse index used by
+    /// `remove_file_definitions` and Pass 1 snapshot building.
+    file_constants: DashMap<Arc<str>, Vec<Arc<str>>>,
+
     /// Methods referenced during Pass 2 — key format: `"ClassName::methodName"`.
     /// Used by the dead-code detector (M18).
     pub referenced_methods: DashSet<Arc<str>>,
@@ -137,6 +142,13 @@ impl Codebase {
             }
         }
 
+        // Remove file-level constants declared in this file
+        if let Some((_, const_names)) = self.file_constants.remove(file_path) {
+            for name in const_names {
+                self.constants.remove(name.as_ref());
+            }
+        }
+
         // Remove reference locations contributed by this file.
         // Use the reverse index to avoid a full scan of all symbols.
         if let Some((_, symbol_keys)) = self.file_symbol_references.remove(file_path) {
@@ -171,6 +183,28 @@ impl Codebase {
             .or_default()
             .push(name.clone());
         self.global_vars.insert(name, ty);
+    }
+
+    // -----------------------------------------------------------------------
+    // Global constant registry
+    // -----------------------------------------------------------------------
+
+    /// Record a global PHP constant (`const FOO = 1` / `define('FOO', 1)`) discovered in Pass 1.
+    pub fn register_constant(&self, file: &Arc<str>, name: Arc<str>, ty: Union) {
+        self.file_constants
+            .entry(file.clone())
+            .or_default()
+            .push(name.clone());
+        self.constants.insert(name, ty);
+    }
+
+    /// Return all global constant names declared in `file`.
+    /// Used to build per-file Pass 1 snapshots for the definition cache.
+    pub fn file_constants_for_file(&self, file: &Arc<str>) -> Vec<Arc<str>> {
+        self.file_constants
+            .get(file.as_ref())
+            .map(|v| v.clone())
+            .unwrap_or_default()
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -154,6 +154,15 @@ impl Codebase {
     // Global variable registry
     // -----------------------------------------------------------------------
 
+    /// Return all `@var`-annotated global variable names declared in `file`.
+    /// Used to build per-file Pass 1 snapshots for the definition cache.
+    pub fn file_global_vars_for_file(&self, file: &Arc<str>) -> Vec<Arc<str>> {
+        self.file_global_vars
+            .get(file.as_ref())
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    }
+
     /// Record an `@var`-annotated global variable type discovered in Pass 1.
     /// If the same variable is annotated in multiple files, the last write wins.
     pub fn register_global_var(&self, file: &Arc<str>, name: Arc<str>, ty: Union) {

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -32,9 +32,9 @@ pub struct Codebase {
     /// Used by `remove_file_definitions` to purge stale entries on re-analysis.
     file_global_vars: DashMap<Arc<str>, Vec<Arc<str>>>,
 
-    /// Global PHP constants (`const FOO = 1` / `define('FOO', 1)`) keyed by value.
-    /// Separate from `constants` to provide a per-file reverse index used by
-    /// `remove_file_definitions` and Pass 1 snapshot building.
+    /// Maps file path → constant names declared in that file.
+    /// Provides the per-file reverse index used by `remove_file_definitions`
+    /// and Pass 1 snapshot building.
     file_constants: DashMap<Arc<str>, Vec<Arc<str>>>,
 
     /// Methods referenced during Pass 2 — key format: `"ClassName::methodName"`.


### PR DESCRIPTION
## Summary

- Adds a bincode-backed per-file snapshot cache (`pass1.bin`) stored alongside the existing Pass 2 (`analysis.json`) cache.
- On subsequent runs, files whose SHA-256 content hash matches a stored snapshot skip parsing and definition collection entirely — the snapshot is replayed directly into the codebase.
- Cache is activated when `ProjectAnalyzer::with_cache(cache_dir)` is used (same path as the Pass 2 cache).

## How it works

1. **`pass1_cache.rs`** — new module with:
   - `Pass1Snapshot`: serialisable struct capturing all per-file definitions (classes, interfaces, traits, enums, functions, global vars, parse errors).
   - `build_snapshot()`: extracts a snapshot from the codebase post-Pass 1 using a reverse index of `symbol_to_file`.
   - `Pass1Cache`: `RwLock<HashMap>` + `AtomicBool dirty` backed by `{cache_dir}/pass1.bin`.

2. **`project.rs`** — `ProjectAnalyzer` gains a `pass1_cache` field. In the parallel Pass 1 closure:
   - Hash is computed only when the cache is active.
   - Cache hit → `snapshot.replay()` populates the codebase and returns immediately.
   - Cache miss → full parse + definition collection, hash carried forward.
   - After the parallel pass (before `finalize()`): snapshots are built for all misses and flushed to disk.

3. **`codebase.rs`** — adds `file_global_vars_for_file()` helper so the snapshot builder can extract per-file global variable annotations.

## Test plan

- [ ] `cargo test` — all 305 existing tests pass (no behaviour change on first run)
- [ ] Manual smoke test: run mir twice on a PHP project with `--cache`; second run should be significantly faster (Pass 1 fully cached)