### PR TITLE
fix(stmt): correct elseif narrowing, merge, and keyed-array foreach key type

### DIFF
--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -6,7 +6,7 @@ use php_ast::ast::StmtKind;
 
 use mir_codebase::Codebase;
 use mir_issues::{IssueBuffer, IssueKind};
-use mir_types::{Atomic, Union};
+use mir_types::{ArrayKey, Atomic, Union};
 
 use crate::context::Context;
 use crate::expr::ExpressionAnalyzer;
@@ -409,14 +409,73 @@ impl<'a> StatementsAnalyzer<'a> {
                 // ElseIf branches (flatten into separate else-if chain)
                 let mut elseif_ctxs: Vec<Context> = vec![];
                 for elseif in if_stmt.elseif_branches.iter() {
-                    let mut branch_ctx = ctx.fork();
+                    // Start from the pre-if context narrowed by the if condition being false
+                    // (an elseif body only runs when the if condition is false).
+                    let mut pre_elseif = ctx.fork();
+                    narrow_from_condition(
+                        &if_stmt.condition,
+                        &mut pre_elseif,
+                        false,
+                        self.codebase,
+                        &self.file,
+                    );
+                    let pre_elseif_diverges = pre_elseif.diverges;
+
+                    // Check reachability of the elseif body (condition narrowed true)
+                    // and its implicit "skip" path (condition narrowed false) to detect
+                    // redundant elseif conditions.
+                    let mut elseif_true_ctx = pre_elseif.clone();
                     narrow_from_condition(
                         &elseif.condition,
-                        &mut branch_ctx,
+                        &mut elseif_true_ctx,
                         true,
                         self.codebase,
                         &self.file,
                     );
+                    let mut elseif_false_ctx = pre_elseif.clone();
+                    narrow_from_condition(
+                        &elseif.condition,
+                        &mut elseif_false_ctx,
+                        false,
+                        self.codebase,
+                        &self.file,
+                    );
+                    if !pre_elseif_diverges
+                        && (elseif_true_ctx.diverges || elseif_false_ctx.diverges)
+                    {
+                        let (line, col_start) =
+                            self.offset_to_line_col(elseif.condition.span.start);
+                        let col_end = if elseif.condition.span.start < elseif.condition.span.end {
+                            let (_end_line, end_col) =
+                                self.offset_to_line_col(elseif.condition.span.end);
+                            end_col
+                        } else {
+                            col_start
+                        };
+                        let elseif_cond_type = self
+                            .expr_analyzer(ctx)
+                            .analyze(&elseif.condition, &mut ctx.fork());
+                        self.issues.add(
+                            mir_issues::Issue::new(
+                                IssueKind::RedundantCondition {
+                                    ty: format!("{}", elseif_cond_type),
+                                },
+                                mir_issues::Location {
+                                    file: self.file.clone(),
+                                    line,
+                                    col_start,
+                                    col_end: col_end.max(col_start + 1),
+                                },
+                            )
+                            .with_snippet(
+                                crate::parser::span_text(self.source, elseif.condition.span)
+                                    .unwrap_or_default(),
+                            ),
+                        );
+                    }
+
+                    // Analyze the elseif body using the narrowed-true context.
+                    let mut branch_ctx = elseif_true_ctx;
                     self.expr_analyzer(&branch_ctx)
                         .analyze(&elseif.condition, &mut branch_ctx);
                     if !branch_ctx.diverges {
@@ -469,10 +528,13 @@ impl<'a> StatementsAnalyzer<'a> {
                     );
                 }
 
-                // Merge all branches
+                // Merge all branches: start with the if/else pair, then fold each
+                // elseif in as an additional possible execution path.  Using the
+                // accumulated ctx (not pre_ctx) as the "else" argument ensures every
+                // branch contributes to the final type environment.
                 *ctx = Context::merge_branches(&pre_ctx, then_ctx, Some(else_ctx));
                 for ec in elseif_ctxs {
-                    *ctx = Context::merge_branches(&pre_ctx, ec, None);
+                    *ctx = Context::merge_branches(&pre_ctx, ec, Some(ctx.clone()));
                 }
             }
 
@@ -1015,18 +1077,29 @@ fn infer_foreach_types(arr_ty: &Union) -> (Union, Union) {
                 return (Union::single(Atomic::TInt), *value.clone());
             }
             Atomic::TKeyedArray { properties, .. } => {
+                let mut keys = Union::empty();
                 let mut values = Union::empty();
-                for (_k, prop) in properties {
+                for (k, prop) in properties {
+                    let key_atomic = match k {
+                        ArrayKey::String(s) => Atomic::TLiteralString(s.clone()),
+                        ArrayKey::Int(i) => Atomic::TLiteralInt(*i),
+                    };
+                    keys = Union::merge(&keys, &Union::single(key_atomic));
                     values = Union::merge(&values, &prop.ty);
                 }
-                // Empty keyed array (e.g. `$arr = []` before push) — treat value as mixed
-                // to avoid propagating Union::empty() as a variable type.
+                // Empty keyed array (e.g. `$arr = []` before push) — treat both as
+                // mixed to avoid propagating Union::empty() as a variable type.
+                let keys = if keys.is_empty() {
+                    Union::mixed()
+                } else {
+                    keys
+                };
                 let values = if values.is_empty() {
                     Union::mixed()
                 } else {
                     values
                 };
-                return (Union::single(Atomic::TMixed), values);
+                return (keys, values);
             }
             Atomic::TString => {
                 return (Union::single(Atomic::TInt), Union::single(Atomic::TString));

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_int_key_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_int_key_no_error.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+// Bug: foreach over a list-shaped keyed array always produced TMixed for the key.
+// A function expecting int should not receive an InvalidArgument when the array
+// has only integer keys.
+function takes_int(int $k): void { var_dump($k); }
+
+function foo(): void {
+    $arr = [0 => 'a', 1 => 'b', 2 => 'c'];
+    foreach ($arr as $k => $v) {
+        takes_int($k);
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_no_error.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+// Bug: foreach over a keyed array (array shape) always produced TMixed for the key
+// type instead of the actual key types. A function expecting string should not
+// receive an InvalidArgument when iterating over a shape with string keys.
+function takes_string(string $k): void { var_dump($k); }
+
+function foo(): void {
+    $arr = ['hello' => 1, 'world' => 2];
+    foreach ($arr as $k => $v) {
+        takes_string($k);
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_to_int_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_to_int_param.phpt
@@ -1,0 +1,16 @@
+===source===
+<?php
+// Bug: foreach over a keyed array always produced TMixed for the key type.
+// With TMixed, no InvalidArgument is reported even when the key is provably
+// string and the parameter expects int. After the fix, the key is typed as
+// the literal string keys and the mismatch is caught.
+function takes_int(int $k): void { var_dump($k); }
+
+function foo(): void {
+    $arr = ['hello' => 1, 'world' => 2];
+    foreach ($arr as $k => $v) {
+        takes_int($k);
+    }
+}
+===expect===
+InvalidArgument: $k

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_all_branches_assigned_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_all_branches_assigned_no_error.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+// Bug: elseif branches were discarded from the post-if merge — variables assigned
+// in every branch (if / elseif / else) were incorrectly treated as possibly-undefined.
+function foo(int $x): string {
+    if ($x > 0) {
+        $result = 'positive';
+    } elseif ($x < 0) {
+        $result = 'negative';
+    } else {
+        $result = 'zero';
+    }
+    return $result;
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_missing_else_branch_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_missing_else_branch_error.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+// Bug: elseif branches were discarded from the post-if merge — even with the bug
+// fixed, a variable assigned only in if/elseif but not else must still be
+// possibly-undefined after the chain.
+function foo(int $x): string {
+    if ($x > 0) {
+        $result = 'positive';
+    } elseif ($x < 0) {
+        $result = 'negative';
+    }
+    return $result;
+}
+===expect===
+PossiblyUndefinedVariable: $result

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_multiple_branches_all_assigned_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_multiple_branches_all_assigned_no_error.phpt
@@ -1,0 +1,17 @@
+===source===
+<?php
+// Bug: with multiple elseif branches, only the last one survived the merge loop —
+// variables assigned in earlier elseif branches were dropped.
+function classify(int $x): string {
+    if ($x < 0) {
+        $label = 'negative';
+    } elseif ($x === 0) {
+        $label = 'zero';
+    } elseif ($x < 10) {
+        $label = 'small';
+    } else {
+        $label = 'large';
+    }
+    return $label;
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/does_not_report_elseif_check_on_remaining_union.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/does_not_report_elseif_check_on_remaining_union.phpt
@@ -1,0 +1,14 @@
+===source===
+<?php
+// The elseif condition is NOT redundant when additional union members remain
+// after the if condition narrows the type. Here $x is string|int|null: the if
+// handles null, leaving string|int in the elseif — so is_string() is still
+// meaningful (it distinguishes string from int).
+function foo(string|int|null $x): void {
+    if ($x === null) {
+        // $x is null
+    } elseif (is_string($x)) {
+        // $x could still be int here; is_string() is not redundant
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_in_elseif.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_in_elseif.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+// Bug: elseif branches were not narrowed on the if condition being false — the
+// if condition's type exclusion was not applied before entering the elseif body.
+// Here $x === null is handled by the if, so in the elseif $x can only be string;
+// the is_string() check is therefore redundant.
+function foo(string|null $x): void {
+    if ($x === null) {
+        // $x is null
+    } elseif (is_string($x)) {
+        // $x is already string (null excluded by the if above)
+    }
+}
+===expect===
+RedundantCondition: is_string($x)

--- a/crates/mir-types/src/lib.rs
+++ b/crates/mir-types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod atomic;
 pub mod display;
 pub mod union;
 
+pub use atomic::ArrayKey;
 pub use atomic::Atomic;
 pub use atomic::Variance;
 pub use union::Union;


### PR DESCRIPTION
## Summary

Three bugs found in the statement analyser, each with fixture tests:

- **elseif narrowing missing `!if_cond`** — elseif branches were not narrowed on the parent `if` condition being false before the elseif condition was applied. Variables with types already excluded by the `if` still appeared with their full pre-if types inside `elseif` bodies, suppressing `RedundantCondition` that should have fired.

- **elseif branches dropped from post-if merge** — the merge loop called `merge_branches(&pre_ctx, ec, None)` on every iteration, resetting the "else" side to the pre-if context and overwriting the accumulated result. Only the last elseif survived, so variables assigned in every branch were incorrectly treated as `PossiblyUndefined`.

- **`TKeyedArray` foreach key always `TMixed`** — `infer_foreach_types` returned `Union::single(Atomic::TMixed)` for the key of any keyed array regardless of its actual keys. Fixed to derive `TLiteralString` / `TLiteralInt` from the `ArrayKey` entries. Also re-exports `ArrayKey` from `mir-types`.

## Test plan

- [ ] `possibly_undefined_variable::elseif_all_branches_assigned_no_error` — no FP when all branches assign
- [ ] `possibly_undefined_variable::elseif_multiple_branches_all_assigned_no_error` — no FP with multiple elseifs
- [ ] `possibly_undefined_variable::elseif_missing_else_branch_error` — still flags when else branch is absent
- [ ] `redundant_condition::reports_redundant_check_in_elseif` — detects redundant check after `!if_cond` narrows the type away
- [ ] `redundant_condition::does_not_report_elseif_check_on_remaining_union` — no FP when union members remain
- [ ] `invalid_argument::keyed_array_foreach_string_key_no_error` — string keys accepted by `string` param
- [ ] `invalid_argument::keyed_array_foreach_int_key_no_error` — int keys accepted by `int` param
- [ ] `invalid_argument::keyed_array_foreach_string_key_to_int_param` — string keys rejected by `int` param