### PR TITLE
feat(stubs): injectable framework stubs with caching and extension filtering

### DIFF
--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -128,6 +128,11 @@ impl AnalysisCache {
         *self.dirty.lock().unwrap() = true;
     }
 
+    /// Return the directory where cache files are stored.
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
     /// Persist the in-memory cache to `{cache_dir}/cache.json`.
     /// This is a no-op if nothing changed since the last flush.
     pub fn flush(&self) {

--- a/crates/mir-analyzer/src/composer.rs
+++ b/crates/mir-analyzer/src/composer.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -172,6 +173,26 @@ impl Psr4Map {
             }
         }
         None
+    }
+}
+
+/// Parse `ext-*` requirements from `composer.json` in the given root directory.
+///
+/// Returns the set of lowercase extension names (without the `ext-` prefix),
+/// or `None` if `composer.json` is absent or contains no `ext-*` requirements.
+/// Callers should add their own always-load set on top of this.
+pub fn parse_required_extensions(root: &Path) -> Option<HashSet<String>> {
+    let content = std::fs::read_to_string(root.join("composer.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let require = value.get("require")?.as_object()?;
+    let exts: HashSet<String> = require
+        .keys()
+        .filter_map(|k| k.to_lowercase().strip_prefix("ext-").map(str::to_string))
+        .collect();
+    if exts.is_empty() {
+        None
+    } else {
+        Some(exts)
     }
 }
 
@@ -364,6 +385,38 @@ mod tests {
         let map = Psr4Map::from_composer(&root).unwrap();
         let result = map.resolve("App\\Models\\User");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn required_extensions_ext_keys() {
+        let root = make_temp_project("required_extensions");
+        fs::write(
+            root.join("composer.json"),
+            r#"{"require":{"php":"^8.2","ext-pdo":"*","ext-curl":"*","laravel/framework":"^11.0"}}"#,
+        )
+        .unwrap();
+
+        let exts = super::parse_required_extensions(&root).unwrap();
+        assert!(exts.contains("pdo"), "missing pdo");
+        assert!(exts.contains("curl"), "missing curl");
+        assert!(
+            !exts.contains("laravel/framework"),
+            "should not include non-ext"
+        );
+        assert_eq!(exts.len(), 2);
+    }
+
+    #[test]
+    fn required_extensions_no_exts_returns_none() {
+        let root = make_temp_project("required_extensions_none");
+        fs::write(
+            root.join("composer.json"),
+            r#"{"require":{"php":"^8.2","laravel/framework":"^11.0"}}"#,
+        )
+        .unwrap();
+
+        let exts = super::parse_required_extensions(&root);
+        assert!(exts.is_none(), "expected None when no ext-* requirements");
     }
 
     #[test]

--- a/crates/mir-analyzer/src/lib.rs
+++ b/crates/mir-analyzer/src/lib.rs
@@ -10,6 +10,7 @@ pub mod narrowing;
 pub mod parser;
 pub mod project;
 pub mod stmt;
+pub mod stub_cache;
 pub mod stubs;
 pub mod taint;
 
@@ -25,6 +26,6 @@ pub use symbol::{ResolvedSymbol, SymbolKind};
 pub use type_env::{ScopeId, TypeEnv};
 
 pub mod composer;
-pub use composer::Psr4Map;
+pub use composer::{parse_required_extensions, Psr4Map};
 
 pub mod test_utils;

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -1,10 +1,9 @@
 /// Project-level orchestration: file discovery, pass 1, pass 2.
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rayon::prelude::*;
-
-use std::collections::{HashMap, HashSet};
 
 use crate::cache::{hash_content, AnalysisCache};
 use mir_codebase::Codebase;
@@ -29,6 +28,15 @@ pub struct ProjectAnalyzer {
     stubs_loaded: std::sync::atomic::AtomicBool,
     /// When true, run dead code detection at the end of analysis.
     pub find_dead_code: bool,
+    /// Target PHP version for extension version gating. `None` = no gating.
+    pub php_version: Option<(u8, u8)>,
+    /// Allowlist of lowercase extension names to load from phpstorm-stubs.
+    /// `None` = load all embedded extensions.
+    pub enabled_extensions: Option<HashSet<String>>,
+    /// Additional stub files to parse (absolute paths).
+    pub stub_files: Vec<PathBuf>,
+    /// Additional stub directories to walk and parse (absolute paths).
+    pub stub_dirs: Vec<PathBuf>,
 }
 
 impl ProjectAnalyzer {
@@ -40,6 +48,10 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: None,
+            enabled_extensions: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         }
     }
 
@@ -52,6 +64,10 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: None,
+            enabled_extensions: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         }
     }
 
