### PR TITLE
test(fixtures): add fixtures for 9 previously uncovered issue kinds

### DIFF
--- a/crates/mir-analyzer/build.rs
+++ b/crates/mir-analyzer/build.rs
@@ -29,6 +29,9 @@ fn main() {
         .collect();
     categories.sort_by_key(|e| e.file_name());
 
+    // Categories that require the dead-code detector to be enabled.
+    const DEAD_CODE_CATEGORIES: &[&str] = &["unused_method", "unused_property"];
+
     for cat_entry in categories {
         let cat_dir_name = cat_entry.file_name().to_string_lossy().into_owned();
         let cat_mod_name = cat_dir_name.replace('-', "_");
@@ -52,6 +55,13 @@ fn main() {
             continue;
         }
 
+        let use_dead_code = DEAD_CODE_CATEGORIES.contains(&cat_dir_name.as_str());
+        let runner = if use_dead_code {
+            "mir_analyzer::test_utils::run_fixture_dead_code"
+        } else {
+            "mir_analyzer::test_utils::run_fixture"
+        };
+
         code.push_str(&format!("\nmod {cat_mod_name} {{\n"));
 
         for fixture in fixtures {
@@ -69,7 +79,7 @@ fn main() {
 
             code.push_str(&format!(
                 "    #[test]\n    fn {stem}() {{\n        \
-                 mir_analyzer::test_utils::run_fixture(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{rel}\"));\n    \
+                 {runner}(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{rel}\"));\n    \
                  }}\n"
             ));
         }

--- a/crates/mir-analyzer/src/test_utils.rs
+++ b/crates/mir-analyzer/src/test_utils.rs
@@ -15,16 +15,34 @@ static COUNTER: AtomicU64 = AtomicU64::new(0);
 /// Creates a unique temp file, analyzes it, deletes it, and returns all
 /// unsuppressed issues.
 pub fn check(src: &str) -> Vec<Issue> {
+    check_with_opts(src, false)
+}
+
+/// Like [`check`] but also runs the dead-code detector
+/// (`UnusedMethod`, `UnusedProperty`).
+pub fn check_dead_code(src: &str) -> Vec<Issue> {
+    check_with_opts(src, true)
+}
+
+fn check_with_opts(src: &str, find_dead_code: bool) -> Vec<Issue> {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     let tmp: PathBuf = std::env::temp_dir().join(format!("mir_test_{}.php", id));
     std::fs::write(&tmp, src)
         .unwrap_or_else(|e| panic!("failed to write temp PHP file {}: {}", tmp.display(), e));
-    let result = ProjectAnalyzer::new().analyze(std::slice::from_ref(&tmp));
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.find_dead_code = find_dead_code;
+    let result = analyzer.analyze(std::slice::from_ref(&tmp));
+    let tmp_str = tmp.to_string_lossy().into_owned();
     std::fs::remove_file(&tmp).ok();
     result
         .issues
         .into_iter()
         .filter(|i| !i.suppressed)
+        // When dead-code analysis is enabled the analyzer walks the entire
+        // codebase (including PHP stubs).  Filter to issues originating from
+        // the test file only so that stub-side false positives don't pollute
+        // the fixture output.
+        .filter(|i| !find_dead_code || i.location.file.as_ref() == tmp_str.as_str())
         .collect()
 }
 
@@ -126,18 +144,28 @@ fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
 ///
 /// Called by the auto-generated test functions in `build.rs`.
 pub fn run_fixture(path: &str) {
+    run_fixture_with_opts(path, false);
+}
+
+/// Like [`run_fixture`] but also enables the dead-code detector for issue kinds
+/// such as `UnusedMethod` and `UnusedProperty` that require it.
+pub fn run_fixture_dead_code(path: &str) {
+    run_fixture_with_opts(path, true);
+}
+
+fn run_fixture_with_opts(path: &str, find_dead_code: bool) {
     let content = std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("failed to read fixture {}: {}", path, e));
 
     if std::env::var("UPDATE_FIXTURES").as_deref() == Ok("1") {
         let source = parse_phpt_source_only(&content, path);
-        let actual = check(&source);
+        let actual = check_with_opts(&source, find_dead_code);
         rewrite_fixture(path, &content, &actual);
         return;
     }
 
     let (source, expected) = parse_phpt(&content, path);
-    let actual = check(&source);
+    let actual = check_with_opts(&source, find_dead_code);
 
     let mut failures: Vec<String> = Vec::new();
 

--- a/crates/mir-analyzer/tests/fixtures/deprecated_call/does_not_report_non_deprecated.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_call/does_not_report_non_deprecated.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+function greet(string $name): void {
+    echo $name;
+}
+
+function test(): void {
+    greet('Alice');
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function.phpt
@@ -1,0 +1,11 @@
+===source===
+<?php
+/** @deprecated use newGreet() instead */
+function oldGreet(string $name): void {}
+
+function test(): void {
+    oldGreet('Alice');
+}
+===expect===
+UnusedParam: $name
+DeprecatedCall: oldGreet('Alice')

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/does_not_report_non_deprecated_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/does_not_report_non_deprecated_method.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class Foo {
+    public function activeMethod(): void {}
+}
+
+$foo = new Foo();
+$foo->activeMethod();
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+class Foo {
+    /** @deprecated use newMethod() instead */
+    public function oldMethod(): void {}
+}
+
+function test(Foo $foo): void {
+    $foo->oldMethod();
+}
+===expect===
+DeprecatedMethodCall: $foo->oldMethod()

--- a/crates/mir-analyzer/tests/fixtures/invalid_throw/does_not_report_exception.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_throw/does_not_report_exception.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function test(): void {
+    throw new \RuntimeException('something went wrong');
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_throw/reports_non_throwable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_throw/reports_non_throwable.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class NotAnException {}
+
+function test(): void {
+    throw new NotAnException();
+}
+===expect===
+InvalidThrow: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/mixed_method_call/does_not_report_typed_method_call.phpt
+++ b/crates/mir-analyzer/tests/fixtures/mixed_method_call/does_not_report_typed_method_call.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {}
+}
+
+function test(Foo $value): void {
+    $value->bar();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/mixed_method_call/reports_method_call_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/mixed_method_call/reports_method_call_on_mixed.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(mixed $value): void {
+    $value->someMethod();
+}
+===expect===
+MixedMethodCall: $value->someMethod()

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_argument/does_not_report_after_null_check.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_argument/does_not_report_after_null_check.phpt
@@ -1,0 +1,11 @@
+===source===
+<?php
+function greet(string $name): void {}
+
+function test(?string $value): void {
+    if ($value !== null) {
+        greet($value);
+    }
+}
+===expect===
+UnusedParam: $name

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_argument/reports_possibly_null_argument.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_argument/reports_possibly_null_argument.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+function greet(string $name): void {}
+
+function test(?string $value): void {
+    greet($value);
+}
+===expect===
+UnusedParam: $name
+PossiblyNullArgument: $value

--- a/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/does_not_report_assignment_in_constructor.phpt
+++ b/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/does_not_report_assignment_in_constructor.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    public readonly string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/reports_assignment_outside_constructor.phpt
+++ b/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/reports_assignment_outside_constructor.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+class Foo {
+    public readonly string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+
+function test(Foo $foo): void {
+    $foo->name = 'bar';
+}
+===expect===
+ReadonlyPropertyAssignment: $foo->name = 'bar'

--- a/crates/mir-analyzer/tests/fixtures/shadowed_template_param/reports_method_shadows_class_template.phpt
+++ b/crates/mir-analyzer/tests/fixtures/shadowed_template_param/reports_method_shadows_class_template.phpt
@@ -1,0 +1,19 @@
+===source===
+<?php
+/** @template T */
+class Box {
+    /**
+     * @template T
+     * @param T $value
+     * @return T
+     */
+    public function transform($value) { return $value; }
+}
+
+function test(): void {
+    /** @var Box<string> $box */
+    $box = new Box();
+    $box->transform('hello');
+}
+===expect===
+ShadowedTemplateParam: $box->transform('hello')

--- a/crates/mir-analyzer/tests/fixtures/unused_method/does_not_report_called_private_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_method/does_not_report_called_private_method.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    public function run(): void {
+        $this->helper();
+    }
+
+    private function helper(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_method/does_not_report_public_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_method/does_not_report_public_method.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+class Foo {
+    public function publicMethod(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_method/reports_private_unused_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_method/reports_private_unused_method.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+class Foo {
+    private function helper(): void {}
+}
+===expect===
+UnusedMethod: <no snippet>

--- a/crates/mir-analyzer/tests/fixtures/unused_property/does_not_report_public_property.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_property/does_not_report_public_property.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+class Foo {
+    public string $name = 'bar';
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_property/does_not_report_read_property.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_property/does_not_report_read_property.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+class Foo {
+    private string $name = 'bar';
+
+    public function getName(): string {
+        return $this->name;
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_property/reports_private_unused_property.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_property/reports_private_unused_property.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+class Foo {
+    private string $name = 'bar';
+}
+===expect===
+UnusedProperty: <no snippet>


### PR DESCRIPTION
## Summary

- Adds `.phpt` fixture directories for 9 issue kinds that had zero coverage: `DeprecatedCall`, `DeprecatedMethodCall`, `InvalidThrow`, `MixedMethodCall`, `PossiblyNullArgument`, `ReadonlyPropertyAssignment`, `ShadowedTemplateParam`, `UnusedMethod`, `UnusedProperty`
- Adds `check_dead_code` / `run_fixture_dead_code` helpers in `test_utils.rs` so `UnusedMethod` and `UnusedProperty` (which require `find_dead_code=true`) can be tested; stub-side false positives are filtered by matching the issue location to the temp test file
- Updates `build.rs` to route `unused_method` and `unused_property` fixture categories through `run_fixture_dead_code`

Note: `NullArgument` and `InvalidTemplateParam` are excluded — `NullArgument` is shadowed by `PossiblyNullArgument` in all reachable paths, and `InvalidTemplateParam` cannot fire because the docblock parser emits `TNamedObject` instead of `TTemplateParam` for bare template names (see issue #26). The remaining unimplemented issue kinds (`InvalidPropertyAssignment`, `MismatchingDocblockReturnType`, etc.) are excluded per the issue notes since they are not yet implemented in the analyzer.

Closes #102