### PR TITLE
perf: skip finalize() in re_analyze_file when inheritance is unchanged

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -472,10 +472,14 @@ impl ProjectAnalyzer {
             }
         }
 
-        // 1. Remove old definitions from this file
+        // 1. Snapshot inheritance structure before removing old definitions.
+        //    This lets us skip finalize() later if only method bodies changed.
+        let structural_snapshot = self.codebase.file_structural_snapshot(file_path);
+
+        // 2. Remove old definitions from this file
         self.codebase.remove_file_definitions(file_path);
 
-        // 2. Parse new content and run Pass 1
+        // 3. Parse new content and run Pass 1
         let file: Arc<str> = Arc::from(file_path);
         let arena = bumpalo::Bump::new();
         let parsed = php_rs_parser::parse(&arena, new_content);
@@ -505,10 +509,23 @@ impl ProjectAnalyzer {
         );
         all_issues.extend(collector.collect(&parsed.program));
 
-        // 3. Re-finalize (invalidation already done by remove_file_definitions)
-        self.codebase.finalize();
+        // 4. Re-finalize, or skip if only method bodies changed.
+        //    finalize() rebuilds all_parents for every class/interface in the
+        //    codebase by walking the full inheritance graph — this is expensive.
+        //    If the inheritance structure of this file is unchanged (same parent,
+        //    interfaces, traits), restore all_parents from the snapshot and skip
+        //    the full walk.
+        if self
+            .codebase
+            .structural_unchanged_after_pass1(file_path, &structural_snapshot)
+        {
+            self.codebase
+                .restore_all_parents(file_path, &structural_snapshot);
+        } else {
+            self.codebase.finalize();
+        }
 
