### PR TITLE
fix(analyzer): emit InvalidArgument for union arg passed to narrower param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-19
+
+### Added
+
+- **Recurse into nested function and class bodies** — the analyzer now descends into nested function declarations and class definitions inside method/function bodies, catching issues in inner scopes that were previously invisible. (#223)
+- **`UndefinedClass` for `extends`/`implements`** — emit `UndefinedClass` when a class extends or implements a type that does not exist in the codebase or stubs. (#224)
+- **`InvalidScope` for `$this` in invalid context** — emit `InvalidScope` when `$this` is used outside of an object method (e.g., in a static method or free function). (#220)
+- **Real-world Criterion benchmark suite** — added a benchmark that runs analysis over a realistic PHP codebase for continuous performance regression tracking. (#219)
+
+### Fixed
+
+- **Intersection type hints** — `type_from_hint` now correctly resolves intersection types (`A&B`), fixing false positives in type-narrowing and parameter checks. (#221)
+
 ## [0.5.2] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -472,12 +472,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -535,9 +535,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -551,9 +551,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "php-ast"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dce9b70d41d6ec987d3bbf004988328aac6e40ab096ca5ec6b62d56e36f0078"
+checksum = "8b7cbca17f0b064532cb6c0457ee6e92f7f165eac108af0c35cd5619d006bacb"
 dependencies = [
  "bumpalo",
  "serde",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f318987253ab8cee464f92fef2d4371bf1689fc75cc46ecd9fdbed0f3a17e7cb"
+checksum = "d6d53970e88af699d5754b0cd6e4ba7797fd25188a842f48800af863ca27e896"
 dependencies = [
  "memchr",
  "php-ast",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5cefd4056147d9307d0ab2f4b56ddc12176a4a021474bec6748de742a95dd45"
+checksum = "717c6c49a71d550e31d63c78ece9683ef9d67b06d8e4ddc743f0bbed6f7b405b"
 dependencies = [
  "bumpalo",
  "miette",
@@ -856,9 +856,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1182,11 +1182,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1195,14 +1195,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1213,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1223,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1279,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1329,6 +1329,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "dashmap",
  "indexmap",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Jorg Sowa <jorg.sowa@gmail.com>"]
@@ -18,10 +18,10 @@ homepage = "https://github.com/jorgsowa/mir"
 
 [workspace.dependencies]
 # Internal crates
-mir-types      = { path = "crates/mir-types",      version = "0.5.2" }
-mir-issues     = { path = "crates/mir-issues",     version = "0.5.2" }
-mir-codebase   = { path = "crates/mir-codebase",   version = "0.5.2" }
-mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.5.2" }
+mir-types      = { path = "crates/mir-types",      version = "0.6.0" }
+mir-issues     = { path = "crates/mir-issues",     version = "0.6.0" }
+mir-codebase   = { path = "crates/mir-codebase",   version = "0.6.0" }
+mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.6.0" }
 
 # PHP parsing
 php-rs-parser = "0.8"

--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -909,11 +909,13 @@ fn check_args(ea: &mut ExpressionAnalyzer<'_>, p: CheckArgsParams<'_>) {
                 && !array_list_compatible(arg_ty, param_ty, ea)
                 // Skip when param is more specific than arg (coercion, not hard error):
                 // e.g. string → non-empty-string, int → positive-int, string → string|null
-                && !param_ty.is_subtype_of_simple(arg_ty)
+                // Only applies when arg is a single type; union args like int|string passed to
+                // an int param must still error even though int <: int|string.
+                && !(arg_ty.is_single() && param_ty.is_subtype_of_simple(arg_ty))
                 // Skip when non-null part of param is a subtype of arg (e.g. non-empty-string|null ← string)
-                && !param_ty.remove_null().is_subtype_of_simple(arg_ty)
+                && !(arg_ty.is_single() && param_ty.remove_null().is_subtype_of_simple(arg_ty))
                 // Skip when any atomic in param is a subtype of arg (e.g. non-empty-string|list ← string)
-                && !param_ty.types.iter().any(|p| Union::single(p.clone()).is_subtype_of_simple(arg_ty))
+                && !(arg_ty.is_single() && param_ty.types.iter().any(|p| Union::single(p.clone()).is_subtype_of_simple(arg_ty)))
                 // Skip when arg is compatible after removing null/false (PossiblyNull/FalseArgument
                 // handles these separately and they may appear in the baseline)
                 && !arg_ty.remove_null().is_subtype_of_simple(param_ty)

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function g(): int|string { return 1; }
+function f(int $x): void { var_dump($x); }
+function test(): void { f(g()); }
+===expect===
+InvalidArgument: g()


### PR DESCRIPTION
## Summary

- Three coercion-skip conditions in `check_args` (`call.rs`) incorrectly suppressed `InvalidArgument` when a union-typed arg was passed to a narrower parameter type (e.g. `int|string` → `int`).
- Root cause: `int <: int|string` is true, so the guards treating "param is subtype of arg" as coercion fired even though `string` is completely incompatible with `int`.
- Fix: restrict those three guards to single-type args only (`arg_ty.is_single()`), so union args with incompatible types now correctly emit `InvalidArgument`.

Fixes #44

## Test plan

- [ ] New fixture `invalid_argument/reports_incompatible_union_arg.phpt` verifies the error is emitted
- [ ] All 219 existing tests pass with no regressions (`cargo test -p mir-analyzer`)