### PR TITLE
fix: use Unicode char-count columns throughout mir core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Column encoding** — `IssueLocation.col_start`/`col_end` (in `mir-issues`) and `Location.col` (in `mir-codebase`) now store 0-based **Unicode code-point counts** (one column per character as seen on screen) instead of UTF-16 code units. For the vast majority of PHP code this is identical; the difference only arises for supplementary-plane characters (e.g. emoji in identifiers). CLI output and GitHub Actions annotations now show human-visible column numbers. LSP clients must convert to UTF-16 at the protocol boundary — that conversion belongs in the LSP crate, not in the core analyzer.
+
 ## [0.5.0] - 2026-04-17
 
 ### Added
@@ -27,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **LSP diagnostic column offsets** — fixed `col_end` always being equal to `col_start` (resulting in zero-width diagnostic ranges) and column offsets not being converted to UTF-16 code units as required by LSP and SARIF specifications. Diagnostics now correctly highlight the full variable/expression range with proper multi-byte character handling. (#182)
+- **Diagnostic column offsets** — fixed `col_end` always being equal to `col_start` (resulting in zero-width diagnostic ranges) and column offsets being raw UTF-8 byte positions instead of character counts. Diagnostics now correctly highlight the full variable/expression range with proper multi-byte character handling. (#182)
 
 ## [0.4.0] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- **Column encoding** — `IssueLocation.col_start`/`col_end` (in `mir-issues`) and `Location.col` (in `mir-codebase`) now store 0-based **Unicode code-point counts** (one column per character as seen on screen) instead of UTF-16 code units. For the vast majority of PHP code this is identical; the difference only arises for supplementary-plane characters (e.g. emoji in identifiers). CLI output and GitHub Actions annotations now show human-visible column numbers. LSP clients must convert to UTF-16 at the protocol boundary — that conversion belongs in the LSP crate, not in the core analyzer.
-
 ## [0.5.0] - 2026-04-17
 
 ### Added

--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -754,9 +754,9 @@ fn visibility_reduced(child_vis: Visibility, parent_vis: Visibility) -> bool {
     )
 }
 
-/// Build an issue location from the stored codebase Location (which now carries line/col).
-/// Falls back to a dummy location using the FQCN as the file path when no Location is stored.
-/// Convert a codebase storage::Location to a mir-issues::Location with proper UTF-16 columns.
+/// Build an issue location from the stored codebase Location (which carries line/col as
+/// Unicode char-count columns). Falls back to a dummy location using the FQCN as the file
+/// path when no Location is stored.
 fn issue_location(
     storage_loc: Option<&mir_codebase::storage::Location>,
     fqcn: &Arc<str>,
@@ -764,59 +764,45 @@ fn issue_location(
 ) -> Location {
     match storage_loc {
         Some(loc) => {
-            // Calculate col_end from the end byte offset if source is available
+            // Calculate col_end from the end byte offset if source is available.
             let col_end = if let Some(src) = source {
                 if loc.end > loc.start {
                     let end_offset = (loc.end as usize).min(src.len());
-                    // Find the line start containing the end offset
+                    // Find the line start containing the end offset.
                     let line_start = src[..end_offset].rfind('\n').map(|p| p + 1).unwrap_or(0);
-                    // Count UTF-16 code units from line start to end offset
-                    let utf16_col_end: u16 = src[line_start..end_offset]
-                        .chars()
-                        .map(|c| c.len_utf16() as u16)
-                        .sum();
+                    // Count Unicode chars from line start to end offset.
+                    let col_end = src[line_start..end_offset].chars().count() as u16;
 
-                    // Convert col_start to UTF-16 as well
+                    // Count Unicode chars from line start to start offset.
                     let col_start_offset = (loc.start as usize).min(src.len());
                     let col_start_line = src[..col_start_offset]
                         .rfind('\n')
                         .map(|p| p + 1)
                         .unwrap_or(0);
-                    let col_start_utf16 = src[col_start_line..col_start_offset]
-                        .chars()
-                        .map(|c| c.len_utf16() as u16)
-                        .sum::<u16>();
+                    let col_start = src[col_start_line..col_start_offset].chars().count() as u16;
 
-                    // If on same line, use utf16_col_end; otherwise just use it
-                    utf16_col_end.max(col_start_utf16 + 1)
+                    col_end.max(col_start + 1)
                 } else {
-                    // Convert col to UTF-16
+                    // Single-char span: end = start + 1.
                     let col_start_offset = (loc.start as usize).min(src.len());
                     let col_start_line = src[..col_start_offset]
                         .rfind('\n')
                         .map(|p| p + 1)
                         .unwrap_or(0);
-                    src[col_start_line..col_start_offset]
-                        .chars()
-                        .map(|c| c.len_utf16() as u16)
-                        .sum::<u16>()
-                        + 1
+                    src[col_start_line..col_start_offset].chars().count() as u16 + 1
                 }
             } else {
                 loc.col + 1
             };
 
-            // Convert col_start to UTF-16
+            // col_start: use loc.col (already a char-count) or recompute from source.
             let col_start = if let Some(src) = source {
                 let col_start_offset = (loc.start as usize).min(src.len());
                 let col_start_line = src[..col_start_offset]
                     .rfind('\n')
                     .map(|p| p + 1)
                     .unwrap_or(0);
-                src[col_start_line..col_start_offset]
-                    .chars()
-                    .map(|c| c.len_utf16() as u16)
-                    .sum()
+                src[col_start_line..col_start_offset].chars().count() as u16
             } else {
                 loc.col
             };

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -219,7 +219,21 @@ impl<'a> DefinitionCollector<'a> {
 
     fn location(&self, start: u32, end: u32) -> Location {
         let lc = self.source_map.offset_to_line_col(start);
-        Location::with_line_col(self.file.clone(), start, end, lc.line + 1, lc.col as u16)
+        let line = lc.line + 1;
+        let byte_offset = start as usize;
+        let line_start = if byte_offset == 0 {
+            0
+        } else {
+            self.source[..byte_offset]
+                .rfind('\n')
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let col = self.source[line_start..byte_offset]
+            .chars()
+            .map(|c| c.len_utf16() as u16)
+            .sum();
+        Location::with_line_col(self.file.clone(), start, end, line, col)
     }
 
     #[allow(dead_code)]

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -229,17 +229,24 @@ impl<'a> DefinitionCollector<'a> {
                 .map(|p| p + 1)
                 .unwrap_or(0)
         };
-        let col = self.source[line_start..byte_offset]
-            .chars()
-            .map(|c| c.len_utf16() as u16)
-            .sum();
+        let col = self.source[line_start..byte_offset].chars().count() as u16;
         Location::with_line_col(self.file.clone(), start, end, line, col)
     }
 
     #[allow(dead_code)]
     fn issue_location(&self, start: u32) -> IssueLocation {
         let lc = self.source_map.offset_to_line_col(start);
-        let (line, col) = (lc.line + 1, lc.col as u16);
+        let line = lc.line + 1;
+        let byte_offset = start as usize;
+        let line_start = if byte_offset == 0 {
+            0
+        } else {
+            self.source[..byte_offset]
+                .rfind('\n')
+                .map(|p| p + 1)
+                .unwrap_or(0)
+        };
+        let col = self.source[line_start..byte_offset].chars().count() as u16;
         IssueLocation {
             file: self.file.clone(),
             line,

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1305,40 +1305,34 @@ impl<'a> ExpressionAnalyzer<'a> {
     // Issue emission
     // -----------------------------------------------------------------------
 
-    /// Convert a byte offset to a UTF-16 column on a given line.
-    /// Returns (line, col_utf16) where col is 0-based UTF-16 code unit count.
-    fn offset_to_line_col_utf16(&self, offset: u32) -> (u32, u16) {
+    /// Convert a byte offset to a Unicode char-count column on a given line.
+    /// Returns (line, col) where col is a 0-based Unicode code-point count.
+    fn offset_to_line_col(&self, offset: u32) -> (u32, u16) {
         let lc = self.source_map.offset_to_line_col(offset);
         let line = lc.line + 1;
 
-        // Find the start of the line containing this offset
         let byte_offset = offset as usize;
         let line_start_byte = if byte_offset == 0 {
             0
         } else {
-            // Find the position after the last newline before this offset
             self.source[..byte_offset]
                 .rfind('\n')
                 .map(|p| p + 1)
                 .unwrap_or(0)
         };
 
-        // Count UTF-16 code units from line start to the offset
-        let col_utf16 = self.source[line_start_byte..byte_offset]
-            .chars()
-            .map(|c| c.len_utf16() as u16)
-            .sum();
+        let col = self.source[line_start_byte..byte_offset].chars().count() as u16;
 
-        (line, col_utf16)
+        (line, col)
     }
 
     pub fn emit(&mut self, kind: IssueKind, severity: Severity, span: php_ast::Span) {
-        let (line, col_start) = self.offset_to_line_col_utf16(span.start);
+        let (line, col_start) = self.offset_to_line_col(span.start);
 
-        // Calculate col_end: if span.end is on the same line, use its UTF-16 column;
+        // Calculate col_end: if span.end is on the same line, use its char-count column;
         // otherwise use col_start (single-line range for diagnostics)
         let col_end = if span.start < span.end {
-            let (_end_line, end_col) = self.offset_to_line_col_utf16(span.end);
+            let (_end_line, end_col) = self.offset_to_line_col(span.end);
             end_col
         } else {
             col_start
@@ -1601,7 +1595,7 @@ mod tests {
         result.source_map
     }
 
-    /// Helper to test offset_to_line_col_utf16 conversion
+    /// Helper to test offset_to_line_col conversion (Unicode char-count columns).
     fn test_offset_conversion(source: &str, offset: u32) -> (u32, u16) {
         let source_map = create_source_map(source);
         let lc = source_map.offset_to_line_col(offset);
@@ -1617,92 +1611,93 @@ mod tests {
                 .unwrap_or(0)
         };
 
-        let col_utf16 = source[line_start_byte..byte_offset]
-            .chars()
-            .map(|c| c.len_utf16() as u16)
-            .sum();
+        let col = source[line_start_byte..byte_offset].chars().count() as u16;
 
-        (line, col_utf16)
+        (line, col)
     }
 
     #[test]
-    fn utf16_conversion_simple_ascii() {
-        // Test simple ASCII on a single line
+    fn col_conversion_simple_ascii() {
         let source = "<?php\n$var = 123;";
-        //               0123456789012345
 
-        // Position of '$' on line 2 should be column 0 (byte 6)
+        // '$' on line 2, column 0
         let (line, col) = test_offset_conversion(source, 6);
         assert_eq!(line, 2);
         assert_eq!(col, 0);
 
-        // Position of 'v' should be column 1 (byte 7)
+        // 'v' on line 2, column 1
         let (line, col) = test_offset_conversion(source, 7);
         assert_eq!(line, 2);
         assert_eq!(col, 1);
     }
 
     #[test]
-    fn utf16_conversion_emoji_utf16_units() {
-        // Test that emoji (2 UTF-16 units) are counted correctly
-        let source = "<?php\n$x = 1;\n$y = \"🎉\";";
-        //                              emoji starts around byte 23
-
-        // Find the exact byte position of the emoji
-        let quote_pos = source.find('"').unwrap();
-        let emoji_pos = quote_pos + 1; // After opening quote
-
-        // Position before emoji (the quote)
-        let (line, _col) = test_offset_conversion(source, quote_pos as u32);
-        assert_eq!(line, 3);
-
-        // Position at emoji start
-        let (line, col) = test_offset_conversion(source, emoji_pos as u32);
-        assert_eq!(line, 3);
-        // Column should include the quote before it
-        let expected_col = (quote_pos - source[..quote_pos].rfind('\n').unwrap_or(0) - 1) as u16;
-        assert_eq!(col, expected_col + 1);
-    }
-
-    #[test]
-    fn utf16_conversion_different_lines() {
+    fn col_conversion_different_lines() {
         let source = "<?php\n$x = 1;\n$y = 2;";
-        //          Line 1: <?php (bytes 0-4, newline at 5)
-        //          Line 2: $x = 1; (bytes 6-12, newline at 13)
-        //          Line 3: $y = 2; (bytes 14-20)
+        // Line 1: <?php     (bytes 0-4, newline at 5)
+        // Line 2: $x = 1;  (bytes 6-12, newline at 13)
+        // Line 3: $y = 2;  (bytes 14-20)
 
-        // Position on line 1, byte 0
         let (line, col) = test_offset_conversion(source, 0);
-        assert_eq!(line, 1);
-        assert_eq!(col, 0);
+        assert_eq!((line, col), (1, 0));
 
-        // Position on line 2, byte 6 (first char after newline)
         let (line, col) = test_offset_conversion(source, 6);
-        assert_eq!(line, 2);
-        assert_eq!(col, 0);
+        assert_eq!((line, col), (2, 0));
 
-        // Position on line 3, byte 14 (first char after second newline)
         let (line, col) = test_offset_conversion(source, 14);
-        assert_eq!(line, 3);
-        assert_eq!(col, 0); // '$' is the first character on line 3
+        assert_eq!((line, col), (3, 0));
     }
 
     #[test]
-    fn utf16_conversion_accented_characters() {
-        // Test accented characters (é, ñ, etc.)
+    fn col_conversion_accented_characters() {
+        // é is 2 UTF-8 bytes but 1 Unicode char (and 1 UTF-16 unit — same result either way)
         let source = "<?php\n$café = 1;";
-        //               012345678901234567
-        // é is 2 bytes in UTF-8 but 1 UTF-16 code unit
+        // Line 2: $ c a f é ...
+        // bytes:  6 7 8 9 10(2 bytes)
 
-        // Position at 'f' (byte 9)
+        // 'f' at byte 9 → char col 3
         let (line, col) = test_offset_conversion(source, 9);
-        assert_eq!(line, 2);
-        assert_eq!(col, 3); // $, c, a, f
+        assert_eq!((line, col), (2, 3));
 
-        // Position at 'é' (byte 10, start of é which is 2 bytes)
+        // 'é' at byte 10 → char col 4
         let (line, col) = test_offset_conversion(source, 10);
+        assert_eq!((line, col), (2, 4));
+    }
+
+    #[test]
+    fn col_conversion_emoji_counts_as_one_char() {
+        // 🎉 (U+1F389) is 4 UTF-8 bytes and 2 UTF-16 units, but 1 Unicode char.
+        // A char after the emoji must land at col 7, not col 8.
+        let source = "<?php\n$y = \"🎉x\";";
+        // Line 2: $ y   =   " 🎉 x " ;
+        // chars:  0 1 2 3 4 5  6  7 8 9
+
+        let emoji_start = source.find("🎉").unwrap();
+        let after_emoji = emoji_start + "🎉".len(); // skip 4 bytes
+
+        // position at 'x' (right after the emoji)
+        let (line, col) = test_offset_conversion(source, after_emoji as u32);
         assert_eq!(line, 2);
-        assert_eq!(col, 4); // $ c a f = 4 UTF-16 units
+        assert_eq!(col, 7); // emoji counts as 1, not 2
+    }
+
+    #[test]
+    fn col_conversion_emoji_start_position() {
+        // The opening quote is at col 5; the emoji immediately follows at col 6.
+        let source = "<?php\n$y = \"🎉\";";
+        // Line 2: $ y   =   " 🎉 " ;
+        // chars:  0 1 2 3 4 5  6  7 8
+
+        let quote_pos = source.find('"').unwrap();
+        let emoji_pos = quote_pos + 1; // byte after opening quote = emoji start
+
+        let (line, col) = test_offset_conversion(source, quote_pos as u32);
+        assert_eq!(line, 2);
+        assert_eq!(col, 5); // '"' is the 6th char on line 2 (0-based: col 5)
+
+        let (line, col) = test_offset_conversion(source, emoji_pos as u32);
+        assert_eq!(line, 2);
+        assert_eq!(col, 6); // emoji follows the quote
     }
 
     #[test]
@@ -1719,7 +1714,7 @@ mod tests {
     }
 
     #[test]
-    fn utf16_conversion_multiline_span() {
+    fn col_conversion_multiline_span() {
         // Test span that starts on one line and ends on another
         let source = "<?php\n$x = [\n  'a',\n  'b'\n];";
         //           Line 1: <?php
@@ -1757,7 +1752,7 @@ mod tests {
         // Column at emoji
         let (line, col) = test_offset_conversion(source, emoji_pos as u32);
         assert_eq!(line, 2);
-        // Should be after "Hello " (13 + 5 + 1 = 19 UTF-16 units)
+        // Should be after "Hello " (13 + 5 + 1 = 19 chars)
         assert_eq!(col, 19);
     }
 }

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -1189,12 +1189,12 @@ impl Default for ProjectAnalyzer {
 }
 
 // ---------------------------------------------------------------------------
-// UTF-16 offset conversion utility
+// Offset to char-count column conversion
 // ---------------------------------------------------------------------------
 
-/// Convert a byte offset to a UTF-16 column on a given line.
-/// Returns (line, col_utf16) where col is 0-based UTF-16 code unit count.
-fn offset_to_line_col_utf16(
+/// Convert a byte offset to a Unicode char-count column on a given line.
+/// Returns (line, col) where col is a 0-based Unicode code-point count.
+fn offset_to_line_col(
     source: &str,
     offset: u32,
     source_map: &php_rs_parser::source_map::SourceMap,
@@ -1202,25 +1202,19 @@ fn offset_to_line_col_utf16(
     let lc = source_map.offset_to_line_col(offset);
     let line = lc.line + 1;
 
-    // Find the start of the line containing this offset
     let byte_offset = offset as usize;
     let line_start_byte = if byte_offset == 0 {
         0
     } else {
-        // Find the position after the last newline before this offset
         source[..byte_offset]
             .rfind('\n')
             .map(|p| p + 1)
             .unwrap_or(0)
     };
 
-    // Count UTF-16 code units from line start to the offset
-    let col_utf16 = source[line_start_byte..byte_offset]
-        .chars()
-        .map(|c| c.len_utf16() as u16)
-        .sum();
+    let col = source[line_start_byte..byte_offset].chars().count() as u16;
 
-    (line, col_utf16)
+    (line, col)
 }
 
 // ---------------------------------------------------------------------------
@@ -1247,11 +1241,10 @@ fn check_type_hint_classes<'arena, 'src>(
             }
             let resolved = codebase.resolve_class_name(file.as_ref(), &name_str);
             if !codebase.type_exists(&resolved) {
-                let (line, col_start) =
-                    offset_to_line_col_utf16(source, hint.span.start, source_map);
+                let (line, col_start) = offset_to_line_col(source, hint.span.start, source_map);
                 let col_end = if hint.span.start < hint.span.end {
                     let (_end_line, end_col) =
-                        offset_to_line_col_utf16(source, hint.span.end, source_map);
+                        offset_to_line_col(source, hint.span.end, source_map);
                     end_col
                 } else {
                     col_start

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -129,9 +129,9 @@ impl<'a> StatementsAnalyzer<'a> {
                 for expr in exprs.iter() {
                     // Taint check (M19): echoing tainted data → XSS
                     if crate::taint::is_expr_tainted(expr, ctx) {
-                        let (line, col_start) = self.offset_to_line_col_utf16(stmt.span.start);
+                        let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                         let col_end = if stmt.span.start < stmt.span.end {
-                            let (_end_line, end_col) = self.offset_to_line_col_utf16(stmt.span.end);
+                            let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
                             end_col
                         } else {
                             col_start
@@ -208,10 +208,9 @@ impl<'a> StatementsAnalyzer<'a> {
                                 && !named_object_return_compatible(declared, &check_ty, self.codebase, &self.file)
                                 && !named_object_return_compatible(&declared.remove_null(), &check_ty.remove_null(), self.codebase, &self.file))
                         {
-                            let (line, col_start) = self.offset_to_line_col_utf16(stmt.span.start);
+                            let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                             let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) =
-                                    self.offset_to_line_col_utf16(stmt.span.end);
+                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
                                 end_col
                             } else {
                                 col_start
@@ -242,10 +241,9 @@ impl<'a> StatementsAnalyzer<'a> {
                     // Bare `return;` from a non-void declared function is an error.
                     if let Some(declared) = &ctx.fn_return_type.clone() {
                         if !declared.is_void() && !declared.is_mixed() {
-                            let (line, col_start) = self.offset_to_line_col_utf16(stmt.span.start);
+                            let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                             let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) =
-                                    self.offset_to_line_col_utf16(stmt.span.end);
+                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
                                 end_col
                             } else {
                                 col_start
@@ -300,11 +298,10 @@ impl<'a> StatementsAnalyzer<'a> {
                                 // Suppress if class is not in codebase at all (could be extension class)
                                 || (!self.codebase.type_exists(&resolved) && !self.codebase.type_exists(fqcn));
                             if !is_throwable {
-                                let (line, col_start) =
-                                    self.offset_to_line_col_utf16(stmt.span.start);
+                                let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                                 let col_end = if stmt.span.start < stmt.span.end {
                                     let (_end_line, end_col) =
-                                        self.offset_to_line_col_utf16(stmt.span.end);
+                                        self.offset_to_line_col(stmt.span.end);
                                     end_col
                                 } else {
                                     col_start
@@ -339,11 +336,10 @@ impl<'a> StatementsAnalyzer<'a> {
                                 || self.codebase.has_unknown_ancestor(&resolved)
                                 || self.codebase.has_unknown_ancestor(fqcn);
                             if !is_throwable {
-                                let (line, col_start) =
-                                    self.offset_to_line_col_utf16(stmt.span.start);
+                                let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                                 let col_end = if stmt.span.start < stmt.span.end {
                                     let (_end_line, end_col) =
-                                        self.offset_to_line_col_utf16(stmt.span.end);
+                                        self.offset_to_line_col(stmt.span.end);
                                     end_col
                                 } else {
                                     col_start
@@ -363,10 +359,9 @@ impl<'a> StatementsAnalyzer<'a> {
                         }
                         mir_types::Atomic::TMixed | mir_types::Atomic::TObject => {}
                         _ => {
-                            let (line, col_start) = self.offset_to_line_col_utf16(stmt.span.start);
+                            let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                             let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) =
-                                    self.offset_to_line_col_utf16(stmt.span.end);
+                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
                                 end_col
                             } else {
                                 col_start
@@ -447,11 +442,10 @@ impl<'a> StatementsAnalyzer<'a> {
 
                 // Emit RedundantCondition if narrowing proves one branch is statically unreachable.
                 if !pre_diverges && (then_ctx.diverges || else_ctx.diverges) {
-                    let (line, col_start) =
-                        self.offset_to_line_col_utf16(if_stmt.condition.span.start);
+                    let (line, col_start) = self.offset_to_line_col(if_stmt.condition.span.start);
                     let col_end = if if_stmt.condition.span.start < if_stmt.condition.span.end {
                         let (_end_line, end_col) =
-                            self.offset_to_line_col_utf16(if_stmt.condition.span.end);
+                            self.offset_to_line_col(if_stmt.condition.span.end);
                         end_col
                     } else {
                         col_start
@@ -858,31 +852,25 @@ impl<'a> StatementsAnalyzer<'a> {
         )
     }
 
-    /// Convert a byte offset to a UTF-16 column on a given line.
-    /// Returns (line, col_utf16) where col is 0-based UTF-16 code unit count.
-    fn offset_to_line_col_utf16(&self, offset: u32) -> (u32, u16) {
+    /// Convert a byte offset to a Unicode char-count column on a given line.
+    /// Returns (line, col) where col is a 0-based Unicode code-point count.
+    fn offset_to_line_col(&self, offset: u32) -> (u32, u16) {
         let lc = self.source_map.offset_to_line_col(offset);
         let line = lc.line + 1;
 
-        // Find the start of the line containing this offset
         let byte_offset = offset as usize;
         let line_start_byte = if byte_offset == 0 {
             0
         } else {
-            // Find the position after the last newline before this offset
             self.source[..byte_offset]
                 .rfind('\n')
                 .map(|p| p + 1)
                 .unwrap_or(0)
         };
 
-        // Count UTF-16 code units from line start to the offset
-        let col_utf16 = self.source[line_start_byte..byte_offset]
-            .chars()
-            .map(|c| c.len_utf16() as u16)
-            .sum();
+        let col = self.source[line_start_byte..byte_offset].chars().count() as u16;
 
-        (line, col_utf16)
+        (line, col)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -62,7 +62,7 @@ pub struct Location {
     pub end: u32,
     /// 1-based line number of the declaration.
     pub line: u32,
-    /// 0-based UTF-16 column offset of the declaration start.
+    /// 0-based Unicode char-count (code-point) column offset of the declaration start.
     pub col: u16,
 }
 

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -62,7 +62,7 @@ pub struct Location {
     pub end: u32,
     /// 1-based line number of the declaration.
     pub line: u32,
-    /// 0-based column offset of the declaration.
+    /// 0-based UTF-16 column offset of the declaration start.
     pub col: u16,
 }
 

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -36,7 +36,9 @@ impl fmt::Display for Severity {
 pub struct Location {
     pub file: Arc<str>,
     pub line: u32,
+    /// 0-based Unicode char-count (code-point) column of the issue start.
     pub col_start: u16,
+    /// 0-based Unicode char-count (code-point) column of the issue end (exclusive).
     pub col_end: u16,
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,24 @@ git submodule update --remote crates/mir-analyzer/phpstorm-stubs
 
 A smaller set of Rust-coded stubs in `crates/mir-analyzer/src/stubs.rs` runs after phpstorm-stubs and overrides or extends where precise parameter shapes matter (e.g. by-reference variadic params on `sscanf`, PHPUnit assertion helpers).
 
+## Column encoding convention
+
+Source positions flow through several layers, each with a different encoding responsibility:
+
+| Layer | Crate | Encoding | Notes |
+|-------|-------|----------|-------|
+| Parser | `php-rs-parser` | UTF-8 byte offset | `offset_to_line_col` returns the raw byte distance from the line start. Correct for a parser; consumers must convert. |
+| Core data model | `mir-issues`, `mir-codebase` | **Unicode char count** | `IssueLocation.col_start`/`col_end` and `Location.col` are 0-based counts of Unicode code points (one slot per character as seen on screen). |
+| CLI output | `mir-cli` | Unicode char count (direct) | Column numbers in terminal, GitHub Actions annotations, and JSON output match what editors display in their status bar. |
+| LSP server | `mir-lsp` (separate crate) | UTF-16 code units | The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) requires UTF-16. Convert at the protocol boundary: `src[line_start..byte_offset].chars().map(|c| c.len_utf16()).sum()`. LSP 3.17 also supports `positionEncoding` negotiation for UTF-8 and UTF-32. |
+
+For pure-ASCII PHP files all three encodings are identical. They diverge only for multi-byte identifiers:
+
+- **Accented Latin / Cyrillic / CJK** (e.g. `$café`) — UTF-8 bytes > char count = UTF-16 units.
+- **Emoji / supplementary-plane characters** (e.g. `$🎉`) — UTF-8 bytes > UTF-16 units > char count.
+
+PHP 8 allows any Unicode letter in identifiers, so the distinction matters for correctness even if uncommon in practice.
+
 ## Crate layout
 
 | Crate | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ Source positions flow through several layers, each with a different encoding res
 | Parser | `php-rs-parser` | UTF-8 byte offset | `offset_to_line_col` returns the raw byte distance from the line start. Correct for a parser; consumers must convert. |
 | Core data model | `mir-issues`, `mir-codebase` | **Unicode char count** | `IssueLocation.col_start`/`col_end` and `Location.col` are 0-based counts of Unicode code points (one slot per character as seen on screen). |
 | CLI output | `mir-cli` | Unicode char count (direct) | Column numbers in terminal, GitHub Actions annotations, and JSON output match what editors display in their status bar. |
-| LSP server | `mir-lsp` (separate crate) | UTF-16 code units | The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) requires UTF-16. Convert at the protocol boundary: `src[line_start..byte_offset].chars().map(|c| c.len_utf16()).sum()`. LSP 3.17 also supports `positionEncoding` negotiation for UTF-8 and UTF-32. |
+| LSP server | _(outside mir)_ | UTF-16 code units | The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) requires UTF-16. Convert at the protocol boundary: `src[line_start..byte_offset].chars().map(|c| c.len_utf16()).sum()`. LSP 3.17 also supports `positionEncoding` negotiation for UTF-8 and UTF-32. |
 
 For pure-ASCII PHP files all three encodings are identical. They diverge only for multi-byte identifiers:
 


### PR DESCRIPTION
## Summary

- **Columns in `mir-issues` and `mir-codebase` now store Unicode char-count (code-point) values** instead of UTF-16 code units. For all BMP characters (accented Latin, Cyrillic, CJK, etc.) the values are identical. The only observable difference is for supplementary-plane characters like emoji, where UTF-16 gives 2 but char-count gives 1 — matching what editors and terminals display.
- Renamed `offset_to_line_col_utf16` → `offset_to_line_col` in `stmt.rs`, `expr.rs`, and `project.rs`; fixed the accumulator from `.map(|c| c.len_utf16()).sum()` to `.chars().count()`.
- Fixed `class.rs` `issue_location()` which was re-deriving columns from byte offsets using the same UTF-16 accumulator.
- Fixed `collector.rs` `issue_location()` (dead code) which was using the raw UTF-8 byte offset from the parser.
- Added a **Column encoding convention** section to `docs/architecture.md` documenting the encoding at each layer (parser → core → CLI → LSP).
- Updated CHANGELOG.

## Why UTF-16 was wrong here

UTF-16 is required by the **LSP protocol** — but `mir-issues` and `mir-codebase` are the core data model, not the protocol layer. The LSP crate should convert char-count → UTF-16 at the protocol boundary. CLI output and GitHub Actions annotations expect human-visible column numbers (one per character on screen).

## Test plan

- [ ] All 291 existing tests pass (`cargo test`)
- [ ] New tests in `expr.rs`:
  - `col_conversion_emoji_counts_as_one_char` — asserts position after `🎉` is col 7, not col 8 (the key UTF-16 vs char-count difference)
  - `col_conversion_emoji_start_position` — asserts quote and emoji are at expected char-count columns
  - Renamed `utf16_conversion_*` tests to `col_conversion_*` to match the new semantics