### PR TITLE
fix(analyzer): emit InvalidArgument for union arg passed to narrower param

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -909,11 +909,13 @@ fn check_args(ea: &mut ExpressionAnalyzer<'_>, p: CheckArgsParams<'_>) {
                 && !array_list_compatible(arg_ty, param_ty, ea)
                 // Skip when param is more specific than arg (coercion, not hard error):
                 // e.g. string → non-empty-string, int → positive-int, string → string|null
-                && !param_ty.is_subtype_of_simple(arg_ty)
+                // Only applies when arg is a single type; union args like int|string passed to
+                // an int param must still error even though int <: int|string.
+                && !(arg_ty.is_single() && param_ty.is_subtype_of_simple(arg_ty))
                 // Skip when non-null part of param is a subtype of arg (e.g. non-empty-string|null ← string)
-                && !param_ty.remove_null().is_subtype_of_simple(arg_ty)
+                && !(arg_ty.is_single() && param_ty.remove_null().is_subtype_of_simple(arg_ty))
                 // Skip when any atomic in param is a subtype of arg (e.g. non-empty-string|list ← string)
-                && !param_ty.types.iter().any(|p| Union::single(p.clone()).is_subtype_of_simple(arg_ty))
+                && !(arg_ty.is_single() && param_ty.types.iter().any(|p| Union::single(p.clone()).is_subtype_of_simple(arg_ty)))
                 // Skip when arg is compatible after removing null/false (PossiblyNull/FalseArgument
                 // handles these separately and they may appear in the baseline)
                 && !arg_ty.remove_null().is_subtype_of_simple(param_ty)

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function g(): int|string { return 1; }
+function f(int $x): void { var_dump($x); }
+function test(): void { f(g()); }
+===expect===
+InvalidArgument: g()


### PR DESCRIPTION
## Summary

- Three coercion-skip conditions in `check_args` (`call.rs`) incorrectly suppressed `InvalidArgument` when a union-typed arg was passed to a narrower parameter type (e.g. `int|string` → `int`).
- Root cause: `int <: int|string` is true, so the guards treating "param is subtype of arg" as coercion fired even though `string` is completely incompatible with `int`.
- Fix: restrict those three guards to single-type args only (`arg_ty.is_single()`), so union args with incompatible types now correctly emit `InvalidArgument`.

Fixes #44

## Test plan

- [ ] New fixture `invalid_argument/reports_incompatible_union_arg.phpt` verifies the error is emitted
- [ ] All 219 existing tests pass with no regressions (`cargo test -p mir-analyzer`)