### PR TITLE
fix(analyzer): parameters of nested class methods no longer reported as undefined

### DIFF
--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -966,7 +966,21 @@ impl<'a> StatementsAnalyzer<'a> {
                         .get_method(fqcn.as_ref(), method.name)
                         .as_deref()
                         .map(|m| (m.params.clone(), m.return_type.clone()))
-                        .unwrap_or_default();
+                        .unwrap_or_else(|| {
+                            let ast_params = method
+                                .params
+                                .iter()
+                                .map(|p| mir_codebase::FnParam {
+                                    name: p.name.trim_start_matches('$').into(),
+                                    ty: None,
+                                    default: p.default.as_ref().map(|_| mir_types::Union::mixed()),
+                                    is_variadic: p.variadic,
+                                    is_byref: p.by_ref,
+                                    is_optional: p.default.is_some() || p.variadic,
+                                })
+                                .collect();
+                            (ast_params, None)
+                        });
                     let is_ctor = method.name == "__construct";
                     let mut method_ctx = Context::for_method(
                         &params,

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/arrow_function_parameter_not_undefined_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/arrow_function_parameter_not_undefined_no_error.phpt
@@ -1,0 +1,4 @@
+===source===
+<?php
+$fn = fn(int $n): int => $n * 2;
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/basic_undefined_in_body_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/basic_undefined_in_body_error.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function foo(): string {
+    return $result;
+}
+===expect===
+UndefinedVariable: Variable $result is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/closure_no_use_captures_outer_param_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/closure_no_use_captures_outer_param_error.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+function outer(string $x): callable {
+    return function(): string {
+        return $x;
+    };
+}
+===expect===
+UndefinedVariable: Variable $x is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/closure_parameter_not_undefined_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/closure_parameter_not_undefined_no_error.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+$fn = function(string $name): string {
+    return $name;
+};
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/method_parameter_not_undefined_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/method_parameter_not_undefined_no_error.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+class Greeter {
+    public function greet(string $name): string {
+        return 'Hello, ' . $name;
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/nested_class_method_parameter_not_undefined_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/nested_class_method_parameter_not_undefined_no_error.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+function outer(): void {
+    class Inner {
+        public function process(string $data): string {
+            return $data;
+        }
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/param_defined_but_other_var_undefined_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/param_defined_but_other_var_undefined_error.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function transform(string $input): string {
+    return $input . $suffix;
+}
+===expect===
+UndefinedVariable: Variable $suffix is not defined

--- a/crates/mir-analyzer/tests/fixtures/undefined_variable/parameter_not_undefined_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_variable/parameter_not_undefined_no_error.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function greet(string $name): string {
+    return 'Hello, ' . $name;
+}
+===expect===


### PR DESCRIPTION
## Summary

- Fixes a false-positive `UndefinedVariable` for parameters of methods on classes declared inside function bodies
- Adds 8 test fixtures covering all parameter-in-function-body scenarios

## Root cause

`DefinitionCollector` (Pass 1) does not recurse into function bodies, so a class declared inside a function is absent from the codebase. The `StmtKind::Class` handler in `stmt.rs` fetched method params via `get_method(...).unwrap_or_default()` — when the class was missing, this produced an **empty param list**, causing every parameter variable in those methods to be reported as `UndefinedVariable`.

## Fix

Replace `unwrap_or_default()` with a fallback that builds params directly from the AST (the same strategy `analyze_fn_decl` already uses for functions not found in the codebase).

## Test plan

- [ ] `nested_class_method_parameter_not_undefined_no_error.phpt` — the direct regression test for the bug
- [ ] `parameter_not_undefined_no_error.phpt` — regular function param
- [ ] `method_parameter_not_undefined_no_error.phpt` — class method param
- [ ] `closure_parameter_not_undefined_no_error.phpt` — closure param
- [ ] `arrow_function_parameter_not_undefined_no_error.phpt` — arrow function param
- [ ] `basic_undefined_in_body_error.phpt` — truly undefined variable still reported
- [ ] `param_defined_but_other_var_undefined_error.phpt` — param present does not suppress other errors
- [ ] `closure_no_use_captures_outer_param_error.phpt` — outer param correctly unavailable inside closure without `use()`
- [ ] `cargo test --package mir-analyzer` — all 228 tests pass