### PR TITLE
feat(fixtures): assert full error messages in phpt expect sections

### DIFF
--- a/crates/mir-analyzer/src/test_utils.rs
+++ b/crates/mir-analyzer/src/test_utils.rs
@@ -52,10 +52,10 @@ fn check_with_opts(src: &str, find_dead_code: bool) -> Vec<Issue> {
 
 /// One expected issue from a `.phpt` fixture's `===expect===` section.
 ///
-/// Format: `KindName: snippet`
+/// Format: `KindName: full human-readable message`
 pub struct ExpectedIssue {
     pub kind_name: String,
-    pub snippet: String,
+    pub message: String,
 }
 
 /// Parse a `.phpt` fixture file into `(php_source, expected_issues)`.
@@ -66,8 +66,8 @@ pub struct ExpectedIssue {
 /// <?php
 /// ...
 /// ===expect===
-/// UndefinedClass: UnknownClass
-/// UndefinedFunction: foo()
+/// UndefinedClass: Class 'UnknownClass' not found
+/// UndefinedFunction: Function 'foo' not found
 /// ```
 /// An empty `===expect===` section means no issues are expected.
 pub fn parse_phpt(content: &str, path: &str) -> (String, Vec<ExpectedIssue>) {
@@ -121,18 +121,18 @@ fn parse_phpt_source_only(content: &str, path: &str) -> String {
 }
 
 fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
-    // Format: "KindName: snippet"
+    // Format: "KindName: full human-readable message"
     let parts: Vec<&str> = line.splitn(2, ": ").collect();
     assert_eq!(
         parts.len(),
         2,
-        "fixture {}: invalid expect line {:?} — expected \"KindName: snippet\"",
+        "fixture {}: invalid expect line {:?} — expected \"KindName: message\"",
         fixture_path,
         line
     );
     ExpectedIssue {
         kind_name: parts[0].trim().to_string(),
-        snippet: parts[1].trim().to_string(),
+        message: parts[1].trim().to_string(),
     }
 }
 
@@ -170,38 +170,22 @@ fn run_fixture_with_opts(path: &str, find_dead_code: bool) {
     let mut failures: Vec<String> = Vec::new();
 
     for exp in &expected {
-        let found = actual.iter().any(|a| {
-            if a.kind.name() != exp.kind_name {
-                return false;
-            }
-            if exp.snippet == "<no snippet>" {
-                a.snippet.is_none()
-            } else {
-                a.snippet.as_deref() == Some(exp.snippet.as_str())
-            }
-        });
+        let found = actual
+            .iter()
+            .any(|a| a.kind.name() == exp.kind_name && a.kind.message() == exp.message.as_str());
         if !found {
-            failures.push(format!("  MISSING  {}: {}", exp.kind_name, exp.snippet));
+            failures.push(format!("  MISSING  {}: {}", exp.kind_name, exp.message));
         }
     }
 
     for act in &actual {
-        let expected_it = expected.iter().any(|e| {
-            if e.kind_name != act.kind.name() {
-                return false;
-            }
-            if e.snippet == "<no snippet>" {
-                act.snippet.is_none()
-            } else {
-                act.snippet.as_deref() == Some(e.snippet.as_str())
-            }
-        });
+        let expected_it = expected
+            .iter()
+            .any(|e| e.kind_name == act.kind.name() && e.message == act.kind.message());
         if !expected_it {
-            let snippet = act.snippet.as_deref().unwrap_or("<no snippet>");
             failures.push(format!(
-                "  UNEXPECTED {}: {}  — {}",
+                "  UNEXPECTED {}: {}",
                 act.kind.name(),
-                snippet,
                 act.kind.message(),
             ));
         }
@@ -238,8 +222,11 @@ fn rewrite_fixture(path: &str, content: &str, actual: &[Issue]) {
     sorted.sort_by_key(|i| (i.location.line, i.location.col_start, i.kind.name()));
 
     for issue in sorted {
-        let snippet = issue.snippet.as_deref().unwrap_or("<no snippet>");
-        new_content.push_str(&format!("{}: {}\n", issue.kind.name(), snippet));
+        new_content.push_str(&format!(
+            "{}: {}\n",
+            issue.kind.name(),
+            issue.kind.message()
+        ));
     }
 
     std::fs::write(path, &new_content)
@@ -307,10 +294,7 @@ fn fmt_issues(issues: &[Issue]) -> String {
     }
     issues
         .iter()
-        .map(|i| {
-            let snippet = i.snippet.as_deref().unwrap_or("<no snippet>");
-            format!("  {}: {}  — {}", i.kind.name(), snippet, i.kind.message(),)
-        })
+        .map(|i| format!("  {}: {}", i.kind.name(), i.kind.message()))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_self_extends.phpt
+++ b/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_self_extends.phpt
@@ -2,4 +2,4 @@
 <?php
 class A extends A {}
 ===expect===
-CircularInheritance: class A extends A {}
+CircularInheritance: Class A has a circular inheritance chain

--- a/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_three_cycle.phpt
+++ b/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_three_cycle.phpt
@@ -4,4 +4,4 @@ class A extends B {}
 class B extends C {}
 class C extends A {}
 ===expect===
-CircularInheritance: class C extends A {}
+CircularInheritance: Class C has a circular inheritance chain

--- a/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_two_cycle.phpt
+++ b/crates/mir-analyzer/tests/fixtures/circular_inheritance/class_two_cycle.phpt
@@ -3,4 +3,4 @@
 class A extends B {}
 class B extends A {}
 ===expect===
-CircularInheritance: class B extends A {}
+CircularInheritance: Class B has a circular inheritance chain

--- a/crates/mir-analyzer/tests/fixtures/circular_inheritance/interface_two_cycle.phpt
+++ b/crates/mir-analyzer/tests/fixtures/circular_inheritance/interface_two_cycle.phpt
@@ -3,4 +3,4 @@
 interface I1 extends I2 {}
 interface I2 extends I1 {}
 ===expect===
-CircularInheritance: interface I2 extends I1 {}
+CircularInheritance: Class I2 has a circular inheritance chain

--- a/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function.phpt
@@ -7,5 +7,5 @@ function test(): void {
     oldGreet('Alice');
 }
 ===expect===
-UnusedParam: $name
-DeprecatedCall: oldGreet('Alice')
+UnusedParam: Parameter $name is never used
+DeprecatedCall: Call to deprecated function oldGreet

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method.phpt
@@ -9,4 +9,4 @@ function test(Foo $foo): void {
     $foo->oldMethod();
 }
 ===expect===
-DeprecatedMethodCall: $foo->oldMethod()
+DeprecatedMethodCall: Call to deprecated method Foo::oldMethod

--- a/crates/mir-analyzer/tests/fixtures/final_class_extended/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_class_extended/basic.phpt
@@ -3,4 +3,4 @@
 final class Base {}
 class Child extends Base {}
 ===expect===
-FinalClassExtended: class Child extends Base {}
+FinalClassExtended: Class Child cannot extend final class Base

--- a/crates/mir-analyzer/tests/fixtures/final_method_overridden/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/final_method_overridden/basic.phpt
@@ -7,4 +7,4 @@ class Child extends ParentClass {
     public function locked(): void {}
 }
 ===expect===
-FinalMethodOverridden: public function locked(): void {}
+FinalMethodOverridden: Method Child::locked() cannot override final method from ParentClass

--- a/crates/mir-analyzer/tests/fixtures/generic_receiver/class_level_template_resolves_to_concrete_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_receiver/class_level_template_resolves_to_concrete_type.phpt
@@ -15,4 +15,4 @@ function test(): void {
     $first->nonExistentMethod();
 }
 ===expect===
-UndefinedMethod: $first->nonExistentMethod()
+UndefinedMethod: Method User::nonExistentMethod() does not exist

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/contravariant_rejects_subtype_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/contravariant_rejects_subtype_arg.phpt
@@ -15,4 +15,4 @@ function test(): void {
     f($c);
 }
 ===expect===
-InvalidArgument: $c
+InvalidArgument: Argument $s of f() expects 'Sink<Animal>', got 'Sink<Cat>'

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/covariant_raw_type_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/covariant_raw_type_no_error.phpt
@@ -13,4 +13,3 @@ function test(): void {
     f($raw);
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/covariant_rejects_supertype_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/covariant_rejects_supertype_arg.phpt
@@ -15,4 +15,4 @@ function test(): void {
     f($a);
 }
 ===expect===
-InvalidArgument: $a
+InvalidArgument: Argument $b of f() expects 'Box<Cat>', got 'Box<Animal>'

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/invariant_rejects_subtype_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/invariant_rejects_subtype_arg.phpt
@@ -15,4 +15,4 @@ function test(): void {
     f($c);
 }
 ===expect===
-InvalidArgument: $c
+InvalidArgument: Argument $b of f() expects 'Box<Animal>', got 'Box<Cat>'

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/invariant_rejects_supertype_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/invariant_rejects_supertype_arg.phpt
@@ -15,4 +15,4 @@ function test(): void {
     f($a);
 }
 ===expect===
-InvalidArgument: $a
+InvalidArgument: Argument $b of f() expects 'Box<Cat>', got 'Box<Animal>'

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/mixed_variance_two_params_compatible.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/mixed_variance_two_params_compatible.phpt
@@ -15,4 +15,3 @@ function test(): void {
     f($p);
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/generic_variance/mixed_variance_two_params_invariant_mismatch.phpt
+++ b/crates/mir-analyzer/tests/fixtures/generic_variance/mixed_variance_two_params_invariant_mismatch.phpt
@@ -15,4 +15,4 @@ function test(): void {
     f($p);
 }
 ===expect===
-InvalidArgument: $p
+InvalidArgument: Argument $p of f() expects 'Pair<string, Animal>', got 'Pair<int, Cat>'

--- a/crates/mir-analyzer/tests/fixtures/intersection_type/reports_int_passed_as_docblock_intersection.phpt
+++ b/crates/mir-analyzer/tests/fixtures/intersection_type/reports_int_passed_as_docblock_intersection.phpt
@@ -10,4 +10,4 @@ function test(): void {
     f(42);
 }
 ===expect===
-InvalidArgument: 42
+InvalidArgument: Argument $x of f() expects 'Iterator&Countable', got '42'

--- a/crates/mir-analyzer/tests/fixtures/intersection_type/reports_scalar_passed_as_nullable_docblock_intersection.phpt
+++ b/crates/mir-analyzer/tests/fixtures/intersection_type/reports_scalar_passed_as_nullable_docblock_intersection.phpt
@@ -10,4 +10,4 @@ function test(): void {
     f("hello");
 }
 ===expect===
-InvalidArgument: "hello"
+InvalidArgument: Argument $x of f() expects 'Iterator&Countable|null', got '"hello"'

--- a/crates/mir-analyzer/tests/fixtures/intersection_type/reports_scalar_passed_as_three_part_intersection.phpt
+++ b/crates/mir-analyzer/tests/fixtures/intersection_type/reports_scalar_passed_as_three_part_intersection.phpt
@@ -10,4 +10,4 @@ function test(): void {
     f("hello");
 }
 ===expect===
-InvalidArgument: "hello"
+InvalidArgument: Argument $x of f() expects 'Iterator&Countable&Stringable', got '"hello"'

--- a/crates/mir-analyzer/tests/fixtures/intersection_type/reports_string_passed_as_intersection.phpt
+++ b/crates/mir-analyzer/tests/fixtures/intersection_type/reports_string_passed_as_intersection.phpt
@@ -9,4 +9,4 @@ function test(): void {
     f("hello");
 }
 ===expect===
-InvalidArgument: "hello"
+InvalidArgument: Argument $x of f() expects 'Iterator&Countable', got '"hello"'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_to_int_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/keyed_array_foreach_string_key_to_int_param.phpt
@@ -13,4 +13,4 @@ function foo(): void {
     }
 }
 ===expect===
-InvalidArgument: $k
+InvalidArgument: Argument $k of takes_int() expects 'int', got '"hello"|"world"'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_incompatible_union_arg.phpt
@@ -4,4 +4,4 @@ function g(): int|string { return 1; }
 function f(int $x): void { var_dump($x); }
 function test(): void { f(g()); }
 ===expect===
-InvalidArgument: g()
+InvalidArgument: Argument $x of f() expects 'int', got 'int|string'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_named_argument_wrong_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_named_argument_wrong_type.phpt
@@ -3,4 +3,4 @@
 function f(int $x): void { var_dump($x); }
 function test(): void { f(x: 'hello'); }
 ===expect===
-InvalidArgument: x: 'hello'
+InvalidArgument: Argument $x of f() expects 'int', got '"hello"'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_object_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_object_passed_as_int.phpt
@@ -4,4 +4,4 @@ class Foo {}
 function f(int $x): void { var_dump($x); }
 function test(): void { f(new Foo()); }
 ===expect===
-InvalidArgument: new Foo()
+InvalidArgument: Argument $x of f() expects 'int', got 'Foo'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_string_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_string_passed_as_int.phpt
@@ -3,4 +3,4 @@
 function f(int $x): void { var_dump($x); }
 function test(): void { f('hello'); }
 ===expect===
-InvalidArgument: 'hello'
+InvalidArgument: Argument $x of f() expects 'int', got '"hello"'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_variadic_wrong_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_variadic_wrong_type.phpt
@@ -3,4 +3,4 @@
 function f(int ...$xs): void { var_dump($xs); }
 function test(): void { f('a'); }
 ===expect===
-InvalidArgument: 'a'
+InvalidArgument: Argument $xs of f() expects 'int', got '"a"'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_bare_return_from_non_void.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_bare_return_from_non_void.phpt
@@ -4,4 +4,4 @@ function f(): int {
     return;
 }
 ===expect===
-InvalidReturnType: return;
+InvalidReturnType: Return type 'void' is not compatible with declared 'int'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_null_returned_from_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_null_returned_from_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(): string {
     return null;
 }
 ===expect===
-InvalidReturnType: return null;
+InvalidReturnType: Return type 'null' is not compatible with declared 'string'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_return_null_from_void.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_return_null_from_void.phpt
@@ -4,4 +4,4 @@ function f(): void {
     return null;
 }
 ===expect===
-InvalidReturnType: return null;
+InvalidReturnType: Return type 'null' is not compatible with declared 'void'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_string_returned_from_int_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_string_returned_from_int_function.phpt
@@ -4,4 +4,4 @@ function f(): int {
     return 'hello';
 }
 ===expect===
-InvalidReturnType: return 'hello';
+InvalidReturnType: Return type '"hello"' is not compatible with declared 'int'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_wrong_union_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/reports_wrong_union_return.phpt
@@ -5,4 +5,4 @@ function f(): int {
     return $x;
 }
 ===expect===
-InvalidReturnType: return $x;
+InvalidReturnType: Return type '1|"hello"' is not compatible with declared 'int'

--- a/crates/mir-analyzer/tests/fixtures/invalid_return_type/switch_fallthrough_widens_type_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_return_type/switch_fallthrough_widens_type_error.phpt
@@ -12,4 +12,4 @@ function foo(int $x): int {
     return $y;
 }
 ===expect===
-InvalidReturnType: return $y;
+InvalidReturnType: Return type '"not an int"|0' is not compatible with declared 'int'

--- a/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_in_static_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_in_static_method.phpt
@@ -6,4 +6,4 @@ class Foo {
     }
 }
 ===expect===
-InvalidScope: $this
+InvalidScope: $this cannot be used in a static method

--- a/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_outside_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_scope/reports_this_outside_class.phpt
@@ -4,4 +4,4 @@ function test(): void {
     $this->close();
 }
 ===expect===
-InvalidScope: $this
+InvalidScope: $this cannot be used outside of a class

--- a/crates/mir-analyzer/tests/fixtures/invalid_throw/reports_non_throwable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_throw/reports_non_throwable.phpt
@@ -6,4 +6,4 @@ function test(): void {
     throw new NotAnException();
 }
 ===expect===
-InvalidThrow: <no snippet>
+InvalidThrow: Thrown type 'NotAnException' does not extend Throwable

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_interface_implementation_wrong_signature.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_interface_implementation_wrong_signature.phpt
@@ -7,4 +7,4 @@ class C implements I {
     public function f(int $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method C::f() signature mismatch: parameter $x type 'int' is narrower than parent type 'string'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_adds_required_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_adds_required_param.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method Child::f() signature mismatch: overriding method requires 1 argument(s) but parent requires 0

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_param_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_param_type.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(int $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method Child::f() signature mismatch: parameter $x type 'int' is narrower than parent type 'string'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_second_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_narrowing_second_param.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x, int $y): void { var_dump($x, $y); }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method Child::f() signature mismatch: parameter $y type 'int' is narrower than parent type 'string'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_removes_default.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_removes_default.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(string $x): void { var_dump($x); }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method Child::f() signature mismatch: overriding method requires 1 argument(s) but parent requires 0

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_widening_return_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/reports_override_widening_return_type.phpt
@@ -7,4 +7,4 @@ class Child extends Base {
     public function f(): int|string { return 1; }
 }
 ===expect===
-MethodSignatureMismatch: f
+MethodSignatureMismatch: Method Child::f() signature mismatch: return type 'int|string' is not a subtype of parent 'int'

--- a/crates/mir-analyzer/tests/fixtures/mixed_method_call/reports_method_call_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/mixed_method_call/reports_method_call_on_mixed.phpt
@@ -4,4 +4,4 @@ function test(mixed $value): void {
     $value->someMethod();
 }
 ===expect===
-MixedMethodCall: $value->someMethod()
+MixedMethodCall: Method someMethod() called on mixed type

--- a/crates/mir-analyzer/tests/fixtures/null_array_access/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_array_access/basic.phpt
@@ -5,4 +5,4 @@ function test(): void {
     echo $x[0];
 }
 ===expect===
-NullArrayAccess: $x[0]
+NullArrayAccess: Cannot access array on null

--- a/crates/mir-analyzer/tests/fixtures/null_array_access/from_nullable_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_array_access/from_nullable_variable.phpt
@@ -5,4 +5,4 @@ function test(bool $flag): void {
     echo $x[0];
 }
 ===expect===
-PossiblyNullArrayAccess: $x[0]
+PossiblyNullArrayAccess: Cannot access array on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/null_method_call/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_method_call/basic.phpt
@@ -5,4 +5,4 @@ function test(): void {
     $x->foo();
 }
 ===expect===
-NullMethodCall: $x->foo()
+NullMethodCall: Cannot call method foo() on null

--- a/crates/mir-analyzer/tests/fixtures/null_method_call/from_ternary.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_method_call/from_ternary.phpt
@@ -5,5 +5,5 @@ function test(bool $flag): void {
     $x->foo();
 }
 ===expect===
-PossiblyNullMethodCall: $x->foo()
-UndefinedMethod: $x->foo()
+PossiblyNullMethodCall: Cannot call method foo() on possibly null value
+UndefinedMethod: Method stdClass::foo() does not exist

--- a/crates/mir-analyzer/tests/fixtures/null_property_fetch/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_property_fetch/basic.phpt
@@ -5,4 +5,4 @@ function test(): void {
     echo $x->prop;
 }
 ===expect===
-NullPropertyFetch: $x->prop
+NullPropertyFetch: Cannot access property $prop on null

--- a/crates/mir-analyzer/tests/fixtures/null_property_fetch/from_nullable_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_property_fetch/from_nullable_return.phpt
@@ -11,4 +11,4 @@ function test(): void {
     echo $x->val;
 }
 ===expect===
-PossiblyNullPropertyFetch: $x->val
+PossiblyNullPropertyFetch: Cannot access property $val on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/overridden_method_access/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/overridden_method_access/basic.phpt
@@ -7,4 +7,4 @@ class Child extends ParentClass {
     private function doStuff(): void {}
 }
 ===expect===
-OverriddenMethodAccess: private function doStuff(): void {}
+OverriddenMethodAccess: Method Child::dostuff() overrides with less visibility

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_both_elements_of_multi_var_destructure.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_both_elements_of_multi_var_destructure.phpt
@@ -7,4 +7,4 @@ function test(): void {
     var_dump($a, $b);
 }
 ===expect===
-PossiblyInvalidArrayOffset: [$a, $b] = get()
+PossiblyInvalidArrayOffset: Array offset might be invalid: expects 'array', got 'array<mixed, mixed>|false'

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_destructure_of_array_or_false.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_destructure_of_array_or_false.phpt
@@ -7,4 +7,4 @@ function test(): void {
     var_dump($a, $b);
 }
 ===expect===
-PossiblyInvalidArrayOffset: [$a, $b] = get()
+PossiblyInvalidArrayOffset: Array offset might be invalid: expects 'array', got 'array<mixed, mixed>|false'

--- a/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_unpack_result_when_stub_present.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_invalid_array_offset/reports_unpack_result_when_stub_present.phpt
@@ -5,4 +5,4 @@ function test(): void {
     var_dump($a);
 }
 ===expect===
-PossiblyInvalidArrayOffset: [$a] = unpack('N', pack('N', 1))
+PossiblyInvalidArrayOffset: Array offset might be invalid: expects 'array', got 'array<int, mixed>|false'

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_argument/does_not_report_after_null_check.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_argument/does_not_report_after_null_check.phpt
@@ -8,4 +8,4 @@ function test(?string $value): void {
     }
 }
 ===expect===
-UnusedParam: $name
+UnusedParam: Parameter $name is never used

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_argument/reports_possibly_null_argument.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_argument/reports_possibly_null_argument.phpt
@@ -6,5 +6,5 @@ function test(?string $value): void {
     greet($value);
 }
 ===expect===
-UnusedParam: $name
-PossiblyNullArgument: $value
+UnusedParam: Parameter $name is never used
+PossiblyNullArgument: Argument $name of greet() might be null

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_array_access/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_array_access/basic.phpt
@@ -7,4 +7,4 @@ function test(?array $arr): void {
     echo $arr[0];
 }
 ===expect===
-PossiblyNullArrayAccess: $arr[0]
+PossiblyNullArrayAccess: Cannot access array on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_array_access/not_reported_after_null_check.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_array_access/not_reported_after_null_check.phpt
@@ -9,4 +9,3 @@ function test(?array $arr): void {
     }
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_method_call/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_method_call/basic.phpt
@@ -7,4 +7,4 @@ function test(?Foo $obj): void {
     $obj->bar();
 }
 ===expect===
-PossiblyNullMethodCall: $obj->bar()
+PossiblyNullMethodCall: Cannot call method bar() on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_method_call/not_reported_after_null_check.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_method_call/not_reported_after_null_check.phpt
@@ -9,4 +9,3 @@ function test(?Foo $obj): void {
     }
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_property_fetch/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_property_fetch/basic.phpt
@@ -7,4 +7,4 @@ function test(?Foo $obj): void {
     echo $obj->value;
 }
 ===expect===
-PossiblyNullPropertyFetch: $obj->value
+PossiblyNullPropertyFetch: Cannot access property $value on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/possibly_null_property_fetch/not_reported_after_null_check.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_null_property_fetch/not_reported_after_null_check.phpt
@@ -9,4 +9,3 @@ function test(?Foo $obj): void {
     }
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_missing_else_branch_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/elseif_missing_else_branch_error.phpt
@@ -12,4 +12,4 @@ function foo(int $x): string {
     return $result;
 }
 ===expect===
-PossiblyUndefinedVariable: $result
+PossiblyUndefinedVariable: Variable $result might not be defined

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/if_only.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/if_only.phpt
@@ -5,4 +5,4 @@ function foo(bool $c): string {
     return $r;
 }
 ===expect===
-PossiblyUndefinedVariable: $r
+PossiblyUndefinedVariable: Variable $r might not be defined

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_no_default_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/switch_fallthrough_no_default_error.phpt
@@ -12,4 +12,4 @@ function foo(int $x): string {
     return $y;
 }
 ===expect===
-PossiblyUndefinedVariable: $y
+PossiblyUndefinedVariable: Variable $y might not be defined

--- a/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/reports_assignment_outside_constructor.phpt
+++ b/crates/mir-analyzer/tests/fixtures/readonly_property_assignment/reports_assignment_outside_constructor.phpt
@@ -12,4 +12,4 @@ function test(Foo $foo): void {
     $foo->name = 'bar';
 }
 ===expect===
-ReadonlyPropertyAssignment: $foo->name = 'bar'
+ReadonlyPropertyAssignment: Cannot assign to readonly property Foo::$name outside of constructor

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_is_string_on_string_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_is_string_on_string_type.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if (is_string($x)) {}
 }
 ===expect===
-RedundantCondition: is_string($x)
+RedundantCondition: Condition is always true/false for type 'bool'

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_not_null_check_on_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_not_null_check_on_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if ($x !== null) {}
 }
 ===expect===
-RedundantCondition: $x !== null
+RedundantCondition: Condition is always true/false for type 'bool'

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_null_check_on_non_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_null_check_on_non_nullable.phpt
@@ -4,4 +4,4 @@ function f(string $x): void {
     if ($x === null) {}
 }
 ===expect===
-RedundantCondition: $x === null
+RedundantCondition: Condition is always true/false for type 'bool'

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_after_narrowing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_after_narrowing.phpt
@@ -6,4 +6,4 @@ function f(string|int $x): void {
     }
 }
 ===expect===
-RedundantCondition: is_string($x)
+RedundantCondition: Condition is always true/false for type 'bool'

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_in_elseif.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/reports_redundant_check_in_elseif.phpt
@@ -12,4 +12,4 @@ function foo(string|null $x): void {
     }
 }
 ===expect===
-RedundantCondition: is_string($x)
+RedundantCondition: Condition is always true/false for type 'bool'

--- a/crates/mir-analyzer/tests/fixtures/shadowed_template_param/reports_method_shadows_class_template.phpt
+++ b/crates/mir-analyzer/tests/fixtures/shadowed_template_param/reports_method_shadows_class_template.phpt
@@ -16,4 +16,4 @@ function test(): void {
     $box->transform('hello');
 }
 ===expect===
-ShadowedTemplateParam: $box->transform('hello')
+ShadowedTemplateParam: Method template parameter 'T' shadows class-level template parameter with the same name

--- a/crates/mir-analyzer/tests/fixtures/tainted_html/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_html/basic.phpt
@@ -4,4 +4,4 @@ function test(): void {
     echo $_GET['x'];
 }
 ===expect===
-TaintedHtml: echo $_GET['x'];
+TaintedHtml: Tainted HTML output — possible XSS

--- a/crates/mir-analyzer/tests/fixtures/tainted_html/variable_from_superglobal.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_html/variable_from_superglobal.phpt
@@ -5,4 +5,4 @@ function test(): void {
     echo $name;
 }
 ===expect===
-TaintedHtml: echo $name;
+TaintedHtml: Tainted HTML output — possible XSS

--- a/crates/mir-analyzer/tests/fixtures/tainted_shell/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/tainted_shell/basic.phpt
@@ -5,4 +5,4 @@ function test(): void {
     exec($cmd);
 }
 ===expect===
-TaintedShell: exec($cmd)
+TaintedShell: Tainted shell command — possible command injection

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/enum_implements_missing_interface.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/enum_implements_missing_interface.phpt
@@ -2,4 +2,4 @@
 <?php
 enum Status: string implements MissingInterface {}
 ===expect===
-UndefinedClass: MissingInterface
+UndefinedClass: Class MissingInterface does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/extends_missing_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/extends_missing_class.phpt
@@ -2,4 +2,4 @@
 <?php
 class Foo extends MissingBase {}
 ===expect===
-UndefinedClass: MissingBase
+UndefinedClass: Class MissingBase does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/extension_class_via_use_alias.phpt
@@ -3,5 +3,5 @@
 use ast\Node;
 function f(Node $x): void {}
 ===expect===
-UnusedParam: $x
-UndefinedClass: Node
+UnusedParam: Parameter $x is never used
+UndefinedClass: Class ast\Node does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/implements_missing_interface.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/implements_missing_interface.phpt
@@ -2,4 +2,4 @@
 <?php
 class Bar implements MissingInterface {}
 ===expect===
-UndefinedClass: MissingInterface
+UndefinedClass: Class MissingInterface does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class.phpt
@@ -4,4 +4,4 @@ function test($x): bool {
     return $x instanceof NoSuchClass;
 }
 ===expect===
-UndefinedClass: NoSuchClass
+UndefinedClass: Class NoSuchClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class_in_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/instanceof_unknown_class_in_method.phpt
@@ -6,4 +6,4 @@ class A {
     }
 }
 ===expect===
-UndefinedClass: UnknownClass
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/interface_extends_missing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/interface_extends_missing.phpt
@@ -2,4 +2,4 @@
 <?php
 interface MyInterface extends MissingParentInterface {}
 ===expect===
-UndefinedClass: MissingParentInterface
+UndefinedClass: Class MissingParentInterface does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/known_aliased_class_not_reported.phpt
@@ -4,4 +4,4 @@ class Bar {}
 use Bar as Baz;
 function f(Baz $x): void {}
 ===expect===
-UnusedParam: $x
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class.phpt
@@ -4,4 +4,4 @@ function test(): void {
     new UnknownClass();
 }
 ===expect===
-UndefinedClass: UnknownClass
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class_in_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class_in_method.phpt
@@ -6,4 +6,4 @@ class A {
     }
 }
 ===expect===
