### PR TITLE
perf: remove all_methods cache — walk inheritance at lookup time

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -144,19 +144,25 @@ impl<'a> ClassAnalyzer<'a> {
 
         // Walk every ancestor class and collect abstract methods
         for ancestor_fqcn in &cls.all_parents {
-            let ancestor = match self.codebase.classes.get(ancestor_fqcn.as_ref()) {
-                Some(a) => a,
-                None => continue,
+            // Collect abstract method names first, then drop the DashMap guard before
+            // calling get_method (which re-enters the same DashMap).
+            let abstract_methods: Vec<Arc<str>> = {
+                let Some(ancestor) = self.codebase.classes.get(ancestor_fqcn.as_ref()) else {
+                    continue;
+                };
+                ancestor
+                    .own_methods
+                    .iter()
+                    .filter(|(_, m)| m.is_abstract)
+                    .map(|(name, _)| name.clone())
+                    .collect()
             };
 
-            for (method_name, method) in &ancestor.own_methods {
-                if !method.is_abstract {
-                    continue;
-                }
-
+            for method_name in abstract_methods {
                 // Check if the concrete class (or any closer ancestor) provides it
-                if cls
-                    .get_method(method_name.as_ref())
+                if self
+                    .codebase
+                    .get_method(fqcn.as_ref(), method_name.as_ref())
                     .map(|m| !m.is_abstract)
                     .unwrap_or(false)
                 {
@@ -205,19 +211,23 @@ impl<'a> ClassAnalyzer<'a> {
             .collect();
 
         for iface_fqcn in &all_ifaces {
-            let iface = match self.codebase.interfaces.get(iface_fqcn.as_ref()) {
-                Some(i) => i,
-                None => continue,
-            };
+            // Collect method names first, then drop the interface guard before calling
+            // get_method (which re-enters self.codebase.interfaces when walking ancestors).
+            let method_names: Vec<Arc<str>> =
+                match self.codebase.interfaces.get(iface_fqcn.as_ref()) {
+                    Some(iface) => iface.own_methods.keys().cloned().collect(),
+                    None => continue,
+                };
 
-            for (method_name, _method) in &iface.own_methods {
+            for method_name in method_names {
                 // PHP method names are case-insensitive; normalize before lookup so that
                 // a hand-written stub key like "jsonSerialize" matches the collector's
-                // lowercased key "jsonserialize" stored in cls.all_methods.
+                // lowercased key "jsonserialize" stored in own_methods.
                 let method_name_lower = method_name.to_lowercase();
                 // Check if the class provides a concrete implementation
-                let implemented = cls
-                    .get_method(&method_name_lower)
+                let implemented = self
+                    .codebase
+                    .get_method(fqcn.as_ref(), &method_name_lower)
                     .map(|m| !m.is_abstract)
                     .unwrap_or(false);
 

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -556,7 +556,6 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     is_abstract: decl.modifiers.is_abstract,
                     is_final: decl.modifiers.is_final,
                     is_readonly: decl.modifiers.is_readonly,
-                    all_methods: indexmap::IndexMap::new(),
                     all_parents: vec![],
                     is_deprecated: class_doc.is_deprecated,
                     is_internal: class_doc.is_internal,

--- a/crates/mir-analyzer/src/stubs.rs
+++ b/crates/mir-analyzer/src/stubs.rs
@@ -3234,7 +3234,6 @@ fn empty_class(
         is_abstract: false,
         is_final: false,
         is_readonly: false,
-        all_methods: indexmap::IndexMap::new(),
         all_parents: vec![],
         is_deprecated: false,
         is_internal: false,

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -25,6 +25,22 @@ use mir_types::Union;
 // Private helper — shared insert logic for reference tracking
 // ---------------------------------------------------------------------------
 
+/// Case-insensitive method lookup within a single `own_methods` map.
+///
+/// Tries an exact key match first (O(1)), then falls back to a linear
+/// case-insensitive scan for stubs that store keys in original case.
+#[inline]
+fn lookup_method<'a>(
+    map: &'a indexmap::IndexMap<Arc<str>, MethodStorage>,
+    name: &str,
+) -> Option<&'a MethodStorage> {
+    map.get(name).or_else(|| {
+        map.iter()
+            .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
+            .map(|(_, v)| v)
+    })
+}
+
 /// Append `(sym_id, file_id, start, end)` to the reference index, skipping
 /// exact duplicates so union receivers like `Foo|Foo->method()` don't inflate
 /// the span list.
@@ -419,63 +435,87 @@ impl Codebase {
         None
     }
 
-    /// Resolve a method, walking up the inheritance chain.
+    /// Resolve a method, walking up the full inheritance chain (own → traits → ancestors).
     pub fn get_method(&self, fqcn: &str, method_name: &str) -> Option<MethodStorage> {
         // PHP method names are case-insensitive — normalize to lowercase for all lookups.
         let method_lower = method_name.to_lowercase();
         let method_name = method_lower.as_str();
-        // Check class methods first
+
+        // --- Class: own methods → own traits → ancestor classes/traits/interfaces ---
         if let Some(cls) = self.classes.get(fqcn) {
-            if let Some(m) = cls.get_method(method_name) {
+            // 1. Own methods (highest priority)
+            if let Some(m) = lookup_method(&cls.own_methods, method_name) {
                 return Some(m.clone());
             }
-        }
-        // Check interface methods (including parent interfaces via all_parents)
-        if let Some(iface) = self.interfaces.get(fqcn) {
-            if let Some(m) = iface.own_methods.get(method_name).or_else(|| {
-                iface
-                    .own_methods
-                    .iter()
-                    .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(method_name))
-                    .map(|(_, v)| v)
-            }) {
-                return Some(m.clone());
-            }
-            // Traverse parent interfaces
-            let parents = iface.all_parents.clone();
-            for parent_fqcn in &parents {
-                if let Some(parent_iface) = self.interfaces.get(parent_fqcn.as_ref()) {
-                    if let Some(m) = parent_iface.own_methods.get(method_name).or_else(|| {
-                        parent_iface
-                            .own_methods
-                            .iter()
-                            .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(method_name))
-                            .map(|(_, v)| v)
-                    }) {
+            // Collect chain info before dropping the DashMap guard.
+            let own_traits = cls.traits.clone();
+            let ancestors = cls.all_parents.clone();
+            drop(cls);
+
+            // 2. Own trait methods
+            for tr_fqcn in &own_traits {
+                if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
+                    if let Some(m) = lookup_method(&tr.own_methods, method_name) {
                         return Some(m.clone());
                     }
                 }
             }
+
+            // 3. Ancestor chain (all_parents is closest-first: parent, grandparent, …)
+            for ancestor_fqcn in &ancestors {
+                if let Some(anc) = self.classes.get(ancestor_fqcn.as_ref()) {
+                    if let Some(m) = lookup_method(&anc.own_methods, method_name) {
+                        return Some(m.clone());
+                    }
+                    let anc_traits = anc.traits.clone();
+                    drop(anc);
+                    for tr_fqcn in &anc_traits {
+                        if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
+                            if let Some(m) = lookup_method(&tr.own_methods, method_name) {
+                                return Some(m.clone());
+                            }
+                        }
+                    }
+                } else if let Some(iface) = self.interfaces.get(ancestor_fqcn.as_ref()) {
+                    if let Some(m) = lookup_method(&iface.own_methods, method_name) {
+                        let mut m = m.clone();
+                        m.is_abstract = true;
+                        return Some(m);
+                    }
+                }
+                // Traits listed in all_parents are already covered via their owning class above.
+            }
+            return None;
         }
-        // Check trait methods (when a variable is annotated with a trait type)
-        if let Some(tr) = self.traits.get(fqcn) {
-            if let Some(m) = tr.own_methods.get(method_name).or_else(|| {
-                tr.own_methods
-                    .iter()
-                    .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(method_name))
-                    .map(|(_, v)| v)
-            }) {
+
+        // --- Interface: own methods + parent interfaces ---
+        if let Some(iface) = self.interfaces.get(fqcn) {
+            if let Some(m) = lookup_method(&iface.own_methods, method_name) {
                 return Some(m.clone());
             }
+            let parents = iface.all_parents.clone();
+            drop(iface);
+            for parent_fqcn in &parents {
+                if let Some(parent_iface) = self.interfaces.get(parent_fqcn.as_ref()) {
+                    if let Some(m) = lookup_method(&parent_iface.own_methods, method_name) {
+                        return Some(m.clone());
+                    }
+                }
+            }
+            return None;
         }
-        // Check enum methods
+
+        // --- Trait (variable annotated with a trait type) ---
+        if let Some(tr) = self.traits.get(fqcn) {
+            if let Some(m) = lookup_method(&tr.own_methods, method_name) {
+                return Some(m.clone());
+            }
+            return None;
+        }
+
+        // --- Enum ---
         if let Some(e) = self.enums.get(fqcn) {
-            if let Some(m) = e.own_methods.get(method_name).or_else(|| {
-                e.own_methods
-                    .iter()
-                    .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(method_name))
-                    .map(|(_, v)| v)
-            }) {
+            if let Some(m) = lookup_method(&e.own_methods, method_name) {
                 return Some(m.clone());
             }
             // PHP 8.1 built-in enum methods: cases(), from(), tryFrom()
@@ -501,6 +541,7 @@ impl Codebase {
                 });
             }
         }
+
         None
     }
 
@@ -572,37 +613,7 @@ impl Codebase {
     /// Returns true if the class (or any ancestor/trait) defines a `__get` magic method.
     /// Such classes allow arbitrary property access, suppressing UndefinedProperty.
     pub fn has_magic_get(&self, fqcn: &str) -> bool {
-        if let Some(cls) = self.classes.get(fqcn) {
-            if cls.own_methods.contains_key("__get") || cls.all_methods.contains_key("__get") {
-                return true;
-            }
-            // Check traits
-            let traits = cls.traits.clone();
-            drop(cls);
-            for tr in &traits {
-                if let Some(t) = self.traits.get(tr.as_ref()) {
-                    if t.own_methods.contains_key("__get") {
-                        return true;
-                    }
-                }
-            }
-            // Check ancestors
-            let all_parents = {
-                if let Some(c) = self.classes.get(fqcn) {
-                    c.all_parents.clone()
-                } else {
-                    vec![]
-                }
-            };
-            for ancestor in &all_parents {
-                if let Some(anc) = self.classes.get(ancestor.as_ref()) {
-                    if anc.own_methods.contains_key("__get") {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        self.get_method(fqcn, "__get").is_some()
     }
 
     /// Returns true if the class (or any of its ancestors) has a parent/interface/trait
@@ -1063,15 +1074,7 @@ impl Codebase {
             }
         }
 
-        // 2. Build method dispatch tables for classes (own methods override inherited)
-        for fqcn in &class_keys {
-            let all_methods = self.build_method_table(fqcn);
-            if let Some(mut cls) = self.classes.get_mut(fqcn.as_ref()) {
-                cls.all_methods = all_methods;
-            }
-        }
-
-        // 3. Resolve all_parents for interfaces
+        // 2. Resolve all_parents for interfaces
         let iface_keys: Vec<Arc<str>> = self.interfaces.iter().map(|e| e.key().clone()).collect();
         for fqcn in &iface_keys {
             let parents = self.collect_interface_ancestors(fqcn);
@@ -1156,76 +1159,6 @@ impl Codebase {
             out.push(e.clone());
             self.collect_interface_ancestors_inner(&e, out, visited);
         }
-    }
-
-    /// Build the full method dispatch table for a class, with own methods taking
-    /// priority over inherited ones.
-    fn build_method_table(&self, fqcn: &str) -> indexmap::IndexMap<Arc<str>, MethodStorage> {
-        use indexmap::IndexMap;
-        let mut table: IndexMap<Arc<str>, MethodStorage> = IndexMap::new();
-
-        // Walk ancestor chain (broad-first from root → child, so child overrides root)
-        let ancestors = {
-            if let Some(cls) = self.classes.get(fqcn) {
-                cls.all_parents.clone()
-            } else {
-                return table;
-            }
-        };
-
-        // Insert ancestor methods (deepest ancestor first, so closer ancestors override).
-        // Also insert trait methods from ancestor classes.
-        for ancestor_fqcn in ancestors.iter().rev() {
-            if let Some(ancestor) = self.classes.get(ancestor_fqcn.as_ref()) {
-                // First insert ancestor's own trait methods (lower priority)
-                let ancestor_traits = ancestor.traits.clone();
-                for trait_fqcn in ancestor_traits.iter().rev() {
-                    if let Some(tr) = self.traits.get(trait_fqcn.as_ref()) {
-                        for (name, method) in &tr.own_methods {
-                            table.insert(name.clone(), method.clone());
-                        }
-                    }
-                }
-                // Then ancestor's own methods (override trait methods)
-                for (name, method) in &ancestor.own_methods {
-                    table.insert(name.clone(), method.clone());
-                }
-            } else if let Some(iface) = self.interfaces.get(ancestor_fqcn.as_ref()) {
-                for (name, method) in &iface.own_methods {
-                    // Interface methods are implicitly abstract — mark them so that
-                    // ClassAnalyzer::check_interface_methods_implemented can detect
-                    // a concrete class that fails to provide an implementation.
-                    let mut m = method.clone();
-                    m.is_abstract = true;
-                    table.insert(name.clone(), m);
-                }
-            }
-        }
-
-        // Insert the class's own trait methods
-        let trait_list = {
-            if let Some(cls) = self.classes.get(fqcn) {
-                cls.traits.clone()
-            } else {
-                vec![]
-            }
-        };
-        for trait_fqcn in &trait_list {
-            if let Some(tr) = self.traits.get(trait_fqcn.as_ref()) {
-                for (name, method) in &tr.own_methods {
-                    table.insert(name.clone(), method.clone());
-                }
-            }
-        }
-
-        // Own methods override everything
-        if let Some(cls) = self.classes.get(fqcn) {
-            for (name, method) in &cls.own_methods {
-                table.insert(name.clone(), method.clone());
-            }
-        }
-
-        table
     }
 }
 

--- a/crates/mir-codebase/src/members.rs
+++ b/crates/mir-codebase/src/members.rs
@@ -67,23 +67,7 @@ impl Codebase {
     ) {
         // --- Class ---
         if let Some(cls) = self.classes.get(fqcn) {
-            // Methods: all_methods already includes inherited + trait methods.
-            for (name, method) in &cls.all_methods {
-                let key = (name.to_string(), MemberKind::Method);
-                if seen.insert(key) {
-                    out.push(MemberInfo {
-                        name: name.clone(),
-                        kind: MemberKind::Method,
-                        ty: method.effective_return_type().cloned(),
-                        visibility: method.visibility,
-                        is_static: method.is_static,
-                        declaring_class: method.fqcn.clone(),
-                        is_deprecated: method.is_deprecated,
-                        params: method.params.clone(),
-                    });
-                }
-            }
-            // Also check own_methods for anything not in all_methods
+            // Own methods (highest priority — first in, wins via `seen` dedup)
             for (name, method) in &cls.own_methods {
                 let key = (name.to_string(), MemberKind::Method);
                 if seen.insert(key) {
@@ -100,9 +84,12 @@ impl Codebase {
                 }
             }
 
-            // Properties: walk own + ancestors (all_parents includes parent chain + traits)
+            // Collect chain before dropping the DashMap guard.
+            let own_traits = cls.traits.clone();
             let all_parents = cls.all_parents.clone();
-            // Own properties first
+            let cls_fqcn = cls.fqcn.clone();
+
+            // Own properties and constants
             for (name, prop) in &cls.own_properties {
                 let key = (name.to_string(), MemberKind::Property);
                 if seen.insert(key) {
@@ -112,13 +99,12 @@ impl Codebase {
                         ty: prop.ty.clone().or_else(|| prop.inferred_ty.clone()),
                         visibility: prop.visibility,
                         is_static: prop.is_static,
-                        declaring_class: cls.fqcn.clone(),
+                        declaring_class: cls_fqcn.clone(),
                         is_deprecated: false,
                         params: vec![],
                     });
                 }
             }
-            // Own constants
             for (name, con) in &cls.own_constants {
                 let key = (name.to_string(), MemberKind::Constant);
                 if seen.insert(key) {
@@ -128,7 +114,7 @@ impl Codebase {
                         ty: Some(con.ty.clone()),
                         visibility: con.visibility.unwrap_or(Visibility::Public),
                         is_static: true,
-                        declaring_class: cls.fqcn.clone(),
+                        declaring_class: cls_fqcn.clone(),
                         is_deprecated: false,
                         params: vec![],
                     });
@@ -136,9 +122,60 @@ impl Codebase {
             }
             drop(cls);
 
-            // Ancestor properties and constants
+            // Own trait methods and properties
+            for tr_fqcn in &own_traits {
+                if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
+                    for (name, method) in &tr.own_methods {
+                        let key = (name.to_string(), MemberKind::Method);
+                        if seen.insert(key) {
+                            out.push(MemberInfo {
+                                name: name.clone(),
+                                kind: MemberKind::Method,
+                                ty: method.effective_return_type().cloned(),
+                                visibility: method.visibility,
+                                is_static: method.is_static,
+                                declaring_class: method.fqcn.clone(),
+                                is_deprecated: method.is_deprecated,
+                                params: method.params.clone(),
+                            });
+                        }
+                    }
+                    for (name, prop) in &tr.own_properties {
+                        let key = (name.to_string(), MemberKind::Property);
+                        if seen.insert(key) {
+                            out.push(MemberInfo {
+                                name: name.clone(),
+                                kind: MemberKind::Property,
+                                ty: prop.ty.clone().or_else(|| prop.inferred_ty.clone()),
+                                visibility: prop.visibility,
+                                is_static: prop.is_static,
+                                declaring_class: tr.fqcn.clone(),
+                                is_deprecated: false,
+                                params: vec![],
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Ancestor classes, their traits, and interfaces from all_parents
             for ancestor_fqcn in &all_parents {
                 if let Some(ancestor) = self.classes.get(ancestor_fqcn.as_ref()) {
+                    for (name, method) in &ancestor.own_methods {
+                        let key = (name.to_string(), MemberKind::Method);
+                        if seen.insert(key) {
+                            out.push(MemberInfo {
+                                name: name.clone(),
+                                kind: MemberKind::Method,
+                                ty: method.effective_return_type().cloned(),
+                                visibility: method.visibility,
+                                is_static: method.is_static,
+                                declaring_class: method.fqcn.clone(),
+                                is_deprecated: method.is_deprecated,
+                                params: method.params.clone(),
+                            });
+                        }
+                    }
                     for (name, prop) in &ancestor.own_properties {
                         let key = (name.to_string(), MemberKind::Property);
                         if seen.insert(key) {
@@ -169,53 +206,75 @@ impl Codebase {
                             });
                         }
                     }
-                }
-                // Trait properties
-                if let Some(tr) = self.traits.get(ancestor_fqcn.as_ref()) {
-                    for (name, prop) in &tr.own_properties {
-                        let key = (name.to_string(), MemberKind::Property);
+                    let anc_traits = ancestor.traits.clone();
+                    drop(ancestor);
+                    for tr_fqcn in &anc_traits {
+                        if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
+                            for (name, method) in &tr.own_methods {
+                                let key = (name.to_string(), MemberKind::Method);
+                                if seen.insert(key) {
+                                    out.push(MemberInfo {
+                                        name: name.clone(),
+                                        kind: MemberKind::Method,
+                                        ty: method.effective_return_type().cloned(),
+                                        visibility: method.visibility,
+                                        is_static: method.is_static,
+                                        declaring_class: method.fqcn.clone(),
+                                        is_deprecated: method.is_deprecated,
+                                        params: method.params.clone(),
+                                    });
+                                }
+                            }
+                            for (name, prop) in &tr.own_properties {
+                                let key = (name.to_string(), MemberKind::Property);
+                                if seen.insert(key) {
+                                    out.push(MemberInfo {
+                                        name: name.clone(),
+                                        kind: MemberKind::Property,
+                                        ty: prop.ty.clone().or_else(|| prop.inferred_ty.clone()),
+                                        visibility: prop.visibility,
+                                        is_static: prop.is_static,
+                                        declaring_class: tr.fqcn.clone(),
+                                        is_deprecated: false,
+                                        params: vec![],
+                                    });
+                                }
+                            }
+                        }
+                    }
+                } else if let Some(iface) = self.interfaces.get(ancestor_fqcn.as_ref()) {
+                    for (name, method) in &iface.own_methods {
+                        let key = (name.to_string(), MemberKind::Method);
                         if seen.insert(key) {
                             out.push(MemberInfo {
                                 name: name.clone(),
-                                kind: MemberKind::Property,
-                                ty: prop.ty.clone().or_else(|| prop.inferred_ty.clone()),
-                                visibility: prop.visibility,
-                                is_static: prop.is_static,
-                                declaring_class: tr.fqcn.clone(),
+                                kind: MemberKind::Method,
+                                ty: method.effective_return_type().cloned(),
+                                visibility: method.visibility,
+                                is_static: method.is_static,
+                                declaring_class: method.fqcn.clone(),
+                                is_deprecated: method.is_deprecated,
+                                params: method.params.clone(),
+                            });
+                        }
+                    }
+                    for (name, con) in &iface.own_constants {
+                        let key = (name.to_string(), MemberKind::Constant);
+                        if seen.insert(key) {
+                            out.push(MemberInfo {
+                                name: name.clone(),
+                                kind: MemberKind::Constant,
+                                ty: Some(con.ty.clone()),
+                                visibility: con.visibility.unwrap_or(Visibility::Public),
+                                is_static: true,
+                                declaring_class: iface.fqcn.clone(),
                                 is_deprecated: false,
                                 params: vec![],
                             });
                         }
                     }
                 }
-            }
-
-            // Trait properties for directly-used traits (not in all_parents)
-            let traits = {
-                if let Some(cls) = self.classes.get(fqcn) {
-                    cls.traits.clone()
-                } else {
-                    vec![]
-                }
-            };
-            for trait_fqcn in &traits {
-                if let Some(tr) = self.traits.get(trait_fqcn.as_ref()) {
-                    for (name, prop) in &tr.own_properties {
-                        let key = (name.to_string(), MemberKind::Property);
-                        if seen.insert(key) {
-                            out.push(MemberInfo {
-                                name: name.clone(),
-                                kind: MemberKind::Property,
-                                ty: prop.ty.clone().or_else(|| prop.inferred_ty.clone()),
-                                visibility: prop.visibility,
-                                is_static: prop.is_static,
-                                declaring_class: tr.fqcn.clone(),
-                                is_deprecated: false,
-                                params: vec![],
-                            });
-                        }
-                    }
-                }
+                // Traits in all_parents are already covered via their owning class's .traits above.
             }
 
             return;
@@ -404,7 +463,6 @@ mod tests {
                 is_abstract: false,
                 is_final: false,
                 is_readonly: false,
-                all_methods: IndexMap::new(),
                 all_parents: vec![],
                 is_deprecated: false,
                 is_internal: false,
@@ -433,7 +491,6 @@ mod tests {
                 is_abstract: false,
                 is_final: false,
                 is_readonly: false,
-                all_methods: IndexMap::new(),
                 all_parents: vec![],
                 is_deprecated: false,
                 is_internal: false,
@@ -477,7 +534,6 @@ mod tests {
                 is_abstract: false,
                 is_final: false,
                 is_readonly: false,
-                all_methods: IndexMap::new(),
                 all_parents: vec![],
                 is_deprecated: false,
                 is_internal: false,
@@ -502,7 +558,6 @@ mod tests {
                 is_abstract: false,
                 is_final: false,
                 is_readonly: false,
-                all_methods: IndexMap::new(),
                 all_parents: vec![],
                 is_deprecated: false,
                 is_internal: false,

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -187,8 +187,6 @@ pub struct ClassStorage {
     pub is_abstract: bool,
     pub is_final: bool,
     pub is_readonly: bool,
-    /// Populated during codebase finalization: all inherited methods (parent chain + traits).
-    pub all_methods: IndexMap<Arc<str>, MethodStorage>,
     /// Populated during finalization: all ancestor FQCNs (parents + interfaces, transitively).
     pub all_parents: Vec<Arc<str>>,
     pub is_deprecated: bool,
@@ -199,25 +197,13 @@ pub struct ClassStorage {
 impl ClassStorage {
     pub fn get_method(&self, name: &str) -> Option<&MethodStorage> {
         // PHP method names are case-insensitive; caller should pass lowercase name.
-        // Fast path: exact match (works when keys are stored lowercase).
-        if let Some(m) = self
-            .all_methods
-            .get(name)
-            .or_else(|| self.own_methods.get(name))
-        {
-            return Some(m);
-        }
-        // Fallback: case-insensitive scan (handles stubs stored with original case).
-        self.all_methods
-            .iter()
-            .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
-            .map(|(_, v)| v)
-            .or_else(|| {
-                self.own_methods
-                    .iter()
-                    .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
-                    .map(|(_, v)| v)
-            })
+        // Only searches own_methods — inherited method resolution is done by Codebase::get_method.
+        self.own_methods.get(name).or_else(|| {
+            self.own_methods
+                .iter()
+                .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
+                .map(|(_, v)| v)
+        })
     }
 
     pub fn get_property(&self, name: &str) -> Option<&PropertyStorage> {


### PR DESCRIPTION
## Summary

- Removes `ClassStorage::all_methods`, an `IndexMap` that stored a full clone of every inherited `MethodStorage` for every class
- Method resolution now walks `all_parents` + traits at lookup time in `Codebase::get_method` (own → own traits → ancestor own methods → ancestor traits → interface methods)
- Removes `build_method_table()` and step 2 from `finalize()` — no more O(N×depth) cloning at startup
- Simplifies `has_magic_get()` to `self.get_method(fqcn, "__get").is_some()`
- Fixes `class.rs` to collect method names before dropping DashMap guards, avoiding potential shard deadlocks

## Memory impact

Every `ClassStorage` previously materialised a complete copy of all inherited methods. For a class inheriting from 10 ancestors averaging 20 methods each, that was ~200 cloned `MethodStorage` objects (~200 bytes each ≈ 40 KB) per class. The saving is largest for phpstorm-stubs classes, which form deep hierarchies and were all eagerly finalized on startup.

## Trade-off

`get_method` goes from O(1) map lookup to O(depth × methods) walk. In practice depth is rarely more than 5–8 levels and the walk short-circuits on first match. The memory saving outweighs the lookup cost for CLI batch analysis.

## Test plan

- All 323 tests pass
- `cargo clippy` clean