### PR TITLE
fix(class): resolve methods from trait-of-trait chains

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -664,6 +664,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                 let mut own_methods = indexmap::IndexMap::new();
                 let mut own_properties = indexmap::IndexMap::new();
                 let mut own_constants = indexmap::IndexMap::new();
+                let mut trait_uses: Vec<Arc<str>> = vec![];
 
                 for member in decl.members.iter() {
                     match &member.kind {
@@ -731,7 +732,11 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 },
                             );
                         }
-                        ClassMemberKind::TraitUse(_) => {}
+                        ClassMemberKind::TraitUse(tu) => {
+                            for t in tu.traits.iter() {
+                                trait_uses.push(self.resolve_name(&name_to_string(t)).into());
+                            }
+                        }
                     }
                 }
 
@@ -747,6 +752,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                         own_properties,
                         own_constants,
                         template_params: trait_template_params,
+                        traits: trait_uses,
                         location: Some(self.location(stmt.span.start, stmt.span.end)),
                     },
                 );

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_not_reported.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+trait RunsTrait {
+    public function run(): void {}
+}
+abstract class Base implements Runnable {
+    use RunsTrait;
+}
+class Task extends Base {}
+===expect===
+

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_of_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_of_trait_not_reported.phpt
@@ -1,0 +1,17 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+trait ActualRunner {
+    public function run(): void {}
+}
+trait RunsTrait {
+    use ActualRunner;
+}
+abstract class Base implements Runnable {
+    use RunsTrait;
+}
+class Task extends Base {}
+===expect===
+

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_not_reported.phpt
@@ -1,0 +1,13 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+trait RunsTrait {
+    public function run(): void {}
+}
+class Task implements Runnable {
+    use RunsTrait;
+}
+===expect===
+

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_of_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_of_trait_not_reported.phpt
@@ -1,0 +1,16 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+trait ActualRunner {
+    public function run(): void {}
+}
+trait RunsTrait {
+    use ActualRunner;
+}
+class Task implements Runnable {
+    use RunsTrait;
+}
+===expect===
+

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_cycle_does_not_crash.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_cycle_does_not_crash.phpt
@@ -1,0 +1,18 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+// Mutual trait use — cycle guard must prevent infinite recursion.
+// Neither trait provides run(), so the issue should still be reported.
+trait TraitA {
+    use TraitB;
+}
+trait TraitB {
+    use TraitA;
+}
+class Task implements Runnable {
+    use TraitA;
+}
+===expect===
+UnimplementedInterfaceMethod: class Task implements Runnable {

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_of_trait_without_method_still_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_of_trait_without_method_still_reported.phpt
@@ -1,0 +1,17 @@
+===source===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+trait HelperTrait {
+    public function helper(): void {}
+}
+trait RunsTrait {
+    use HelperTrait;
+    // run() is not provided anywhere in the chain
+}
+class Task implements Runnable {
+    use RunsTrait;
+}
+===expect===
+UnimplementedInterfaceMethod: class Task implements Runnable {

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -623,12 +623,10 @@ impl Codebase {
             let ancestors = cls.all_parents.clone();
             drop(cls);
 
-            // 2. Own trait methods
+            // 2. Own trait methods (recursive into trait-of-trait)
             for tr_fqcn in &own_traits {
-                if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
-                    if let Some(m) = lookup_method(&tr.own_methods, method_name) {
-                        return Some(m.clone());
-                    }
+                if let Some(m) = self.get_method_in_trait(tr_fqcn, method_name) {
+                    return Some(m);
                 }
             }
 
@@ -641,10 +639,8 @@ impl Codebase {
                     let anc_traits = anc.traits.clone();
                     drop(anc);
                     for tr_fqcn in &anc_traits {
-                        if let Some(tr) = self.traits.get(tr_fqcn.as_ref()) {
-                            if let Some(m) = lookup_method(&tr.own_methods, method_name) {
-                                return Some(m.clone());
-                            }
+                        if let Some(m) = self.get_method_in_trait(tr_fqcn, method_name) {
+                            return Some(m);
                         }
                     }
                 } else if let Some(iface) = self.interfaces.get(ancestor_fqcn.as_ref()) {
@@ -1261,6 +1257,37 @@ impl Codebase {
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
+
+    /// Look up `method_name` in a trait's own methods, then recursively in any
+    /// traits that the trait itself uses (`use OtherTrait;` inside a trait body).
+    /// A visited set prevents infinite loops on pathological mutual trait use.
+    fn get_method_in_trait(&self, tr_fqcn: &Arc<str>, method_name: &str) -> Option<MethodStorage> {
+        let mut visited = std::collections::HashSet::new();
+        self.get_method_in_trait_inner(tr_fqcn, method_name, &mut visited)
+    }
+
+    fn get_method_in_trait_inner(
+        &self,
+        tr_fqcn: &Arc<str>,
+        method_name: &str,
+        visited: &mut std::collections::HashSet<String>,
+    ) -> Option<MethodStorage> {
+        if !visited.insert(tr_fqcn.to_string()) {
+            return None; // cycle guard
+        }
+        let tr = self.traits.get(tr_fqcn.as_ref())?;
+        if let Some(m) = lookup_method(&tr.own_methods, method_name) {
+            return Some(m.clone());
+        }
+        let used_traits = tr.traits.clone();
+        drop(tr);
+        for used_fqcn in &used_traits {
+            if let Some(m) = self.get_method_in_trait_inner(used_fqcn, method_name, visited) {
+                return Some(m);
+            }
+        }
+        None
+    }
 
     fn collect_class_ancestors(&self, fqcn: &str) -> Vec<Arc<str>> {
         let mut result = Vec::new();

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -243,6 +243,8 @@ pub struct TraitStorage {
     pub own_properties: IndexMap<Arc<str>, PropertyStorage>,
     pub own_constants: IndexMap<Arc<str>, ConstantStorage>,
     pub template_params: Vec<TemplateParam>,
+    /// Traits used by this trait (`use OtherTrait;` inside a trait body).
+    pub traits: Vec<Arc<str>>,
     pub location: Option<Location>,
 }
 


### PR DESCRIPTION
## Summary

- `TraitStorage` had no `traits` field, so `use OtherTrait;` inside a trait body was silently discarded during definition collection
- `get_method()` only checked one level of traits — any method contributed by a transitively-used trait was invisible, producing false `UnimplementedInterfaceMethod` errors
- Added `get_method_in_trait` helper that walks the full trait-of-trait chain with a cycle guard, and wired it into both trait-lookup sites in `get_method`

## Changes

- **`mir-codebase/src/storage.rs`** — `TraitStorage` gains `traits: Vec<Arc<str>>`
- **`mir-analyzer/src/collector.rs`** — `ClassMemberKind::TraitUse(_) => {}` inside the trait branch now collects the used trait FQCNs (was a silent no-op)
- **`mir-codebase/src/codebase.rs`** — new `get_method_in_trait` / `get_method_in_trait_inner` recursive helpers; both trait-lookup sites in `get_method` updated
- Two new fixture tests: `implemented_via_trait_not_reported` and `implemented_via_trait_of_trait_not_reported`

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] New fixture `implemented_via_trait_not_reported.phpt` — direct trait satisfies interface method, no issue raised
- [ ] New fixture `implemented_via_trait_of_trait_not_reported.phpt` — trait-of-trait chain satisfies interface method, no issue raised