-UndefinedClass: UnknownClass
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class_in_nested_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/new_unknown_class_in_nested_function.phpt
@@ -6,4 +6,4 @@ function outer(): void {
     }
 }
 ===expect===
-UndefinedClass: UnknownClass
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_param_type_hint.phpt
@@ -2,5 +2,5 @@
 <?php
 function f(UnknownClass $x): void {}
 ===expect===
-UnusedParam: $x
-UndefinedClass: UnknownClass
+UnusedParam: Parameter $x is never used
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/unknown_return_type_hint.phpt
@@ -4,4 +4,4 @@ function f(): UnknownClass {
     return null;
 }
 ===expect===
-UndefinedClass: UnknownClass
+UndefinedClass: Class UnknownClass does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/global_namespace_unknown_function.phpt
@@ -4,4 +4,4 @@ function test(): void {
     \nonExistent();
 }
 ===expect===
-UndefinedFunction: \nonExistent()
+UndefinedFunction: Function nonExistent() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/inside_method_body.phpt
@@ -6,4 +6,4 @@ class A {
     }
 }
 ===expect===
-UndefinedFunction: missing()
+UndefinedFunction: Function missing() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/multiple_call_sites.phpt
@@ -5,5 +5,5 @@ function test(): void {
     foo();
 }
 ===expect===
