### PR TITLE
perf: skip full re-analysis in re_analyze_file when content is unchanged

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -458,6 +458,20 @@ impl ProjectAnalyzer {
     /// 4. Re-runs Pass 2 (body analysis) on this file
     /// 5. Returns the analysis result for this file only
     pub fn re_analyze_file(&self, file_path: &str, new_content: &str) -> AnalysisResult {
+        // Fast path: content unchanged and cache has a valid entry — skip full re-analysis.
+        if let Some(cache) = &self.cache {
+            let h = hash_content(new_content);
+            if let Some((issues, ref_locs)) = cache.get(file_path, &h) {
+                let file: Arc<str> = Arc::from(file_path);
+                self.codebase.replay_reference_locations(file, &ref_locs);
+                return AnalysisResult {
+                    issues,
+                    type_envs: HashMap::new(),
+                    symbols: Default::default(),
+                };
+            }
+        }
+
         // 1. Remove old definitions from this file
         self.codebase.remove_file_definitions(file_path);
 

--- a/crates/mir-analyzer/tests/incremental_reanalysis.rs
+++ b/crates/mir-analyzer/tests/incremental_reanalysis.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use mir_analyzer::ProjectAnalyzer;
 use tempfile::TempDir;
@@ -134,4 +135,70 @@ fn re_analyze_file_fixes_error() {
         .filter(|i| i.kind.name() == "UndefinedFunction")
         .count();
     assert_eq!(undef_count2, 0, "after fix, no UndefinedFunction expected");
+}
+
+/// Verify that `re_analyze_file` takes the content-hash fast path when the
+/// cache already holds a valid entry for the unchanged content.
+///
+/// Strategy: after the initial analysis caches an `UndefinedFunction` issue,
+/// we manually insert the "missing" function into the codebase so that a slow-
+/// path re-analysis would find it and return *no* issues.  Re-analyzing with
+/// the same content then lets us distinguish the two paths:
+/// - fast path (cache hit)  → cached `UndefinedFunction` issue still returned
+/// - slow path (re-analyze) → no issue (function now exists in codebase)
+#[test]
+fn re_analyze_file_uses_cache_on_unchanged_content() {
+    let src_dir = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+
+    // Content that calls an undefined function → produces UndefinedFunction
+    let content = "<?php\nfunction test(): void { ghost_fn(); }\n";
+    let file_a = write(&src_dir, "A.php", content);
+    let file_path = file_a.to_string_lossy().to_string();
+
+    let analyzer = ProjectAnalyzer::with_cache(cache_dir.path());
+    let result1 = analyzer.analyze(std::slice::from_ref(&file_a));
+
+    let undef_count = result1
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert!(
+        undef_count > 0,
+        "initial analysis should report UndefinedFunction"
+    );
+
+    // Insert ghost_fn() into the codebase so a slow-path re-analysis would
+    // find it and produce no issues.
+    analyzer.codebase().functions.insert(
+        Arc::from("ghost_fn"),
+        mir_codebase::FunctionStorage {
+            fqn: Arc::from("ghost_fn"),
+            short_name: Arc::from("ghost_fn"),
+            params: vec![],
+            return_type: None,
+            inferred_return_type: None,
+            template_params: vec![],
+            assertions: vec![],
+            throws: vec![],
+            is_deprecated: false,
+            is_pure: false,
+            location: None,
+        },
+    );
+
+    // Re-analyze with identical content — must hit the cache.
+    let result2 = analyzer.re_analyze_file(&file_path, content);
+
+    let undef_count2 = result2
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .count();
+    assert_eq!(
+        undef_count2, undef_count,
+        "cache hit should return the same cached issues; slow-path would return 0 \
+         because ghost_fn was inserted into the codebase"
+    );
 }


### PR DESCRIPTION
## Problem

`re_analyze_file` (the LSP incremental analysis path) had no content-hash check. Even when the file content was identical to the last save, it always called:

1. `remove_file_definitions` → `invalidate_finalization()`
2. Pass 1 (definition collection)
3. `finalize()` — re-walks **all** classes including stubs
4. Pass 2 (body analysis)

This made repeated LSP saves on an unchanged file as expensive as a full re-analysis.

## Solution

Add a content-hash fast path at the top of `re_analyze_file`: if the cache holds a valid entry for the `(file, hash)` pair, replay the cached reference locations and return the cached issues immediately — skipping all four steps above.

## Test

Added `re_analyze_file_uses_cache_on_unchanged_content` to `tests/incremental_reanalysis.rs`. The test distinguishes the two paths by injecting a function into the codebase after the initial cache population:

- **Fast path (cache hit):** returns the cached `UndefinedFunction` issue
- **Slow path (re-analysis):** finds the injected function, returns zero issues → assertion fails

This ensures the test will catch any future regression that removes the fast path.