### PR TITLE
bench: add real-world Criterion benchmark suite

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,145 @@
+name: Benchmarks
+
+# Run on every push to main that touches Rust source (saves a new baseline),
+# and on every PR that touches Rust source (compares against the latest main
+# baseline and posts a comment).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+# Keep the fixture version in sync with download-fixtures.sh.
+env:
+  LARAVEL_FIXTURE_VERSION: v11.44.7
+
+jobs:
+  bench:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   # needed to post the comparison comment
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Caches registry index, downloaded crates, and compiled artifacts.
+      # The bench profile inherits [profile.release] (lto=thin, codegen-units=1)
+      # so the first compile is slow; this makes subsequent runs fast.
+      - uses: Swatinem/rust-cache@v2
+
+      # critcmp reads Criterion's raw JSON and produces a before/after table.
+      # Cache the compiled binary so we don't rebuild it on every run.
+      - name: Cache critcmp
+        id: critcmp-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/critcmp
+          key: critcmp-${{ runner.os }}-v1
+
+      - name: Install critcmp
+        if: steps.critcmp-cache.outputs.cache-hit != 'true'
+        run: cargo install critcmp
+
+      # Cache the cloned + composer-installed fixture. Key includes the pinned
+      # version so a version bump in download-fixtures.sh automatically
+      # invalidates the cache.
+      - name: Cache Laravel fixture
+        id: fixture-cache
+        uses: actions/cache@v4
+        with:
+          path: crates/mir-analyzer/benches/fixtures
+          key: laravel-fixture-${{ env.LARAVEL_FIXTURE_VERSION }}
+
+      # PHP + Composer are only needed when the fixture cache is cold.
+      - name: Set up PHP
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      - name: Download and install benchmark fixture
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        run: bash crates/mir-analyzer/benches/download-fixtures.sh
+
+      # Reduce measurement noise on the shared runner:
+      #   - ASLR off → stable memory-layout addresses across samples
+      #   - Performance governor → no frequency scaling mid-measurement
+      #   - No turbo boost → eliminates burst-clock outliers
+      # These are best-effort; governors and turbo knobs are silently
+      # unavailable in most cloud VMs.
+      - name: Tune system for stable measurements
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+          echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 2>/dev/null || true
+          echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null || true
+
+      # PRs: restore the most recent main baseline so critcmp can compare.
+      - name: Restore main baseline
+        if: github.event_name == 'pull_request'
+        id: restore-baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: target/criterion
+          # Exact key won't match (PR SHA ≠ any main SHA); falls through to
+          # restore-keys prefix match which picks the most recent main run.
+          key: criterion-baseline-main-${{ github.sha }}
+          restore-keys: criterion-baseline-main-
+
+      - name: Run benchmarks
+        env:
+          # 'main' on push, 'pr' on pull_request — used by --save-baseline.
+          BASELINE_NAME: ${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
+        run: |
+          cargo bench -p mir-analyzer --bench analyze_real_world \
+            -- --save-baseline "$BASELINE_NAME" --noplot
+
+      # Push to main: persist the new baseline for future PR comparisons.
+      - name: Save main baseline
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-main-${{ github.sha }}
+
+      # PRs: compare and post. Skip gracefully if no baseline was restored
+      # (first benchmark run ever, or cache was evicted).
+      - name: Compare baselines
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore-baseline.outputs.cache-hit == 'true'
+        run: critcmp main pr | tee critcmp-output.txt
+
+      - name: Post comparison comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore-baseline.outputs.cache-hit == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const table = fs.readFileSync('critcmp-output.txt', 'utf8');
+            const logsUrl =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const body =
+              `## Benchmark results (PR vs \`main\`)\n` +
+              `\`\`\`\n${table}\`\`\`\n` +
+              `*Peak memory and total-allocation stats are printed to stderr — ` +
+              `see the [workflow logs](${logsUrl}) for those numbers.*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /book
+crates/mir-analyzer/benches/fixtures/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,10 +140,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -198,6 +252,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +311,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -316,6 +412,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +448,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hybrid-array"
@@ -383,6 +496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +517,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -493,6 +626,7 @@ name = "mir-analyzer"
 version = "0.5.2"
 dependencies = [
  "bumpalo",
+ "criterion",
  "indexmap",
  "mir-codebase",
  "mir-issues",
@@ -556,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +718,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "owo-colors"
@@ -626,6 +775,34 @@ dependencies = [
  "php-ast",
  "php-lexer",
  "thiserror",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -707,6 +884,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +936,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -898,6 +1113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1169,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
@@ -1043,6 +1278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1295,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1153,6 +1407,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/mir-analyzer/Cargo.toml
+++ b/crates/mir-analyzer/Cargo.toml
@@ -26,3 +26,8 @@ quick-xml     = "0.36"
 [dev-dependencies]
 mir-issues     = { workspace = true }
 tempfile = "3.27.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name    = "analyze_real_world"
+harness = false

--- a/crates/mir-analyzer/benches/analyze_real_world.rs
+++ b/crates/mir-analyzer/benches/analyze_real_world.rs
@@ -1,0 +1,429 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use mir_analyzer::ProjectAnalyzer;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering::Relaxed};
+use std::time::Duration;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Counting allocator
+//
+// Tracks peak live bytes and total bytes allocated since the last
+// `reset_alloc_counters()` call. Thread-safe via atomics.
+//
+// Pre-existing allocations freed after a reset drive LIVE_BYTES negative,
+// which is intentional: PEAK_BYTES only updates while live > 0, so it
+// reflects only allocations that occurred after the reset point.
+// ---------------------------------------------------------------------------
+
+struct CountingAllocator;
+
+static LIVE_BYTES: AtomicI64 = AtomicI64::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            let live = LIVE_BYTES.fetch_add(layout.size() as i64, Relaxed) + layout.size() as i64;
+            if live > 0 {
+                PEAK_BYTES.fetch_max(live as usize, Relaxed);
+            }
+            TOTAL_BYTES.fetch_add(layout.size(), Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        LIVE_BYTES.fetch_sub(layout.size() as i64, Relaxed);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn reset_alloc_counters() {
+    LIVE_BYTES.store(0, Relaxed);
+    PEAK_BYTES.store(0, Relaxed);
+    TOTAL_BYTES.store(0, Relaxed);
+}
+
+fn print_alloc_stats(label: &str) {
+    let peak = PEAK_BYTES.load(Relaxed) as f64 / 1_048_576.0;
+    let total = TOTAL_BYTES.load(Relaxed) as f64 / 1_048_576.0;
+    eprintln!(
+        "  [memory] {}: peak live {:.1} MiB, total allocated {:.1} MiB  (one cold run)",
+        label, peak, total
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/fixtures/laravel")
+}
+
+/// Returns true (and prints a message) when the fixture is absent or
+/// `composer install` has not been run yet.
+fn skip_if_missing(root: &Path) -> bool {
+    let src = root.join("src");
+    let vendor = root.join("vendor");
+    if !src.exists() || !vendor.exists() {
+        eprintln!(
+            "\nSkipping benchmark: fixture not found or incomplete at {}\n\
+             Run once to download and install it:\n\
+             \n    bash crates/mir-analyzer/benches/download-fixtures.sh\n",
+            root.display()
+        );
+        true
+    } else {
+        false
+    }
+}
+
+/// Split files into (vendor, project) using the real composer-installed
+/// `vendor/` directory and the framework's own `src/` directory — the same
+/// split the CLI performs for a composer-managed project.
+fn split_vendor_project(root: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let vendor_files = ProjectAnalyzer::discover_files(&root.join("vendor"));
+    let project_files = ProjectAnalyzer::discover_files(&root.join("src"));
+    (vendor_files, project_files)
+}
+
+/// Run the full pipeline once into `cache_dir` so subsequent analyses can use
+/// cached results.
+fn warm_cache(cache_dir: &TempDir, vendor_files: &[PathBuf], project_files: &[PathBuf]) {
+    let analyzer = ProjectAnalyzer::with_cache(cache_dir.path());
+    analyzer.load_stubs();
+    analyzer.collect_types_only(vendor_files);
+    let _ = analyzer.analyze(project_files);
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+//
+// NOTE: Results are only meaningful under the `bench` profile (release-
+// equivalent). Running under debug (`cargo test --bench`) produces numbers
+// that are 5–10× slower and should be ignored.
+// ---------------------------------------------------------------------------
+
+/// Cold-start full pipeline: stubs + vendor type collection + Pass 1 +
+/// codebase finalization + Pass 2. No cache.
+///
+/// Benchmarked at both 1 thread and the default thread count so that
+/// parallelism scaling (or contention regressions) are visible.
+///
+/// Memory stats for one cold run are printed to stderr before the timed loop.
+fn bench_full_analysis(c: &mut Criterion) {
+    let root = fixtures_root();
+    if skip_if_missing(&root) {
+        return;
+    }
+
+    let (vendor_files, project_files) = split_vendor_project(&root);
+    assert!(
+        !project_files.is_empty(),
+        "No project PHP files found under {}",
+        root.display()
+    );
+
+    // Print memory stats once before the Criterion loop.
+    reset_alloc_counters();
+    {
+        let analyzer = ProjectAnalyzer::new();
+        analyzer.load_stubs();
+        analyzer.collect_types_only(&vendor_files);
+        let _ = analyzer.analyze(&project_files);
+    }
+    print_alloc_stats("full_analysis/laravel");
+
+    let num_threads = rayon::current_num_threads();
+    let mut thread_counts = vec![1usize, num_threads];
+    thread_counts.dedup(); // avoid duplicate variant on single-core machines
+
+    let mut group = c.benchmark_group("full_analysis");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+    group.throughput(Throughput::Elements(project_files.len() as u64));
+
+    for &threads in &thread_counts {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap();
+
+        group.bench_function(BenchmarkId::new("laravel", format!("{threads}t")), |b| {
+            b.iter(|| {
+                pool.install(|| {
+                    let analyzer = ProjectAnalyzer::new();
+                    analyzer.load_stubs();
+                    analyzer.collect_types_only(&vendor_files);
+                    analyzer.analyze(&project_files)
+                })
+            })
+        });
+    }
+
+    group.finish();
+}
+
+/// Incremental re-analysis with a warm cache, as the CLI experiences it: every
+/// iteration rebuilds the codebase from scratch (stubs + vendor collection +
+/// project analysis), but project files that have not changed are served from
+/// the cache. Two variants show worst-case and best-case invalidation:
+///
+/// * `high_fanout` — touches `Model.php`, a large base class with many
+///   subclasses. `evict_with_dependents` cascades widely; worst-case path.
+///
+/// * `leaf_file` — touches `Auth/Events/Login.php`, an event class with no
+///   dependents. Only one file is re-analysed; best-case path.
+///
+/// Vendor-reload cost is intentionally included because the CLI always re-runs
+/// it. See `bench_reanalysis_project_only` to isolate the cache benefit alone.
+///
+/// Memory stats for one warm re-analysis run are printed to stderr.
+fn bench_reanalysis(c: &mut Criterion) {
+    let root = fixtures_root();
+    // Bug fix: check both src/ and vendor/, not just root existence.
+    if skip_if_missing(&root) {
+        return;
+    }
+
+    let (vendor_files, project_files) = split_vendor_project(&root);
+
+    let model_path = root.join("src/Illuminate/Database/Eloquent/Model.php");
+    let leaf_path = root.join("src/Illuminate/Auth/Events/Login.php");
+
+    let model_original = model_path
+        .exists()
+        .then(|| std::fs::read_to_string(&model_path).unwrap());
+    let leaf_original = leaf_path
+        .exists()
+        .then(|| std::fs::read_to_string(&leaf_path).unwrap());
+
+    if model_original.is_none() && leaf_original.is_none() {
+        eprintln!("\nSkipping reanalysis: neither target file found");
+        return;
+    }
+
+    // Memory snapshot: one warm re-analysis run before the Criterion loop.
+    if let Some(original) = &model_original {
+        let cache_mem: TempDir = tempfile::tempdir().unwrap();
+        warm_cache(&cache_mem, &vendor_files, &project_files);
+        std::fs::write(&model_path, format!("{}\n// memory-check", original)).unwrap();
+        reset_alloc_counters();
+        {
+            let analyzer = ProjectAnalyzer::with_cache(cache_mem.path());
+            analyzer.load_stubs();
+            analyzer.collect_types_only(&vendor_files);
+            let _ = analyzer.analyze(&project_files);
+        }
+        print_alloc_stats("reanalysis/laravel_high_fanout");
+        std::fs::write(&model_path, original).unwrap();
+    }
+
+    // Separate cache dirs so the two variants don't interfere with each other.
+    let cache_model: TempDir = tempfile::tempdir().unwrap();
+    let cache_leaf: TempDir = tempfile::tempdir().unwrap();
+    if model_original.is_some() {
+        warm_cache(&cache_model, &vendor_files, &project_files);
+    }
+    if leaf_original.is_some() {
+        warm_cache(&cache_leaf, &vendor_files, &project_files);
+    }
+
+    let mut counter_model = 0u32;
+    let mut counter_leaf = 0u32;
+
+    let mut group = c.benchmark_group("reanalysis");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.throughput(Throughput::Elements(project_files.len() as u64));
+
+    if let Some(original) = &model_original {
+        group.bench_function("laravel_high_fanout", |b| {
+            b.iter_batched(
+                || {
+                    // Not timed: touch the file so its content hash changes.
+                    counter_model += 1;
+                    std::fs::write(
+                        &model_path,
+                        format!("{}\n// bench {}", original, counter_model),
+                    )
+                    .unwrap();
+                },
+                |_| {
+                    let analyzer = ProjectAnalyzer::with_cache(cache_model.path());
+                    analyzer.load_stubs();
+                    analyzer.collect_types_only(&vendor_files);
+                    analyzer.analyze(&project_files)
+                },
+                BatchSize::LargeInput,
+            );
+        });
+        std::fs::write(&model_path, original).unwrap();
+    }
+
+    if let Some(original) = &leaf_original {
+        group.bench_function("laravel_leaf_file", |b| {
+            b.iter_batched(
+                || {
+                    counter_leaf += 1;
+                    std::fs::write(
+                        &leaf_path,
+                        format!("{}\n// bench {}", original, counter_leaf),
+                    )
+                    .unwrap();
+                },
+                |_| {
+                    let analyzer = ProjectAnalyzer::with_cache(cache_leaf.path());
+                    analyzer.load_stubs();
+                    analyzer.collect_types_only(&vendor_files);
+                    analyzer.analyze(&project_files)
+                },
+                BatchSize::LargeInput,
+            );
+        });
+        std::fs::write(&leaf_path, original).unwrap();
+    }
+
+    group.finish();
+}
+
+/// Isolates the pure cache benefit: vendor types are pre-loaded in the untimed
+/// setup, so each timed iteration measures only `analyze()`. Directly
+/// comparable to the `analyze()` portion of `full_analysis` without the
+/// constant vendor-reload cost that would otherwise compress the signal.
+fn bench_reanalysis_project_only(c: &mut Criterion) {
+    let root = fixtures_root();
+    if skip_if_missing(&root) {
+        return;
+    }
+
+    let (vendor_files, project_files) = split_vendor_project(&root);
+
+    let model_path = root.join("src/Illuminate/Database/Eloquent/Model.php");
+    let leaf_path = root.join("src/Illuminate/Auth/Events/Login.php");
+
+    let model_original = model_path
+        .exists()
+        .then(|| std::fs::read_to_string(&model_path).unwrap());
+    let leaf_original = leaf_path
+        .exists()
+        .then(|| std::fs::read_to_string(&leaf_path).unwrap());
+
+    if model_original.is_none() && leaf_original.is_none() {
+        return;
+    }
+
+    let cache_model: TempDir = tempfile::tempdir().unwrap();
+    let cache_leaf: TempDir = tempfile::tempdir().unwrap();
+    if model_original.is_some() {
+        warm_cache(&cache_model, &vendor_files, &project_files);
+    }
+    if leaf_original.is_some() {
+        warm_cache(&cache_leaf, &vendor_files, &project_files);
+    }
+
+    let mut counter_model = 0u32;
+    let mut counter_leaf = 0u32;
+
+    let mut group = c.benchmark_group("reanalysis_project_only");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.throughput(Throughput::Elements(project_files.len() as u64));
+
+    if let Some(original) = &model_original {
+        group.bench_function("laravel_high_fanout", |b| {
+            b.iter_batched(
+                || {
+                    // Not timed: touch file and pre-load stubs + vendor types into
+                    // a fresh analyzer so only `analyze()` is measured.
+                    counter_model += 1;
+                    std::fs::write(
+                        &model_path,
+                        format!("{}\n// bench {}", original, counter_model),
+                    )
+                    .unwrap();
+                    let analyzer = ProjectAnalyzer::with_cache(cache_model.path());
+                    analyzer.load_stubs();
+                    analyzer.collect_types_only(&vendor_files);
+                    analyzer
+                },
+                |analyzer| analyzer.analyze(&project_files),
+                BatchSize::LargeInput,
+            );
+        });
+        std::fs::write(&model_path, original).unwrap();
+    }
+
+    if let Some(original) = &leaf_original {
+        group.bench_function("laravel_leaf_file", |b| {
+            b.iter_batched(
+                || {
+                    counter_leaf += 1;
+                    std::fs::write(
+                        &leaf_path,
+                        format!("{}\n// bench {}", original, counter_leaf),
+                    )
+                    .unwrap();
+                    let analyzer = ProjectAnalyzer::with_cache(cache_leaf.path());
+                    analyzer.load_stubs();
+                    analyzer.collect_types_only(&vendor_files);
+                    analyzer
+                },
+                |analyzer| analyzer.analyze(&project_files),
+                BatchSize::LargeInput,
+            );
+        });
+        std::fs::write(&leaf_path, original).unwrap();
+    }
+
+    group.finish();
+}
+
+/// Vendor type collection: stubs + `collect_types_only` across the real
+/// composer-installed `vendor/` directory, no body analysis. Isolates the cost
+/// of loading third-party type definitions before project analysis.
+///
+/// Note: unlike the project Pass 1 inside `full_analysis`, this skips the FQCN
+/// pre-index step, so it measures a slightly narrower slice of the pipeline.
+fn bench_vendor_collection(c: &mut Criterion) {
+    let root = fixtures_root();
+    // Bug fix: check vendor/ specifically, not just root existence.
+    if skip_if_missing(&root) {
+        return;
+    }
+
+    // Bug fix: collect from vendor/ only, not the entire repo root.
+    let vendor_files = ProjectAnalyzer::discover_files(&root.join("vendor"));
+
+    let mut group = c.benchmark_group("vendor_collection");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.throughput(Throughput::Elements(vendor_files.len() as u64));
+
+    group.bench_function("laravel", |b| {
+        b.iter(|| {
+            let analyzer = ProjectAnalyzer::new();
+            analyzer.load_stubs();
+            analyzer.collect_types_only(&vendor_files)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_full_analysis,
+    bench_reanalysis,
+    bench_reanalysis_project_only,
+    bench_vendor_collection
+);
+criterion_main!(benches);

--- a/crates/mir-analyzer/benches/download-fixtures.sh
+++ b/crates/mir-analyzer/benches/download-fixtures.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Downloads the laravel/framework fixture used by the real-world benchmarks.
+# Pins the version so every machine analyses the exact same PHP files.
+# To upgrade: delete benches/fixtures/laravel/, bump LARAVEL_VERSION, re-run.
+#
+# Prerequisites: git, composer
+set -euo pipefail
+
+LARAVEL_VERSION="v11.44.7"
+DEST="$(dirname "$0")/fixtures/laravel"
+
+if [ -d "$DEST" ]; then
+    echo "Fixture already exists at $DEST — skipping."
+    echo "Delete it and re-run to refresh: rm -rf $DEST"
+    exit 0
+fi
+
+echo "Cloning laravel/framework $LARAVEL_VERSION into $DEST ..."
+git clone --depth=1 --branch "$LARAVEL_VERSION" \
+    https://github.com/laravel/framework "$DEST"
+
+echo ""
+echo "Installing vendor dependencies (composer install) ..."
+composer install \
+    --working-dir="$DEST" \
+    --no-scripts \
+    --no-plugins \
+    --no-interaction \
+    --prefer-dist \
+    --quiet
+
+echo ""
+echo "Done. Run benchmarks with:"
+echo "  cargo bench -p mir-analyzer --bench analyze_real_world"


### PR DESCRIPTION
## Summary

- Adds `crates/mir-analyzer/benches/analyze_real_world.rs` — a Criterion benchmark that runs mir against a real PHP codebase (laravel/framework v11.44.7, ~800 files with composer-installed vendor/)
- Four benchmark groups: cold-start full pipeline (1-thread and N-thread variants with memory stats), warm-cache incremental re-analysis (high-fanout + leaf-file variants), cache-isolated project-only re-analysis, and vendor-only type collection
- `benches/download-fixtures.sh` script for one-time fixture download + `composer install`

## How to use

```sh
# One-time setup
bash crates/mir-analyzer/benches/download-fixtures.sh

# Run all benchmarks
cargo bench -p mir-analyzer --bench analyze_real_world

# Save a baseline before a change, compare after
cargo bench -p mir-analyzer --bench analyze_real_world -- --save-baseline main
cargo bench -p mir-analyzer --bench analyze_real_world -- --baseline main
```

## Note

`.github/workflows/bench.yml` (CI that saves baselines on `main` and posts comparisons on PRs) is ready locally but requires the `workflow` OAuth scope to push. It will be added in a follow-up commit after running:
```
gh auth refresh -s workflow --hostname github.com
```