-UndefinedFunction: foo()
-UndefinedFunction: foo()
+UndefinedFunction: Function foo() is not defined
+UndefinedFunction: Function foo() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/namespaced_method_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/namespaced_method_body.phpt
@@ -8,4 +8,4 @@ namespace MyApp {
     }
 }
 ===expect===
-UndefinedFunction: nonexistent_function()
+UndefinedFunction: Function nonexistent_function() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/nested_class_method_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/nested_class_method_body.phpt
@@ -8,4 +8,4 @@ function outer(): void {
     }
 }
 ===expect===
-UndefinedFunction: nonexistent_function()
+UndefinedFunction: Function nonexistent_function() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/nested_function_body.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/nested_function_body.phpt
@@ -6,4 +6,4 @@ function outer(): void {
     }
 }
 ===expect===
-UndefinedFunction: nonexistent_function()
+UndefinedFunction: Function nonexistent_function() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_function/unknown_function.phpt
@@ -4,4 +4,4 @@ function test(): void {
     foo();
 }
 ===expect===
-UndefinedFunction: foo()
+UndefinedFunction: Function foo() is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_apply_var_annotation_to_wrong_global_variable.phpt
@@ -11,4 +11,4 @@ function test(): void {
     $y->bar();
 }
 ===expect===
-MixedMethodCall: $y->bar()
+MixedMethodCall: Method bar() called on mixed type

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_call_on_null_as_undefined_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_call_on_null_as_undefined_method.phpt
@@ -5,4 +5,4 @@ function test(): void {
     $x->foo();
 }
 ===expect===