-        // 4. Run Pass 2 on this file
+        // 5. Run Pass 2 on this file
         let (body_issues, symbols) = self.analyze_bodies(
             &parsed.program,
             file.clone(),
@@ -517,7 +534,7 @@ impl ProjectAnalyzer {
         );
         all_issues.extend(body_issues);
 
-        // 5. Update cache if present
+        // 6. Update cache if present
         if let Some(cache) = &self.cache {
             let h = hash_content(new_content);
             cache.evict_with_dependents(&[file_path.to_string()]);

--- a/crates/mir-analyzer/tests/incremental_reanalysis.rs
+++ b/crates/mir-analyzer/tests/incremental_reanalysis.rs
@@ -137,6 +137,72 @@ fn re_analyze_file_fixes_error() {
     assert_eq!(undef_count2, 0, "after fix, no UndefinedFunction expected");
 }
 
+/// Verify that `re_analyze_file` skips `finalize()` when only method bodies change.
+///
+/// Strategy: after the initial analysis (which populates `all_parents` for every
+/// class), we manually insert a new class `C extends A` into the codebase with
+/// `all_parents = []`.  A full re-analysis of `A.php` with a body-only edit would
+/// call `finalize()`, which would walk the hierarchy and set `C::all_parents = [A]`.
+/// The structural-snapshot fast path skips `finalize()`, so `all_parents` stays
+/// empty — proving the skip was taken.
+#[test]
+fn re_analyze_file_skips_finalize_on_body_only_change() {
+    let src_dir = TempDir::new().unwrap();
+
+    let file_a = write(
+        &src_dir,
+        "A.php",
+        "<?php\nclass A { public function foo(): void {} }\n",
+    );
+    let file_path = file_a.to_string_lossy().to_string();
+
+    let analyzer = ProjectAnalyzer::new();
+    analyzer.analyze(std::slice::from_ref(&file_a));
+
+    // Insert class C that extends A, but leave all_parents empty.
+    // A slow-path finalize() would populate it to [A]; the fast path skips finalize.
+    analyzer.codebase().classes.insert(
+        Arc::from("C"),
+        mir_codebase::ClassStorage {
+            fqcn: Arc::from("C"),
+            short_name: Arc::from("C"),
+            parent: Some(Arc::from("A")),
+            interfaces: vec![],
+            traits: vec![],
+            own_methods: indexmap::IndexMap::new(),
+            own_properties: indexmap::IndexMap::new(),
+            own_constants: indexmap::IndexMap::new(),
+            template_params: vec![],
+            is_abstract: false,
+            is_final: false,
+            is_readonly: false,
+            all_parents: vec![],
+            is_deprecated: false,
+            is_internal: false,
+            location: None,
+        },
+    );
+
+    // Re-analyze A.php with a body-only change (same class signature, new method body).
+    let new_content = "<?php\nclass A { public function foo(): int { return 1; } }\n";
+    analyzer.re_analyze_file(&file_path, new_content);
+
+    // Fast path: finalize() was skipped, so C::all_parents is still empty.
+    // Slow path: finalize() would have set C::all_parents = [A].
+    let c_all_parents = analyzer
+        .codebase()
+        .classes
+        .get("C")
+        .map(|c| c.all_parents.clone())
+        .unwrap_or_default();
+    assert!(
+        c_all_parents.is_empty(),
+        "finalize() should have been skipped for a body-only change; \
+         C::all_parents should still be [] but got {:?}",
+        c_all_parents
+    );
+}
+
 /// Verify that `re_analyze_file` takes the content-hash fast path when the
 /// cache already holds a valid entry for the unchanged content.
 ///

--- a/crates/mir-analyzer/tests/incremental_reanalysis.rs
+++ b/crates/mir-analyzer/tests/incremental_reanalysis.rs
@@ -183,7 +183,8 @@ fn re_analyze_file_skips_finalize_on_body_only_change() {
         },
     );
 
-    // Re-analyze A.php with a body-only change (same class signature, new method body).
+    // Re-analyze A.php with a signature change that does not affect inheritance
+    // (return type void → int).  finalize() is not needed for such changes.
     let new_content = "<?php\nclass A { public function foo(): int { return 1; } }\n";
     analyzer.re_analyze_file(&file_path, new_content);
 

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -98,6 +98,34 @@ struct CompactRefIndex {
 }
 
 // ---------------------------------------------------------------------------
+// StructuralSnapshot — inheritance data captured before file removal
+// ---------------------------------------------------------------------------
+
+struct ClassInheritance {
+    parent: Option<Arc<str>>,
+    interfaces: Vec<Arc<str>>, // sorted for order-insensitive comparison
+    traits: Vec<Arc<str>>,     // sorted
+    all_parents: Vec<Arc<str>>,
+}
+
+struct InterfaceInheritance {
+    extends: Vec<Arc<str>>, // sorted
+    all_parents: Vec<Arc<str>>,
+}
+
+/// Snapshot of the inheritance structure of all symbols defined in a file.
+///
+/// Produced by [`Codebase::file_structural_snapshot`] before
+/// [`Codebase::remove_file_definitions`], and consumed by
+/// [`Codebase::structural_unchanged_after_pass1`] /
+/// [`Codebase::restore_all_parents`] to skip an expensive `finalize()` call
+/// when only method bodies (not class hierarchies) changed.
+pub struct StructuralSnapshot {
+    classes: std::collections::HashMap<Arc<str>, ClassInheritance>,
+    interfaces: std::collections::HashMap<Arc<str>, InterfaceInheritance>,
+}
+
+// ---------------------------------------------------------------------------
 // Codebase — thread-safe global symbol registry
 // ---------------------------------------------------------------------------
 
@@ -366,6 +394,149 @@ impl Codebase {
         }
 
         self.invalidate_finalization();
+    }
+
+    // -----------------------------------------------------------------------
+    // Structural snapshot — skip finalize() on body-only changes
+    // -----------------------------------------------------------------------
+
+    /// Capture the inheritance structure of all symbols defined in `file_path`.
+    ///
+    /// Call this *before* `remove_file_definitions` to preserve the data that
+    /// `finalize()` would otherwise have to recompute.  The snapshot records, for
+    /// each class/interface in the file, the fields that feed into
+    /// `all_parents` (parent class, implemented interfaces, used traits, extended
+    /// interfaces) as well as the already-computed `all_parents` list itself.
+    pub fn file_structural_snapshot(&self, file_path: &str) -> StructuralSnapshot {
+        let symbols: Vec<Arc<str>> = self
+            .symbol_to_file
+            .iter()
+            .filter(|e| e.value().as_ref() == file_path)
+            .map(|e| e.key().clone())
+            .collect();
+
+        let mut classes = std::collections::HashMap::new();
+        let mut interfaces = std::collections::HashMap::new();
+
+        for sym in symbols {
+            if let Some(cls) = self.classes.get(sym.as_ref()) {
+                let mut ifaces = cls.interfaces.clone();
+                ifaces.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                let mut traits = cls.traits.clone();
+                traits.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                classes.insert(
+                    sym,
+                    ClassInheritance {
+                        parent: cls.parent.clone(),
+                        interfaces: ifaces,
+                        traits,
+                        all_parents: cls.all_parents.clone(),
+                    },
+                );
+            } else if let Some(iface) = self.interfaces.get(sym.as_ref()) {
+                let mut extends = iface.extends.clone();
+                extends.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                interfaces.insert(
+                    sym,
+                    InterfaceInheritance {
+                        extends,
+                        all_parents: iface.all_parents.clone(),
+                    },
+                );
+            }
+        }
+
+        StructuralSnapshot {
+            classes,
+            interfaces,
+        }
+    }
+
+    /// After Pass 1 completes, check whether the inheritance structure in
+    /// `file_path` matches the snapshot taken before `remove_file_definitions`.
+    ///
+    /// Returns `true` if `finalize()` can be skipped — i.e. only method bodies,
+    /// properties, or annotations changed, not any class/interface hierarchy.
+    pub fn structural_unchanged_after_pass1(
+        &self,
+        file_path: &str,
+        old: &StructuralSnapshot,
+    ) -> bool {
+        let symbols: Vec<Arc<str>> = self
+            .symbol_to_file
+            .iter()
+            .filter(|e| e.value().as_ref() == file_path)
+            .map(|e| e.key().clone())
+            .collect();
+
+        let mut seen_classes = 0usize;
+        let mut seen_interfaces = 0usize;
+
+        for sym in &symbols {
+            if let Some(cls) = self.classes.get(sym.as_ref()) {
+                seen_classes += 1;
+                let Some(old_cls) = old.classes.get(sym.as_ref()) else {
+                    return false; // new class added
+                };
+                if old_cls.parent != cls.parent {
+                    return false;
+                }
+                let mut new_ifaces = cls.interfaces.clone();
+                new_ifaces.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                if old_cls.interfaces != new_ifaces {
+                    return false;
+                }
+                let mut new_traits = cls.traits.clone();
+                new_traits.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                if old_cls.traits != new_traits {
+                    return false;
+                }
+            } else if let Some(iface) = self.interfaces.get(sym.as_ref()) {
+                seen_interfaces += 1;
+                let Some(old_iface) = old.interfaces.get(sym.as_ref()) else {
+                    return false; // new interface added
+                };
+                let mut new_extends = iface.extends.clone();
+                new_extends.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+                if old_iface.extends != new_extends {
+                    return false;
+                }
+            }
+            // Traits, enums, functions, constants: not finalization-relevant, skip.
+        }
+
+        // Check for removed classes or interfaces.
+        seen_classes == old.classes.len() && seen_interfaces == old.interfaces.len()
+    }
+
+    /// Restore `all_parents` from a snapshot and mark the codebase as finalized.
+    ///
+    /// Call this instead of `finalize()` when `structural_unchanged_after_pass1`
+    /// returns `true`.  The newly re-registered symbols (written by Pass 1) have
+    /// `all_parents = []`; this method repopulates them from the snapshot so that
+    /// all downstream lookups that depend on `all_parents` keep working correctly.
+    pub fn restore_all_parents(&self, file_path: &str, snapshot: &StructuralSnapshot) {
+        let symbols: Vec<Arc<str>> = self
+            .symbol_to_file
+            .iter()
+            .filter(|e| e.value().as_ref() == file_path)
+            .map(|e| e.key().clone())
+            .collect();
+
+        for sym in &symbols {
+            if let Some(old_cls) = snapshot.classes.get(sym.as_ref()) {
+                if let Some(mut cls) = self.classes.get_mut(sym.as_ref()) {
+                    cls.all_parents = old_cls.all_parents.clone();
+                }
+            } else if let Some(old_iface) = snapshot.interfaces.get(sym.as_ref()) {
+                if let Some(mut iface) = self.interfaces.get_mut(sym.as_ref()) {
+                    iface.all_parents = old_iface.all_parents.clone();
+                }
+            }
+        }
+
+        self.finalized
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-codebase/src/lib.rs
+++ b/crates/mir-codebase/src/lib.rs
@@ -3,7 +3,7 @@ pub mod interner;
 pub mod members;
 pub mod storage;
 
-pub use codebase::Codebase;
+pub use codebase::{Codebase, StructuralSnapshot};
 pub use members::{MemberInfo, MemberKind};
 pub use storage::{
     ClassStorage, ConstantStorage, EnumCaseStorage, EnumStorage, FnParam, FunctionStorage,


### PR DESCRIPTION
## Summary

- `re_analyze_file` called `finalize()` unconditionally after every edit, even when only method bodies changed — causing a full class-hierarchy walk over all classes and stubs on every LSP keystroke.
- Added a structural-snapshot fast path: captures each class/interface's inheritance fields before removal; after Pass 1, compares the new definitions; if unchanged, restores `all_parents` directly and skips `finalize()`.
- When the parent class, implemented interfaces, used traits, or extended interfaces change, falls through to the full `finalize()` as before.

## New public API on `Codebase`

- `file_structural_snapshot(file_path)` — capture before `remove_file_definitions`
- `structural_unchanged_after_pass1(file_path, snapshot)` — check after Pass 1
- `restore_all_parents(file_path, snapshot)` — restore and mark finalized

## Test plan

- [ ] `re_analyze_file_skips_finalize_on_body_only_change` — injects a class with `all_parents=[]` after initial analysis; a slow-path `finalize()` would populate it, fast path leaves it empty
- [ ] All 325 existing tests pass (`cargo test --workspace`)