### PR TITLE
feat(analyzer): emit InvalidScope when $this is used in invalid context

### DIFF
--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -105,7 +105,15 @@ impl<'a> ExpressionAnalyzer<'a> {
                             Severity::Info,
                             expr.span,
                         );
-                    } else if name_str != "this" {
+                    } else if name_str == "this" {
+                        self.emit(
+                            IssueKind::InvalidScope {
+                                in_class: ctx.self_fqcn.is_some(),
+                            },
+                            Severity::Error,
+                            expr.span,
+                        );
+                    } else {
                         self.emit(
                             IssueKind::UndefinedVariable {
                                 name: name_str.to_string(),
@@ -116,7 +124,11 @@ impl<'a> ExpressionAnalyzer<'a> {
                     }
                 }
                 ctx.read_vars.insert(name_str.to_string());
-                let ty = ctx.get_var(name_str);
+                let ty = if name_str == "this" && !ctx.var_is_defined("this") {
+                    Union::never()
+                } else {
+                    ctx.get_var(name_str)
+                };
                 self.record_symbol(
                     expr.span,
                     SymbolKind::Variable(name_str.to_string()),

--- a/crates/mir-analyzer/tests/fixtures/invalid_scope/does_not_report_this_in_instance_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_scope/does_not_report_this_in_instance_method.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class Foo {
+    public function bar(): void {
+        $this->baz();
+    }
+    public function baz(): void {}
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_in_static_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_in_static_method.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class Foo {
+    public static function bar(): void {
+        $this->close();
+    }
+}
+===expect===
+InvalidScope: $this

--- a/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_outside_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_outside_class.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function test(): void {
+    $this->close();
+}
+===expect===
+InvalidScope: $this

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -56,6 +56,10 @@ impl fmt::Display for Location {
 #[non_exhaustive]
 pub enum IssueKind {
     // --- Undefined ----------------------------------------------------------
+    InvalidScope {
+        /// `true` when inside a class but in a static method; `false` when outside a class.
+        in_class: bool,
+    },
     UndefinedVariable {
         name: String,
     },
@@ -306,7 +310,8 @@ impl IssueKind {
     pub fn default_severity(&self) -> Severity {
         match self {
             // Errors (always blocking)
-            IssueKind::UndefinedVariable { .. }
+            IssueKind::InvalidScope { .. }
+            | IssueKind::UndefinedVariable { .. }
             | IssueKind::UndefinedFunction { .. }
             | IssueKind::UndefinedMethod { .. }
             | IssueKind::UndefinedClass { .. }
@@ -383,6 +388,7 @@ impl IssueKind {
     /// Identifier name used in config and `@psalm-suppress` / `@suppress` annotations.
     pub fn name(&self) -> &'static str {
         match self {
+            IssueKind::InvalidScope { .. } => "InvalidScope",
             IssueKind::UndefinedVariable { .. } => "UndefinedVariable",
             IssueKind::UndefinedFunction { .. } => "UndefinedFunction",
             IssueKind::UndefinedMethod { .. } => "UndefinedMethod",
@@ -454,6 +460,13 @@ impl IssueKind {
     /// Human-readable message for this issue.
     pub fn message(&self) -> String {
         match self {
+            IssueKind::InvalidScope { in_class } => {
+                if *in_class {
+                    "$this cannot be used in a static method".to_string()
+                } else {
+                    "$this cannot be used outside of a class".to_string()
+                }
+            }
             IssueKind::UndefinedVariable { name } => format!("Variable ${} is not defined", name),
             IssueKind::UndefinedFunction { name } => format!("Function {}() is not defined", name),
             IssueKind::UndefinedMethod { class, method } => {


### PR DESCRIPTION
## Summary

- Adds a new `InvalidScope` error diagnostic (matching Psalm's name) emitted when `$this` is used in a static method or outside a class
- `$this` resolves to `never` in invalid scope so no cascading `MixedMethodCall` info diagnostic is produced
- Distinguishes two cases in the message: static method context vs. outside a class entirely

Fixes #218

## Test plan

- [ ] `reports_this_in_static_method` — `InvalidScope` emitted for `$this` in a static method
- [ ] `reports_this_outside_class` — `InvalidScope` emitted for `$this` in a free function
- [ ] `does_not_report_this_in_instance_method` — no diagnostic for valid `$this` usage