-NullMethodCall: $x->foo()
+NullMethodCall: Cannot call method foo() on null

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_method_call_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_method_call_on_mixed.phpt
@@ -6,4 +6,4 @@ function test(): void {
     $x->anything();
 }
 ===expect===
-MixedMethodCall: $x->anything()
+MixedMethodCall: Method anything() called on mixed type

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_instance_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_instance_method.phpt
@@ -6,4 +6,4 @@ function test(): void {
     $f->missing();
 }
 ===expect===
-UndefinedMethod: $f->missing()
+UndefinedMethod: Method Foo::missing() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_static_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_missing_static_method.phpt
@@ -5,4 +5,4 @@ function test(): void {
     Foo::missing();
 }
 ===expect===
-UndefinedMethod: Foo::missing()
+UndefinedMethod: Method Foo::missing() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_this_undefined_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_this_undefined_method.phpt
@@ -6,4 +6,4 @@ class Svc {
     }
 }
 ===expect===
-UndefinedMethod: $this->nonExistent()
+UndefinedMethod: Method Svc::nonExistent() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_unannotated_global_as_mixed_when_sibling_is_annotated.phpt
@@ -12,4 +12,4 @@ function test(): void {
     $y->bar();
 }
 ===expect===
-MixedMethodCall: $y->bar()
+MixedMethodCall: Method bar() called on mixed type

