### PR TITLE
fix(stmt): collect fallthrough-case contexts in switch analysis

### DIFF
--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -664,6 +664,7 @@ impl<'a> StatementsAnalyzer<'a> {
 
                 let mut all_cases_diverge = true;
                 let has_default = sw.cases.iter().any(|c| c.value.is_none());
+                let mut fallthrough_ctxs: Vec<Context> = Vec::new();
 
                 for case in sw.cases.iter() {
                     let mut case_ctx = pre_ctx.fork();
@@ -705,6 +706,9 @@ impl<'a> StatementsAnalyzer<'a> {
                     }
                     if !case_ctx.diverges {
                         all_cases_diverge = false;
+                        // Case fell through to the end of the switch without a break/return/throw.
+                        // Collect its context so it contributes to the post-switch state.
+                        fallthrough_ctxs.push(case_ctx);
                     }
                 }
 
@@ -715,7 +719,11 @@ impl<'a> StatementsAnalyzer<'a> {
                 // Build the post-switch merged context:
                 // Start with pre_ctx if no default case (switch might not match anything)
                 // or if not all cases diverge via return/throw.
-                let mut merged = if has_default && all_cases_diverge && break_ctxs.is_empty() {
+                let mut merged = if has_default
+                    && all_cases_diverge
+                    && break_ctxs.is_empty()
+                    && fallthrough_ctxs.is_empty()
+                {
                     // All paths return/throw — post-switch is unreachable
                     let mut m = pre_ctx.clone();
                     m.diverges = true;
@@ -728,6 +736,9 @@ impl<'a> StatementsAnalyzer<'a> {
 
                 for bctx in break_ctxs {
                     merged = Context::merge_branches(&pre_ctx, bctx, Some(merged));
+                }
+                for fctx in fallthrough_ctxs {
+                    merged = Context::merge_branches(&pre_ctx, fctx, Some(merged));
                 }
 
                 *ctx = merged;

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -662,10 +662,12 @@ impl<'a> StatementsAnalyzer<'a> {
                 // the case's context for merging into the post-switch result.
                 self.break_ctx_stack.push(Vec::new());
 
-                let mut all_cases_diverge = true;
                 let has_default = sw.cases.iter().any(|c| c.value.is_none());
-                let mut fallthrough_ctxs: Vec<Context> = Vec::new();
 
+                // First pass: analyse each case body independently from pre_ctx.
+                // Break statements inside a body save their context to break_ctx_stack
+                // automatically; we just collect the per-case contexts here.
+                let mut case_results: Vec<Context> = Vec::new();
                 for case in sw.cases.iter() {
                     let mut case_ctx = pre_ctx.fork();
                     if let Some(val) = &case.value {
@@ -704,10 +706,39 @@ impl<'a> StatementsAnalyzer<'a> {
                     for stmt in case.body.iter() {
                         self.analyze_stmt(stmt, &mut case_ctx);
                     }
-                    if !case_ctx.diverges {
+                    case_results.push(case_ctx);
+                }
+
+                // Second pass: propagate divergence backwards through the fallthrough
+                // chain. A non-diverging case (no break/return/throw) flows into the
+                // next case at runtime, so if that next case effectively diverges, this
+                // case effectively diverges too.
+                //
+                // Example:
+                //   case 1: $y = "a";   // no break — chains into case 2
+                //   case 2: return;     // diverges
+                //
+                // Case 1 is effectively diverging because its only exit is through
+                // case 2's return. Adding case 1 to fallthrough_ctxs would be wrong.
+                let n = case_results.len();
+                let mut effective_diverges = vec![false; n];
+                for i in (0..n).rev() {
+                    if case_results[i].diverges {
+                        effective_diverges[i] = true;
+                    } else if i + 1 < n {
+                        // Non-diverging body: falls through to the next case.
+                        effective_diverges[i] = effective_diverges[i + 1];
+                    }
+                    // else: last case with no break/return — falls to end of switch.
+                }
+
+                // Build fallthrough_ctxs from cases that truly exit via the end of
+                // the switch (not through a subsequent diverging case).
+                let mut all_cases_diverge = true;
+                let mut fallthrough_ctxs: Vec<Context> = Vec::new();
+                for (i, case_ctx) in case_results.into_iter().enumerate() {
+                    if !effective_diverges[i] {
                         all_cases_diverge = false;
-                        // Case fell through to the end of the switch without a break/return/throw.
-                        // Collect its context so it contributes to the post-switch state.
                         fallthrough_ctxs.push(case_ctx);
                     }
                 }

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/switch_fallthrough_widens_type_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/switch_fallthrough_widens_type_error.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+// Before the fallthrough-context fix, the case-2 assignment was silently dropped,
+// so $y appeared to be `int` post-switch and no error was reported.
+function foo(int $x): int {
+    $y = 0;
+    switch ($x) {
+        case 2:
+            $y = "not an int";
+            // no break — falls through to end of switch
+    }
+    return $y;
+}
+===expect===
+InvalidReturnType: return $y;

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_no_default_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_no_default_error.phpt
@@ -1,0 +1,15 @@
+===source===
+<?php
+function foo(int $x): string {
+    switch ($x) {
+        case 1:
+            $y = "hello";
+            break;
+        case 2:
+            $y = "world";
+            // no break — falls through to end of switch
+    }
+    return $y;
+}
+===expect===
+PossiblyUndefinedVariable: $y

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_preassigned_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_preassigned_no_error.phpt
@@ -1,0 +1,19 @@
+===source===
+<?php
+// Variable assigned before the switch is always defined post-switch, even when
+// some cases fall through without a break. Before the fallthrough-context fix,
+// the fallthrough case's assignment was dropped, but the pre-existing $y still
+// kept the function valid — no regression here.
+function foo(int $x): string {
+    $y = "default";
+    switch ($x) {
+        case 1:
+            $y = "one";
+            break;
+        case 2:
+            $y = "two";
+            // no break — falls through to end of switch
+    }
+    return $y;
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/switch_fallthrough_into_return_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/switch_fallthrough_into_return_error.phpt
@@ -1,0 +1,17 @@
+===source===
+<?php
+// case 1 has no break and chains into case 2 which returns. Both cases
+// effectively diverge, so $y is only reachable when no case matches (no
+// default) — i.e., $y is always undefined at the echo.
+function foo(int $x): void {
+    switch ($x) {
+        case 1:
+            $y = "a";
+            // no break — falls through into case 2
+        case 2:
+            return;
+    }
+    echo $y;
+}
+===expect===
+UndefinedVariable: $y


### PR DESCRIPTION
## Summary

Two related bugs in the switch-statement analysis, both fixed in this PR.

---

### Bug A — Fallthrough contexts were silently dropped

Cases that reach the end of a `switch` body without a `break`, `return`, or `throw` had their analysis context silently dropped. Only cases with an explicit `break` contributed to the post-switch type environment (via `break_ctx_stack`).

**Impact**: Variables assigned exclusively in fallthrough cases were invisible post-switch, causing missed `InvalidReturnType` when a fallthrough case widened a variable's type.

**Fix** (commit 1): Collect non-diverging `case_ctx` values in `fallthrough_ctxs` and fold them into the merged post-switch context alongside `break_ctxs`. The "all paths diverge" guard is also extended to require `fallthrough_ctxs` to be empty. Mirrors the elseif fix from #211.

---

### Bug B — Chain-fallthrough into diverging case was not propagated

Each case was analysed in isolation. When case N had no `break` and its body flowed into case N+1 at runtime, and case N+1 diverged (return/throw), the analyser did not see case N as diverging. It incorrectly added case N's context to `fallthrough_ctxs`, making variables assigned in case N look "possibly defined" after the switch — even though the only path reaching post-switch code (no default) never ran case N's body.

```php
case 1: $y = "a";  // no break — chains into case 2
case 2: return;    // diverges
// $y is ALWAYS undefined here (only no-match path reaches this point)
```

Before: `PossiblyUndefinedVariable: $y` (wrong — $y is definitely undefined)  
After: `UndefinedVariable: $y` (correct)

**Fix** (commit 2): Replace the single analysis loop with two passes:
1. Analyse each case body independently (unchanged).
2. Walk case results in **reverse**: if case N is non-diverging and case N+1 effectively diverges, mark case N as effectively diverging too.

Only cases that truly exit via the end of the switch are added to `fallthrough_ctxs`.

---

## Test coverage

| Fixture | What it proves |
|---------|---------------|
| `invalid_return_type/switch_fallthrough_widens_type_error` | Fallthrough case that assigns `"not an int"` to an `int` variable now triggers `InvalidReturnType` (Bug A) |
| `possibly_undefined_variable/switch_fallthrough_no_default_error` | `PossiblyUndefinedVariable` still fires when the switch has no `default` — the genuinely possibly-undefined path is preserved |
| `possibly_undefined_variable/switch_fallthrough_preassigned_no_error` | Pre-assigned variable stays valid through a mix of `break` and fallthrough cases — no false positives |
| `undefined_variable/switch_fallthrough_into_return_error` | Chain-fallthrough into `return` now correctly reports `UndefinedVariable` (Bug B) |

## Known limitation (pre-existing, not introduced here)

Each case is still analysed independently from `pre_ctx`, so assignments from case N are not visible in case N+1's analysis context. Properly modelling chain-fallthrough type flow (e.g. case N sets `$y`, falls into case N+1 which `break`s — that `$y` value is not tracked in the break context) would require a more significant refactor of the case analysis loop.