@@ -70,6 +86,10 @@ impl ProjectAnalyzer {
             psr4: Some(psr4),
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: None,
+            enabled_extensions: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         };
         Ok((analyzer, map))
     }
@@ -85,7 +105,17 @@ impl ProjectAnalyzer {
             .stubs_loaded
             .swap(true, std::sync::atomic::Ordering::SeqCst)
         {
-            crate::stubs::load_stubs(&self.codebase);
+            let cache_dir = self.cache.as_ref().map(|c| c.cache_dir());
+            crate::stubs::load_stubs_configured(
+                &self.codebase,
+                &crate::stubs::StubConfig {
+                    php_version: self.php_version,
+                    enabled_extensions: self.enabled_extensions.as_ref(),
+                    stub_files: &self.stub_files,
+                    stub_dirs: &self.stub_dirs,
+                    cache_dir,
+                },
+            );
         }
     }
 

--- a/crates/mir-analyzer/src/stub_cache.rs
+++ b/crates/mir-analyzer/src/stub_cache.rs
@@ -1,0 +1,235 @@
+/// Disk-backed cache for parsed stub definitions.
+///
+/// Stub loading (phpstorm-stubs + user stubs) costs 20–50 ms per run. For
+/// repeated invocations — watch mode, LSP server, CI — this overhead is
+/// unnecessary when nothing has changed. This module serializes the stub
+/// portion of a `Codebase` to disk after the first load, and restores it on
+/// subsequent runs when the cache key matches.
+///
+/// Cache key captures everything that affects stub output:
+/// - mir crate version (changes when phpstorm-stubs are updated in a release)
+/// - Target PHP version
+/// - Enabled extension set
+/// - Content hashes of user-provided stub files and directories
+///
+/// Cache file: `{cache_dir}/stub-cache.json`.
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use mir_codebase::storage::{
+    ClassStorage, EnumStorage, FunctionStorage, InterfaceStorage, TraitStorage,
+};
+use mir_codebase::Codebase;
+use mir_types::Union;
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+/// Serializable copy of the stub-only entries in a `Codebase`.
+/// Captured right after `load_stubs_configured()`, before any user-code Pass 1.
+/// `all_parents` fields are intentionally empty here — `Codebase::finalize()`
+/// rebuilds them after user code is added.
+#[derive(Serialize, Deserialize)]
+pub struct StubSnapshot {
+    classes: HashMap<String, ClassStorage>,
+    interfaces: HashMap<String, InterfaceStorage>,
+    traits: HashMap<String, TraitStorage>,
+    enums: HashMap<String, EnumStorage>,
+    functions: HashMap<String, FunctionStorage>,
+    constants: HashMap<String, Union>,
+    known_symbols: Vec<String>,
+    symbol_to_file: HashMap<String, String>,
+}
+
+/// Capture every entry currently in `codebase` into a serializable snapshot.
+pub fn capture(codebase: &Codebase) -> StubSnapshot {
+    StubSnapshot {
+        classes: codebase
+            .classes
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        interfaces: codebase
+            .interfaces
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        traits: codebase
+            .traits
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        enums: codebase
+            .enums
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        functions: codebase
+            .functions
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        constants: codebase
+            .constants
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().clone()))
+            .collect(),
+        known_symbols: codebase
+            .known_symbols
+            .iter()
+            .map(|e| e.key().to_string())
+            .collect(),
+        symbol_to_file: codebase
+            .symbol_to_file
+            .iter()
+            .map(|e| (e.key().to_string(), e.value().to_string()))
+            .collect(),
+    }
+}
+
+/// Inject a snapshot into an empty `Codebase` (before any user-code Pass 1).
+pub fn apply(codebase: &Codebase, snap: StubSnapshot) {
+    for (k, v) in snap.classes {
+        codebase.classes.insert(Arc::from(k.as_str()), v);
+    }
+    for (k, v) in snap.interfaces {
+        codebase.interfaces.insert(Arc::from(k.as_str()), v);
+    }
+    for (k, v) in snap.traits {
+        codebase.traits.insert(Arc::from(k.as_str()), v);
+    }
+    for (k, v) in snap.enums {
+        codebase.enums.insert(Arc::from(k.as_str()), v);
+    }
+    for (k, v) in snap.functions {
+        codebase.functions.insert(Arc::from(k.as_str()), v);
+    }
+    for (k, v) in snap.constants {
+        codebase.constants.insert(Arc::from(k.as_str()), v);
+    }
+    for sym in snap.known_symbols {
+        codebase.known_symbols.insert(Arc::from(sym.as_str()));
+    }
+    for (k, v) in snap.symbol_to_file {
+        codebase
+            .symbol_to_file
+            .insert(Arc::from(k.as_str()), Arc::from(v.as_str()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache key
+// ---------------------------------------------------------------------------
+
+/// Compute a deterministic cache key that covers all inputs to stub loading.
+pub fn cache_key(
+    php_version: Option<(u8, u8)>,
+    enabled_extensions: Option<&HashSet<String>>,
+    stub_files: &[PathBuf],
+    stub_dirs: &[PathBuf],
+) -> String {
+    let mut h = Sha256::new();
+
+    // Crate version — changes whenever phpstorm-stubs are updated in a release.
+    h.update(env!("CARGO_PKG_VERSION").as_bytes());
+    h.update(b"|");
+
+    // PHP version gate.
+    match php_version {
+        Some((maj, min)) => h.update(format!("php={}.{}", maj, min).as_bytes()),
+        None => h.update(b"php=any"),
+    }
+    h.update(b"|");
+
+    // Enabled extension set (sorted for determinism).
+    match enabled_extensions {
+        None => h.update(b"ext=all"),
+        Some(set) => {
+            let mut exts: Vec<&str> = set.iter().map(String::as_str).collect();
+            exts.sort_unstable();
+            h.update(b"ext=");
+            h.update(exts.join(",").as_bytes());
+        }
+    }
+    h.update(b"|");
+
+    // User stub files sorted by path for determinism.
+    let mut direct_files: Vec<PathBuf> = stub_files.to_vec();
+    for dir in stub_dirs {
+        collect_php_files_sorted(dir, &mut direct_files);
+    }
+    direct_files.sort_unstable();
+    direct_files.dedup();
+
+    for path in &direct_files {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            h.update(path.to_string_lossy().as_bytes());
+            h.update(b":");
+            h.update(content.as_bytes());
+            h.update(b"|");
+        }
+    }
+
+    h.finalize().iter().fold(String::new(), |mut acc, b| {
+        use std::fmt::Write;
+        write!(acc, "{:02x}", b).unwrap();
+        acc
+    })
+}
+
+fn collect_php_files_sorted(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
+    paths.sort_unstable();
+    for path in paths {
+        if path.is_dir() {
+            collect_php_files_sorted(&path, out);
+        } else if path.extension().is_some_and(|e| e == "php") {
+            out.push(path);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct CacheFile {
+    key: String,
+    snapshot: StubSnapshot,
+}
+
+fn cache_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join("stub-cache.json")
+}
+
+/// Try to load a valid snapshot from disk.
+/// Returns `None` if the cache file is absent, corrupt, or the key has changed.
+pub fn load(cache_dir: &Path, key: &str) -> Option<StubSnapshot> {
+    let data = std::fs::read_to_string(cache_path(cache_dir)).ok()?;
+    let file: CacheFile = serde_json::from_str(&data).ok()?;
+    if file.key == key {
+        Some(file.snapshot)
+    } else {
+        None
+    }
+}
+
+/// Persist a stub snapshot to disk. Silently ignores write errors.
+pub fn save(cache_dir: &Path, key: &str, snapshot: StubSnapshot) {
+    let file = CacheFile {
+        key: key.to_string(),
+        snapshot,
+    };
+    if let Ok(json) = serde_json::to_string(&file) {
+        let _ = std::fs::write(cache_path(cache_dir), json);
+    }
+}

--- a/crates/mir-analyzer/src/stubs.rs
+++ b/crates/mir-analyzer/src/stubs.rs
@@ -10,7 +10,10 @@
 ///    things that need custom handling (precise by-ref/variadic params, return
 ///    type shorthands, PHPUnit helpers, etc.).
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
+
+use crate::stub_cache;
 
 use mir_codebase::storage::{
     ClassStorage, FnParam, FunctionStorage, InterfaceStorage, MethodStorage, Visibility,
@@ -22,26 +25,135 @@ use mir_types::{Atomic, Union};
 include!(concat!(env!("OUT_DIR"), "/phpstorm_stubs.rs"));
 
 // ---------------------------------------------------------------------------
-// Public entry point
+// Extension version gates
 // ---------------------------------------------------------------------------
 
+/// Minimum PHP version required for each phpstorm-stubs extension directory.
+/// Extensions not listed here are always loaded (they exist in all supported PHP versions).
+/// Values are `(major, minor)` tuples.
+const EXTENSION_MIN_PHP: &[(&str, (u8, u8))] = &[
+    ("random", (8, 2)), // \Random\Engine, \Random\Randomizer added in PHP 8.2
+];
+
+/// Extensions always loaded regardless of the enabled-extension set.
+/// These form the baseline PHP runtime every project depends on.
+const ALWAYS_LOAD_EXTENSIONS: &[&str] = &[
+    "core",
+    "standard",
+    "spl",
+    "date",
+    "json",
+    "pcre",
+    "reflection",
+    "filter",
+];
+
+// ---------------------------------------------------------------------------
+// Stub load configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for stub loading, passed to [`load_stubs_configured`].
+pub struct StubConfig<'a> {
+    /// Target PHP version for extension version gating. `None` disables gating.
+    pub php_version: Option<(u8, u8)>,
+    /// Allowlist of lowercase extension names to load from phpstorm-stubs.
+    /// `None` loads all embedded extensions (default behavior).
+    /// The [`ALWAYS_LOAD_EXTENSIONS`] set is always included.
+    pub enabled_extensions: Option<&'a HashSet<String>>,
+    /// Additional stub files to parse (absolute paths).
+    pub stub_files: &'a [PathBuf],
+    /// Additional stub directories to walk and parse (absolute paths).
+    pub stub_dirs: &'a [PathBuf],
+    /// Directory for the stub snapshot cache. `None` disables caching.
+    /// When set, a warm cache skips all PHP parsing for stubs entirely.
+    pub cache_dir: Option<&'a Path>,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Load PHP built-in stubs with default settings (all extensions, no user stubs, no cache).
+/// Kept for backward compatibility; prefer [`load_stubs_configured`] for new callers.
 pub fn load_stubs(codebase: &Codebase) {
-    // Layer 1: parse phpstorm-stubs for comprehensive built-in coverage.
-    load_phpstorm_stubs(codebase);
-    // Layer 2: hand-written stubs override/supplement where needed.
-    load_functions(codebase);
-    load_classes(codebase);
-    load_interfaces(codebase);
+    load_stubs_configured(
+        codebase,
+        &StubConfig {
+            php_version: None,
+            enabled_extensions: None,
+            stub_files: &[],
+            stub_dirs: &[],
+            cache_dir: None,
+        },
+    );
+}
+
+/// Load stubs with full configuration: filtered phpstorm-stubs + user-provided stubs.
+/// When `config.cache_dir` is set, attempts to restore from a snapshot on cache hit,
+/// and saves a new snapshot on cache miss.
+pub fn load_stubs_configured(codebase: &Codebase, config: &StubConfig<'_>) {
+    if let Some(cache_dir) = config.cache_dir {
+        let key = stub_cache::cache_key(
+            config.php_version,
+            config.enabled_extensions,
+            config.stub_files,
+            config.stub_dirs,
+        );
+        if let Some(snap) = stub_cache::load(cache_dir, &key) {
+            stub_cache::apply(codebase, snap);
+            return;
+        }
+        // Cache miss — parse normally, then save snapshot.
+        load_phpstorm_stubs(codebase, config.php_version, config.enabled_extensions);
+        load_user_stubs(codebase, config.stub_files, config.stub_dirs);
+        load_functions(codebase);
+        load_classes(codebase);
+        load_interfaces(codebase);
+        stub_cache::save(cache_dir, &key, stub_cache::capture(codebase));
+    } else {
+        load_phpstorm_stubs(codebase, config.php_version, config.enabled_extensions);
+        load_user_stubs(codebase, config.stub_files, config.stub_dirs);
+        load_functions(codebase);
+        load_classes(codebase);
+        load_interfaces(codebase);
+    }
 }
 
 // ---------------------------------------------------------------------------
 // phpstorm-stubs loader
 // ---------------------------------------------------------------------------
 
-/// Parse every embedded phpstorm-stub file through the standard PHP parser and
-/// `DefinitionCollector`, populating `codebase` with PHP built-in definitions.
-fn load_phpstorm_stubs(codebase: &Codebase) {
+/// Parse embedded phpstorm-stub files, optionally filtered by PHP version and extension set.
+fn load_phpstorm_stubs(
+    codebase: &Codebase,
+    php_version: Option<(u8, u8)>,
+    enabled: Option<&HashSet<String>>,
+) {
     for (filename, content) in PHPSTORM_STUB_FILES {
+        // Extension name = first path segment, lowercased (e.g. "PDO/PDO.php" → "pdo").
+        let ext_lc = filename.split('/').next().unwrap_or("").to_lowercase();
+
+        // Skip if the extension requires a newer PHP than the target version.
+        if let Some(ver) = php_version {
+            if let Some(&(maj, min)) = EXTENSION_MIN_PHP
+                .iter()
+                .find(|(n, _)| *n == ext_lc)
+                .map(|(_, v)| v)
+            {
+                if ver < (maj, min) {
+                    continue;
+                }
+            }
+        }
+
+        // Skip if an extension allowlist is active and this extension isn't on it
+        // (always-load extensions bypass the allowlist).
+        if let Some(allowed) = enabled {
+            if !ALWAYS_LOAD_EXTENSIONS.contains(&ext_lc.as_str()) && !allowed.contains(&ext_lc) {
+                continue;
+            }
+        }
+
         let arena = bumpalo::Bump::new();
         let result = php_rs_parser::parse(&arena, content);
         let file: Arc<str> = Arc::from(*filename);
@@ -49,6 +161,52 @@ fn load_phpstorm_stubs(codebase: &Codebase) {
             crate::collector::DefinitionCollector::new(codebase, file, content, &result.source_map);
         // Ignore stub parse issues — they don't affect user code analysis.
         let _ = collector.collect(&result.program);
+    }
+}
+
+/// Parse user-provided stub files and directories into `codebase`.
+pub fn load_user_stubs(codebase: &Codebase, files: &[PathBuf], dirs: &[PathBuf]) {
+    for path in files {
+        parse_stub_file(codebase, path);
+    }
+    for dir in dirs {
+        walk_stub_dir(codebase, dir);
+    }
+}
+
+fn parse_stub_file(codebase: &Codebase, path: &Path) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("mir: cannot read stub file {}: {}", path.display(), e);
+            return;
+        }
+    };
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, &content);
+    let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
+    let collector =
+        crate::collector::DefinitionCollector::new(codebase, file, &content, &result.source_map);
+    let _ = collector.collect(&result.program);
+}
+
+fn walk_stub_dir(codebase: &Codebase, dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("mir: cannot read stub directory {}: {}", dir.display(), e);
+            return;
+        }
+    };
+    let mut paths: Vec<std::path::PathBuf> =
+        entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
+    paths.sort_unstable();
+    for path in paths {
+        if path.is_dir() {
+            walk_stub_dir(codebase, &path);
+        } else if path.extension().is_some_and(|e| e == "php") {
+            parse_stub_file(codebase, &path);
+        }
     }
 }
 

--- a/crates/mir-analyzer/tests/stub_cache.rs
+++ b/crates/mir-analyzer/tests/stub_cache.rs
@@ -1,0 +1,103 @@
+// Integration tests for the stub snapshot cache (Phase 2 of stub injection).
+//
+// Verifies that:
+// 1. A warm cache hit skips PHP parsing and produces identical analysis results.
+// 2. The cache is invalidated when the cache key changes (e.g. a user stub file changes).
+
+use std::fs;
+use std::path::PathBuf;
+
+use mir_analyzer::{cache::AnalysisCache, ProjectAnalyzer};
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+fn analyzer_with_cache(cache_dir: &TempDir) -> ProjectAnalyzer {
+    let mut a = ProjectAnalyzer::new();
+    a.cache = Some(AnalysisCache::open(cache_dir.path()));
+    a
+}
+
+#[test]
+fn stub_cache_hit_produces_same_results() {
+    let cache_dir = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+
+    let php = write(&src_dir, "main.php", "<?php\n$s = strlen('hello');\n");
+
+    // First run — cold cache, stubs parsed from PHP.
+    let result1 = {
+        let a = analyzer_with_cache(&cache_dir);
+        a.load_stubs();
+        a.analyze(std::slice::from_ref(&php)).issues
+    };
+
+    // Second run — warm cache, stubs restored from snapshot.
+    let result2 = {
+        let a = analyzer_with_cache(&cache_dir);
+        a.load_stubs();
+        a.analyze(std::slice::from_ref(&php)).issues
+    };
+
+    assert_eq!(
+        result1.len(),
+        result2.len(),
+        "warm cache should produce identical issue count"
+    );
+
+    // Verify the stub cache file exists.
+    assert!(
+        cache_dir.path().join("stub-cache.json").exists(),
+        "stub-cache.json should be written after first run"
+    );
+}
+
+#[test]
+fn stub_cache_invalidated_on_user_stub_change() {
+    let cache_dir = TempDir::new().unwrap();
+    let stubs_dir = TempDir::new().unwrap();
+
+    // Write a user stub file.
+    let stub_file = write(
+        &stubs_dir,
+        "MyStubs.php",
+        "<?php\nfunction my_stub_fn(): string { return ''; }\n",
+    );
+
+    // First run — builds cache with my_stub_fn defined.
+    {
+        let mut a = analyzer_with_cache(&cache_dir);
+        a.stub_files = vec![stub_file.clone()];
+        a.load_stubs();
+        assert!(
+            a.codebase.functions.contains_key("my_stub_fn"),
+            "stub function must be registered after first load"
+        );
+    }
+
+    // Modify the stub file content — this must invalidate the cache.
+    fs::write(
+        &stub_file,
+        "<?php\nfunction my_stub_fn_v2(): int { return 0; }\n",
+    )
+    .unwrap();
+
+    // Second run — cache key changes, stubs re-parsed.
+    {
+        let mut a = analyzer_with_cache(&cache_dir);
+        a.stub_files = vec![stub_file.clone()];
+        a.load_stubs();
+        assert!(
+            a.codebase.functions.contains_key("my_stub_fn_v2"),
+            "updated stub function must be registered after cache invalidation"
+        );
+        assert!(
+            !a.codebase.functions.contains_key("my_stub_fn"),
+            "old stub function must not appear after cache invalidation"
+        );
+    }
+}

--- a/crates/mir-cli/src/config.rs
+++ b/crates/mir-cli/src/config.rs
@@ -38,12 +38,20 @@ pub struct Config {
     pub issue_handlers: HashMap<String, ErrorLevel>,
     /// Global error level 1–8 (lower = stricter). 1 = errors only, 2 = +warnings, 3+ = +info.
     pub error_level: u8,
-    /// Target PHP version string (e.g. `"8.2"`).
+    /// Target PHP version string (e.g. `"8.2"`). Accepts both root attribute and child element.
     pub php_version: Option<String>,
     /// Whether dead-code detection is enabled.
     pub find_unused_code: bool,
     /// Whether unused-variable checking is enabled.
     pub find_unused_variables: bool,
+    /// External stub files to load (from `<stubs><file name="..."/>`). Psalm-compatible.
+    pub stub_files: Vec<String>,
+    /// External stub directories to load (from `<stubs><directory name="..."/>`). mir extension.
+    pub stub_dirs: Vec<String>,
+    /// PHP extensions to enable on top of auto-detected ones (from `<enableExtensions>`).
+    pub enable_extensions: Vec<String>,
+    /// PHP extensions to disable (from `<disableExtensions>`).
+    pub disable_extensions: Vec<String>,
 }
 
 impl Default for Config {
@@ -56,6 +64,10 @@ impl Default for Config {
             php_version: None,
             find_unused_code: false,
             find_unused_variables: false,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
+            enable_extensions: Vec::new(),
+            disable_extensions: Vec::new(),
         }
     }
 }
@@ -127,6 +139,19 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
             Ok(Event::Start(e)) => {
                 let name = bytes_to_string(e.name().as_ref());
 
+                // phpVersion as attribute on the root element (Psalm-compatible).
+                // <mir phpVersion="8.2"> or <psalm phpVersion="8.2">
+                if path.is_empty() && (name == "mir" || name == "psalm") {
+                    for attr in e.attributes().flatten() {
+                        if bytes_to_string(attr.key.as_ref()) == "phpVersion" {
+                            let val = bytes_to_string(&attr.value);
+                            if !val.is_empty() && config.php_version.is_none() {
+                                config.php_version = Some(val);
+                            }
+                        }
+                    }
+                }
+
                 // Issue handler: <SomeIssueKind errorLevel="..." />  inside <issueHandlers>
                 if path
                     .last()
@@ -146,6 +171,16 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
                 // <directory name="..."> inside <projectFiles> or <ignoreFiles>
                 if name == "directory" {
                     collect_directory(&e, &path, &mut config);
+                }
+
+                // <file name="..."> or <directory name="..."> inside <stubs>
+                if name == "file" || name == "directory" {
+                    collect_stub_entry(&e, &path, &mut config);
+                }
+
+                // <extension name="..."> inside <enableExtensions> or <disableExtensions>
+                if name == "extension" {
+                    collect_extension(&e, &path, &mut config);
                 }
 
                 text_buf.clear();
@@ -173,6 +208,16 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
 
                 if name == "directory" {
                     collect_directory(&e, &path, &mut config);
+                }
+
+                // <file name="..."> inside <stubs>
+                if name == "file" || name == "directory" {
+                    collect_stub_entry(&e, &path, &mut config);
+                }
+
+                // <extension name="..."> inside <enableExtensions> or <disableExtensions>
+                if name == "extension" {
+                    collect_extension(&e, &path, &mut config);
                 }
             }
 
@@ -229,6 +274,48 @@ fn collect_directory<'a>(
             match parent {
                 "projectFiles" => config.project_dirs.push(val),
                 "ignoreFiles" => config.ignore_dirs.push(val),
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Handle `<file name="..."/>` and `<directory name="..."/>` inside `<stubs>`.
+fn collect_stub_entry<'a>(
+    e: &quick_xml::events::BytesStart<'a>,
+    path: &[String],
+    config: &mut Config,
+) {
+    let parent = path.last().map(|s| s.as_str()).unwrap_or("");
+    if parent != "stubs" {
+        return;
+    }
+    let elem = bytes_to_string(e.name().as_ref());
+    for attr in e.attributes().flatten() {
+        if bytes_to_string(attr.key.as_ref()) == "name" {
+            let val = bytes_to_string(&attr.value);
+            match elem.as_str() {
+                "file" => config.stub_files.push(val),
+                "directory" => config.stub_dirs.push(val),
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Handle `<extension name="..."/>` inside `<enableExtensions>` or `<disableExtensions>`.
+fn collect_extension<'a>(
+    e: &quick_xml::events::BytesStart<'a>,
+    path: &[String],
+    config: &mut Config,
+) {
+    let parent = path.last().map(|s| s.as_str()).unwrap_or("");
+    for attr in e.attributes().flatten() {
+        if bytes_to_string(attr.key.as_ref()) == "name" {
+            let val = bytes_to_string(&attr.value).to_lowercase();
+            match parent {
+                "enableExtensions" => config.enable_extensions.push(val),
+                "disableExtensions" => config.disable_extensions.push(val),
                 _ => {}
             }
         }

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
@@ -204,6 +205,7 @@ fn main() {
         }
 
         analyzer.find_dead_code = cli.find_dead_code;
+        apply_stub_config(&mut analyzer, &config, &config_base);
 
         let vendor_files = map.vendor_files();
 
@@ -388,6 +390,7 @@ fn main() {
     };
 
     analyzer.find_dead_code = cli.find_dead_code;
+    apply_stub_config(&mut analyzer, &config, &config_base);
 
     // Load type stubs first (needed before collect_types_only)
     analyzer.load_stubs();
@@ -694,6 +697,82 @@ fn run_output(
     let has_errors = display_issues.iter().any(|i| i.severity == Severity::Error);
     if has_errors {
         process::exit(1);
+    }
+}
+
+/// Parse a PHP version string like `"8.2"` into a `(major, minor)` tuple.
+fn parse_php_version(s: &str) -> Option<(u8, u8)> {
+    let mut parts = s.splitn(2, '.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor))
+}
+
+/// Build the effective enabled-extension set from config + optional composer auto-detection.
+///
+/// Returns `None` when no filtering is requested (load all), or `Some(set)` with the
+/// lowercase extension names that should be loaded.
+fn build_extension_set(
+    config: &Config,
+    composer_root: Option<&std::path::Path>,
+) -> Option<HashSet<String>> {
+    let has_explicit =
+        !config.enable_extensions.is_empty() || !config.disable_extensions.is_empty();
+
+    // Try to auto-detect extensions from composer.json
+    let composer_exts = composer_root.and_then(mir_analyzer::composer::parse_required_extensions);
+
+    if composer_exts.is_none() && !has_explicit {
+        // No filtering requested — load all embedded extensions.
+        return None;
+    }
+
+    let mut set: HashSet<String> = composer_exts.unwrap_or_default();
+
+    // Apply explicit enable/disable overrides from config.
+    for ext in &config.enable_extensions {
+        set.insert(ext.clone());
+    }
+    for ext in &config.disable_extensions {
+        set.remove(ext.as_str());
+    }
+
+    Some(set)
+}
+
+/// Apply stub configuration from `Config` to a `ProjectAnalyzer`.
+/// `config_base` is the directory containing `mir.xml`, used to resolve relative paths.
+fn apply_stub_config(
+    analyzer: &mut ProjectAnalyzer,
+    config: &Config,
+    config_base: &std::path::Path,
+) {
+    // PHP version
+    if let Some(ver) = config.php_version.as_deref().and_then(parse_php_version) {
+        analyzer.php_version = Some(ver);
+    }
+
+    // Extension set — use config_base as composer root for auto-detection
+    analyzer.enabled_extensions = build_extension_set(config, Some(config_base));
+
+    // Stub files (resolve relative paths against config_base)
+    for f in &config.stub_files {
+        let p = PathBuf::from(f);
+        analyzer.stub_files.push(if p.is_absolute() {
+            p
+        } else {
+            config_base.join(f)
+        });
+    }
+
+    // Stub directories
+    for d in &config.stub_dirs {
+        let p = PathBuf::from(d);
+        analyzer.stub_dirs.push(if p.is_absolute() {
+            p
+        } else {
+            config_base.join(d)
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `<stubs>`, `<enableExtensions>`, and `<disableExtensions>` to `mir.xml` so projects can inject external type definitions (Laravel, Doctrine, Drupal, etc.) and control which built-in PHP extensions are loaded
- Auto-detects required PHP extensions from `ext-*` keys in `composer.json` with no configuration needed
- Adds a stub snapshot cache (`{cache_dir}/stub-cache.json`) that serialises the parsed stub `Codebase` to disk — warm runs skip all PHP stub parsing entirely
- Accepts `phpVersion` as a root element attribute (in addition to the existing child element form) so both formats work without migration

## Configuration

```xml
<mir phpVersion="8.2">

  <!-- External stub files and directories -->
  <stubs>
    <file name="stubs/_ide_helper.php"/>
    <directory name="stubs/doctrine"/>
  </stubs>

  <!-- Extension control (auto-detected from composer.json ext-* by default) -->
  <enableExtensions>
    <extension name="pdo"/>
    <extension name="redis"/>
  </enableExtensions>
  <disableExtensions>
    <extension name="sockets"/>
  </disableExtensions>

</mir>
```

## How the stub cache works

On the first run with `--cache-dir`, after all stubs are parsed, mir serialises the stub portion of the `Codebase` (classes, interfaces, traits, enums, functions, constants) to `{cache_dir}/stub-cache.json`. On subsequent runs the snapshot is restored directly — no PHP files are parsed for stubs. The cache key covers the crate version, PHP version, extension set, and content hashes of every user stub file, so any change invalidates automatically.

## New public API

| Item | Location |
|------|----------|
| `StubConfig`, `load_stubs_configured()` | `stubs` |
| `load_user_stubs()` | `stubs` |
| `parse_required_extensions()` | `composer` |
| `stub_cache` module | `stub_cache` |
| `php_version`, `enabled_extensions`, `stub_files`, `stub_dirs` | `ProjectAnalyzer` |
| `AnalysisCache::cache_dir()` | `cache` |

## Test plan

- [ ] `cargo test` passes (383 tests, 0 failures)
- [ ] `tests/stub_cache.rs`: cache hit produces identical results; cache invalidated when user stub file changes
- [ ] `tests/composer.rs`: `parse_required_extensions` correctly reads `ext-*` keys and returns `None` when none present
- [ ] Manual: add `<stubs><file name="stubs/test.php"/>` to `mir.xml`, verify the stub class resolves during analysis
- [ ] Manual: set `<disableExtensions><extension name="gmp"/></disableExtensions>`, verify `gmp_add()` gives `UndefinedFunction`
- [ ] Manual: run with `--cache-dir`, confirm `stub-cache.json` is written; run again and confirm no stub parse output