--- a/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_property/basic.phpt
@@ -8,4 +8,4 @@ function test(): void {
     echo $f->nonexistent;
 }
 ===expect===
-UndefinedProperty: nonexistent
+UndefinedProperty: Property Foo::$nonexistent does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/switch_fallthrough_into_return_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/switch_fallthrough_into_return_error.phpt
@@ -14,4 +14,4 @@ function foo(int $x): void {
     echo $y;
 }
 ===expect===
-UndefinedVariable: $y
+UndefinedVariable: Variable $y is not defined

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
@@ -5,4 +5,4 @@ abstract class Base {
 }
 class Incomplete extends Base {}
 ===expect===
-UnimplementedAbstractMethod: class Incomplete extends Base {}
+UnimplementedAbstractMethod: Class Incomplete must implement abstract method dowork()

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/abstract_class_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/abstract_class_not_reported.phpt
@@ -5,4 +5,3 @@ interface Runnable {
 }
 abstract class AbstractTask implements Runnable {}
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/basic.phpt
@@ -5,4 +5,4 @@ interface Runnable {
 }
 class Task implements Runnable {}
 ===expect===
-UnimplementedInterfaceMethod: class Task implements Runnable {}
+UnimplementedInterfaceMethod: Class Task must implement Runnable::run() from interface

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_not_reported.phpt
@@ -11,4 +11,3 @@ abstract class Base implements Runnable {
 }
 class Task extends Base {}
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_of_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_in_parent_via_trait_of_trait_not_reported.phpt
@@ -14,4 +14,3 @@ abstract class Base implements Runnable {
 }
 class Task extends Base {}
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_not_reported.phpt
@@ -7,4 +7,3 @@ class Task implements Runnable {
     public function run(): void {}
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_not_reported.phpt
@@ -10,4 +10,3 @@ class Task implements Runnable {
     use RunsTrait;
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_of_trait_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/implemented_via_trait_of_trait_not_reported.phpt
@@ -13,4 +13,3 @@ class Task implements Runnable {
     use RunsTrait;
 }
 ===expect===
-

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_cycle_does_not_crash.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_cycle_does_not_crash.phpt
@@ -15,4 +15,4 @@ class Task implements Runnable {
     use TraitA;
 }
 ===expect===
-UnimplementedInterfaceMethod: class Task implements Runnable {
+UnimplementedInterfaceMethod: Class Task must implement Runnable::run() from interface

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_of_trait_without_method_still_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/trait_of_trait_without_method_still_reported.phpt
@@ -14,4 +14,4 @@ class Task implements Runnable {
     use RunsTrait;
 }
 ===expect===
-UnimplementedInterfaceMethod: class Task implements Runnable {
+UnimplementedInterfaceMethod: Class Task must implement Runnable::run() from interface

--- a/crates/mir-analyzer/tests/fixtures/unused_method/reports_private_unused_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_method/reports_private_unused_method.phpt
@@ -4,4 +4,4 @@ class Foo {
     private function helper(): void {}
 }
 ===expect===
-UnusedMethod: <no snippet>
+UnusedMethod: Private method Foo::helper() is never called

--- a/crates/mir-analyzer/tests/fixtures/unused_param/constructor_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/constructor_reported.phpt
@@ -4,4 +4,4 @@ class Foo {
     public function __construct(int $x) {}
 }
 ===expect===
-UnusedParam: $x
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_param/non_runtime_magic_methods_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/non_runtime_magic_methods_reported.phpt
@@ -12,4 +12,4 @@ class Foo {
     }
 }
 ===expect===
-UnusedParam: $x
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_param/regular_function_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/regular_function_reported.phpt
@@ -4,4 +4,4 @@ function greet(string $name): string {
     return 'hello';
 }
 ===expect===
-UnusedParam: $name
+UnusedParam: Parameter $name is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_param/regular_method_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/regular_method_reported.phpt
@@ -6,4 +6,4 @@ class Foo {
     }
 }
 ===expect===
-UnusedParam: $x
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_param/underscore_param_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/underscore_param_reported.phpt
@@ -6,4 +6,4 @@ class Foo {
     }
 }
 ===expect===
-UnusedParam: $_unused
+UnusedParam: Parameter $_unused is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_param/variadic_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/variadic_reported.phpt
@@ -4,4 +4,4 @@ function sum(int ...$nums): int {
     return 0;
 }
 ===expect===
-UnusedParam: $nums
+UnusedParam: Parameter $nums is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_property/reports_private_unused_property.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_property/reports_private_unused_property.phpt
@@ -4,4 +4,4 @@ class Foo {
     private string $name = 'bar';
 }
 ===expect===
-UnusedProperty: <no snippet>
+UnusedProperty: Private property Foo::$name is never read

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_mixed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_mixed.phpt
@@ -9,4 +9,4 @@ class Foo {
     private function doSomething(array $a): void {}
 }
 ===expect===
-UnusedParam: $a
+UnusedParam: Parameter $a is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_null.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_null.phpt
@@ -9,4 +9,4 @@ class Bar {
     }
 }
 ===expect===
