### PR TITLE
perf(codebase): store MethodStorage as Arc<MethodStorage> to avoid deep clones

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -503,16 +503,16 @@ impl<'a> ClassAnalyzer<'a> {
         &self,
         cls: &mir_codebase::storage::ClassStorage,
         method_name: &str,
-    ) -> Option<MethodStorage> {
+    ) -> Option<Arc<MethodStorage>> {
         // Walk all_parents in order (closest ancestor first)
         for ancestor_fqcn in &cls.all_parents {
             if let Some(ancestor_cls) = self.codebase.classes.get(ancestor_fqcn.as_ref()) {
                 if let Some(m) = ancestor_cls.own_methods.get(method_name) {
-                    return Some(m.clone());
+                    return Some(Arc::clone(m));
                 }
             } else if let Some(iface) = self.codebase.interfaces.get(ancestor_fqcn.as_ref()) {
                 if let Some(m) = iface.own_methods.get(method_name) {
-                    return Some(m.clone());
+                    return Some(Arc::clone(m));
                 }
             }
         }

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -491,8 +491,10 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 }
                             }
                             let method = self.build_method_storage(m, &fqcn, Some(&member.span));
-                            own_methods
-                                .insert(Arc::from(method.name.to_lowercase().as_str()), method);
+                            own_methods.insert(
+                                Arc::from(method.name.to_lowercase().as_str()),
+                                Arc::new(method),
+                            );
                         }
                         ClassMemberKind::Property(p) => {
                             let prop = PropertyStorage {
@@ -601,8 +603,10 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     match &member.kind {
                         ClassMemberKind::Method(m) => {
                             let method = self.build_method_storage(m, &fqcn, Some(&member.span));
-                            own_methods
-                                .insert(Arc::from(method.name.to_lowercase().as_str()), method);
+                            own_methods.insert(
+                                Arc::from(method.name.to_lowercase().as_str()),
+                                Arc::new(method),
+                            );
                         }
                         ClassMemberKind::ClassConst(c) => {
                             own_constants.insert(
@@ -695,8 +699,10 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 }
                             }
                             let method = self.build_method_storage(m, &fqcn, Some(&member.span));
-                            own_methods
-                                .insert(Arc::from(method.name.to_lowercase().as_str()), method);
+                            own_methods.insert(
+                                Arc::from(method.name.to_lowercase().as_str()),
+                                Arc::new(method),
+                            );
                         }
                         ClassMemberKind::Property(p) => {
                             own_properties.insert(
@@ -792,8 +798,10 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                         }
                         EnumMemberKind::Method(m) => {
                             let method = self.build_method_storage(m, &fqcn, Some(&member.span));
-                            own_methods
-                                .insert(Arc::from(method.name.to_lowercase().as_str()), method);
+                            own_methods.insert(
+                                Arc::from(method.name.to_lowercase().as_str()),
+                                Arc::new(method),
+                            );
                         }
                         EnumMemberKind::ClassConst(c) => {
                             own_constants.insert(

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -813,9 +813,10 @@ impl ProjectAnalyzer {
 
             let Some(body) = &method.body else { continue };
 
-            let method_storage = self.codebase.get_method(fqcn, method.name);
-            let (params, return_ty) = method_storage
-                .as_ref()
+            let (params, return_ty) = self
+                .codebase
+                .get_method(fqcn, method.name)
+                .as_deref()
                 .map(|m| (m.params.clone(), m.return_type.clone()))
                 .unwrap_or_default();
 
@@ -850,7 +851,7 @@ impl ProjectAnalyzer {
 
             if let Some(mut cls) = self.codebase.classes.get_mut(fqcn) {
                 if let Some(m) = cls.own_methods.get_mut(method.name) {
-                    m.inferred_return_type = Some(inferred);
+                    Arc::make_mut(m).inferred_return_type = Some(inferred);
                 }
             }
         }
@@ -1105,9 +1106,10 @@ impl ProjectAnalyzer {
 
             let Some(body) = &method.body else { continue };
 
-            let method_storage = self.codebase.get_method(fqcn, method.name);
-            let (params, return_ty) = method_storage
-                .as_ref()
+            let (params, return_ty) = self
+                .codebase
+                .get_method(fqcn, method.name)
+                .as_deref()
                 .map(|m| (m.params.clone(), m.return_type.clone()))
                 .unwrap_or_default();
 
@@ -1151,7 +1153,7 @@ impl ProjectAnalyzer {
 
             if let Some(mut cls) = self.codebase.classes.get_mut(fqcn) {
                 if let Some(m) = cls.own_methods.get_mut(method.name) {
-                    m.inferred_return_type = Some(inferred);
+                    Arc::make_mut(m).inferred_return_type = Some(inferred);
                 }
             }
         }

--- a/crates/mir-analyzer/src/stubs.rs
+++ b/crates/mir-analyzer/src/stubs.rs
@@ -3261,11 +3261,11 @@ fn stub_method(
     params: Vec<FnParam>,
     ret: Union,
     vis: Visibility,
-) -> (Arc<str>, MethodStorage) {
+) -> (Arc<str>, Arc<MethodStorage>) {
     let key: Arc<str> = Arc::from(name);
     (
         key.clone(),
-        MethodStorage {
+        Arc::new(MethodStorage {
             name: key,
             fqcn: Arc::from(class_fqcn),
             params,
@@ -3283,7 +3283,7 @@ fn stub_method(
             is_internal: false,
             is_pure: false,
             location: None,
-        },
+        }),
     )
 }
 
@@ -3442,7 +3442,7 @@ fn load_classes(codebase: &Codebase) {
         for (method_name, params, ret) in exc_methods {
             let is_ctor = *method_name == "__construct";
             let mut m = stub_method(class_name, method_name, params.clone(), ret.clone(), Public).1;
-            m.is_constructor = is_ctor;
+            Arc::make_mut(&mut m).is_constructor = is_ctor;
             cls.own_methods.insert(Arc::from(*method_name), m);
         }
         codebase.classes.insert(Arc::from(*class_name), cls);
@@ -3514,7 +3514,7 @@ fn load_classes(codebase: &Codebase) {
         ] {
             let is_ctor = *name == "__construct";
             let mut m = stub_method(class_name, name, params.clone(), ret.clone(), Public).1;
-            m.is_constructor = is_ctor;
+            Arc::make_mut(&mut m).is_constructor = is_ctor;
             dt.own_methods.insert(Arc::from(*name), m);
         }
         codebase.classes.insert(Arc::from(*class_name), dt);

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -31,9 +31,9 @@ use mir_types::Union;
 /// case-insensitive scan for stubs that store keys in original case.
 #[inline]
 fn lookup_method<'a>(
-    map: &'a indexmap::IndexMap<Arc<str>, MethodStorage>,
+    map: &'a indexmap::IndexMap<Arc<str>, Arc<MethodStorage>>,
     name: &str,
-) -> Option<&'a MethodStorage> {
+) -> Option<&'a Arc<MethodStorage>> {
     map.get(name).or_else(|| {
         map.iter()
             .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
@@ -607,7 +607,7 @@ impl Codebase {
     }
 
     /// Resolve a method, walking up the full inheritance chain (own → traits → ancestors).
-    pub fn get_method(&self, fqcn: &str, method_name: &str) -> Option<MethodStorage> {
+    pub fn get_method(&self, fqcn: &str, method_name: &str) -> Option<Arc<MethodStorage>> {
         // PHP method names are case-insensitive — normalize to lowercase for all lookups.
         let method_lower = method_name.to_lowercase();
         let method_name = method_lower.as_str();
@@ -616,7 +616,7 @@ impl Codebase {
         if let Some(cls) = self.classes.get(fqcn) {
             // 1. Own methods (highest priority)
             if let Some(m) = lookup_method(&cls.own_methods, method_name) {
-                return Some(m.clone());
+                return Some(Arc::clone(m));
             }
             // Collect chain info before dropping the DashMap guard.
             let own_traits = cls.traits.clone();
@@ -634,7 +634,7 @@ impl Codebase {
             for ancestor_fqcn in &ancestors {
                 if let Some(anc) = self.classes.get(ancestor_fqcn.as_ref()) {
                     if let Some(m) = lookup_method(&anc.own_methods, method_name) {
-                        return Some(m.clone());
+                        return Some(Arc::clone(m));
                     }
                     let anc_traits = anc.traits.clone();
                     drop(anc);
@@ -645,9 +645,9 @@ impl Codebase {
                     }
                 } else if let Some(iface) = self.interfaces.get(ancestor_fqcn.as_ref()) {
                     if let Some(m) = lookup_method(&iface.own_methods, method_name) {
-                        let mut m = m.clone();
-                        m.is_abstract = true;
-                        return Some(m);
+                        let mut ms = (**m).clone();
+                        ms.is_abstract = true;
+                        return Some(Arc::new(ms));
                     }
                 }
                 // Traits listed in all_parents are already covered via their owning class above.
@@ -658,14 +658,14 @@ impl Codebase {
         // --- Interface: own methods + parent interfaces ---
         if let Some(iface) = self.interfaces.get(fqcn) {
             if let Some(m) = lookup_method(&iface.own_methods, method_name) {
-                return Some(m.clone());
+                return Some(Arc::clone(m));
             }
             let parents = iface.all_parents.clone();
             drop(iface);
             for parent_fqcn in &parents {
                 if let Some(parent_iface) = self.interfaces.get(parent_fqcn.as_ref()) {
                     if let Some(m) = lookup_method(&parent_iface.own_methods, method_name) {
-                        return Some(m.clone());
+                        return Some(Arc::clone(m));
                     }
                 }
             }
@@ -675,7 +675,7 @@ impl Codebase {
         // --- Trait (variable annotated with a trait type) ---
         if let Some(tr) = self.traits.get(fqcn) {
             if let Some(m) = lookup_method(&tr.own_methods, method_name) {
-                return Some(m.clone());
+                return Some(Arc::clone(m));
             }
             return None;
         }
@@ -683,11 +683,11 @@ impl Codebase {
         // --- Enum ---
         if let Some(e) = self.enums.get(fqcn) {
             if let Some(m) = lookup_method(&e.own_methods, method_name) {
-                return Some(m.clone());
+                return Some(Arc::clone(m));
             }
             // PHP 8.1 built-in enum methods: cases(), from(), tryFrom()
             if matches!(method_name, "cases" | "from" | "tryfrom") {
-                return Some(crate::storage::MethodStorage {
+                return Some(Arc::new(crate::storage::MethodStorage {
                     fqcn: Arc::from(fqcn),
                     name: Arc::from(method_name),
                     params: vec![],
@@ -705,7 +705,7 @@ impl Codebase {
                     is_pure: false,
                     is_deprecated: false,
                     location: None,
-                });
+                }));
             }
         }
 
@@ -1261,7 +1261,11 @@ impl Codebase {
     /// Look up `method_name` in a trait's own methods, then recursively in any
     /// traits that the trait itself uses (`use OtherTrait;` inside a trait body).
     /// A visited set prevents infinite loops on pathological mutual trait use.
-    fn get_method_in_trait(&self, tr_fqcn: &Arc<str>, method_name: &str) -> Option<MethodStorage> {
+    fn get_method_in_trait(
+        &self,
+        tr_fqcn: &Arc<str>,
+        method_name: &str,
+    ) -> Option<Arc<MethodStorage>> {
         let mut visited = std::collections::HashSet::new();
         self.get_method_in_trait_inner(tr_fqcn, method_name, &mut visited)
     }
@@ -1271,13 +1275,13 @@ impl Codebase {
         tr_fqcn: &Arc<str>,
         method_name: &str,
         visited: &mut std::collections::HashSet<String>,
-    ) -> Option<MethodStorage> {
+    ) -> Option<Arc<MethodStorage>> {
         if !visited.insert(tr_fqcn.to_string()) {
             return None; // cycle guard
         }
         let tr = self.traits.get(tr_fqcn.as_ref())?;
         if let Some(m) = lookup_method(&tr.own_methods, method_name) {
-            return Some(m.clone());
+            return Some(Arc::clone(m));
         }
         let used_traits = tr.traits.clone();
         drop(tr);

--- a/crates/mir-codebase/src/members.rs
+++ b/crates/mir-codebase/src/members.rs
@@ -446,7 +446,7 @@ mod tests {
         let mut parent_methods = IndexMap::new();
         parent_methods.insert(
             Arc::from("parentMethod"),
-            make_method("parentMethod", "Parent"),
+            Arc::new(make_method("parentMethod", "Parent")),
         );
         cb.classes.insert(
             Arc::from("Parent"),
@@ -474,7 +474,7 @@ mod tests {
         let mut child_methods = IndexMap::new();
         child_methods.insert(
             Arc::from("childMethod"),
-            make_method("childMethod", "Child"),
+            Arc::new(make_method("childMethod", "Child")),
         );
         cb.classes.insert(
             Arc::from("Child"),
@@ -518,7 +518,7 @@ mod tests {
         let cb = Codebase::new();
 
         let mut a_methods = IndexMap::new();
-        a_methods.insert(Arc::from("aMethod"), make_method("aMethod", "A"));
+        a_methods.insert(Arc::from("aMethod"), Arc::new(make_method("aMethod", "A")));
         cb.classes.insert(
             Arc::from("A"),
             ClassStorage {
@@ -542,7 +542,7 @@ mod tests {
         );
 
         let mut b_methods = IndexMap::new();
-        b_methods.insert(Arc::from("bMethod"), make_method("bMethod", "B"));
+        b_methods.insert(Arc::from("bMethod"), Arc::new(make_method("bMethod", "B")));
         cb.classes.insert(
             Arc::from("B"),
             ClassStorage {

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -180,7 +180,7 @@ pub struct ClassStorage {
     pub parent: Option<Arc<str>>,
     pub interfaces: Vec<Arc<str>>,
     pub traits: Vec<Arc<str>>,
-    pub own_methods: IndexMap<Arc<str>, MethodStorage>,
+    pub own_methods: IndexMap<Arc<str>, Arc<MethodStorage>>,
     pub own_properties: IndexMap<Arc<str>, PropertyStorage>,
     pub own_constants: IndexMap<Arc<str>, ConstantStorage>,
     pub template_params: Vec<TemplateParam>,
@@ -198,11 +198,11 @@ impl ClassStorage {
     pub fn get_method(&self, name: &str) -> Option<&MethodStorage> {
         // PHP method names are case-insensitive; caller should pass lowercase name.
         // Only searches own_methods — inherited method resolution is done by Codebase::get_method.
-        self.own_methods.get(name).or_else(|| {
+        self.own_methods.get(name).map(Arc::as_ref).or_else(|| {
             self.own_methods
                 .iter()
                 .find(|(k, _)| k.as_ref().eq_ignore_ascii_case(name))
-                .map(|(_, v)| v)
+                .map(|(_, v)| v.as_ref())
         })
     }
 
@@ -224,7 +224,7 @@ pub struct InterfaceStorage {
     pub fqcn: Arc<str>,
     pub short_name: Arc<str>,
     pub extends: Vec<Arc<str>>,
-    pub own_methods: IndexMap<Arc<str>, MethodStorage>,
+    pub own_methods: IndexMap<Arc<str>, Arc<MethodStorage>>,
     pub own_constants: IndexMap<Arc<str>, ConstantStorage>,
     pub template_params: Vec<TemplateParam>,
     pub all_parents: Vec<Arc<str>>,
@@ -239,7 +239,7 @@ pub struct InterfaceStorage {
 pub struct TraitStorage {
     pub fqcn: Arc<str>,
     pub short_name: Arc<str>,
-    pub own_methods: IndexMap<Arc<str>, MethodStorage>,
+    pub own_methods: IndexMap<Arc<str>, Arc<MethodStorage>>,
     pub own_properties: IndexMap<Arc<str>, PropertyStorage>,
     pub own_constants: IndexMap<Arc<str>, ConstantStorage>,
     pub template_params: Vec<TemplateParam>,
@@ -266,7 +266,7 @@ pub struct EnumStorage {
     pub scalar_type: Option<Union>,
     pub interfaces: Vec<Arc<str>>,
     pub cases: IndexMap<Arc<str>, EnumCaseStorage>,
-    pub own_methods: IndexMap<Arc<str>, MethodStorage>,
+    pub own_methods: IndexMap<Arc<str>, Arc<MethodStorage>>,
     pub own_constants: IndexMap<Arc<str>, ConstantStorage>,
     pub location: Option<Location>,
 }


### PR DESCRIPTION
## Summary

- `own_methods` in `ClassStorage`, `InterfaceStorage`, `TraitStorage`, and `EnumStorage` changed from `IndexMap<Arc<str>, MethodStorage>` to `IndexMap<Arc<str>, Arc<MethodStorage>>`
- `get_method()` (and its trait-walking helpers) now returns `Option<Arc<MethodStorage>>` — every lookup is an atomic refcount bump instead of a full struct deep-clone
- The two `inferred_return_type` write-back sites in `project.rs` use `Arc::make_mut()`; the borrowed `method_storage` Arc is dropped beforehand so refcount is 1 at write-back time (no CoW clone triggered)
- `stub_method()` return type changed to `(Arc<str>, Arc<MethodStorage>)` so all ~40 call sites get the right type automatically; two mutation sites use `Arc::make_mut()`

## Test plan

- [x] `cargo test` — all 349 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo build --release` — clean

Closes #206