-NullMethodCall: $obj->doSomething($ctx)
+NullMethodCall: Cannot call method doSomething() on null

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_nullable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/does_not_report_arg_passed_to_method_on_nullable.phpt
@@ -7,4 +7,4 @@ class Baz {
     }
 }
 ===expect===
-PossiblyNullMethodCall: $obj->doSomething($ctx)
+PossiblyNullMethodCall: Cannot call method doSomething() on possibly null value

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/parameter_not_reported_as_unused_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/parameter_not_reported_as_unused_variable.phpt
@@ -4,4 +4,4 @@ function foo(int $param): int {
     return 42;
 }
 ===expect===
-UnusedParam: $param
+UnusedParam: Parameter $param is never used

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/unused_variable_is_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/unused_variable_is_reported.phpt
@@ -5,4 +5,4 @@ function foo(): int {
     return 42;
 }
 ===expect===
-UnusedVariable: <no snippet>
+UnusedVariable: Variable $unused is never read


### PR DESCRIPTION
## Summary

- Replaces snippet-based assertions in `.phpt` fixtures with exact human-readable messages from `kind.message()`
- The expect format changes from `KindName: snippet` to `KindName: full message`
- All 126 fixture files regenerated via `UPDATE_FIXTURES=1 cargo test`

## Test plan

- [ ] `cargo test -p mir-analyzer` — all 340 fixture tests pass
- [ ] Manually verify a fixture shows the full message (e.g. `NullMethodCall: Cannot call method foo() on null`)
- [ ] Change a message in `kind.message()` and confirm the corresponding fixture test fails