### PR TITLE
fix(ci): benchmark workflow never posted PR comments

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -102,7 +102,11 @@ jobs:
           BASELINE_NAME: ${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
         run: |
           cargo bench -p mir-analyzer --bench analyze_real_world \
-            -- --save-baseline "$BASELINE_NAME" --noplot
+            -- --save-baseline "$BASELINE_NAME" --noplot 2>&1 | tee bench-output.txt
+          echo '## Benchmark output' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat bench-output.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       # Push to main: persist the new baseline for future PR comparisons.
       - name: Save main baseline
@@ -117,13 +121,32 @@ jobs:
       - name: Compare baselines
         if: >-
           github.event_name == 'pull_request' &&
-          steps.restore-baseline.outputs.cache-hit == 'true'
-        run: critcmp main pr | tee critcmp-output.txt
+          steps.restore-baseline.outputs.cache-matched-key != ''
+        run: |
+          critcmp main pr | tee critcmp-output.txt
+          echo '## Benchmark results (PR vs `main`)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat critcmp-output.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post no-baseline notice
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore-baseline.outputs.cache-matched-key == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '## Benchmark results\n\nNo `main` baseline found — comparison skipped. A baseline will be saved when this PR merges.',
+            });
 
       - name: Post comparison comment
         if: >-
           github.event_name == 'pull_request' &&
-          steps.restore-baseline.outputs.cache-hit == 'true'
+          steps.restore-baseline.outputs.cache-matched-key != ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -137,7 +160,7 @@ jobs:
               `\`\`\`\n${table}\`\`\`\n` +
               `*Peak memory and total-allocation stats are printed to stderr — ` +
               `see the [workflow logs](${logsUrl}) for those numbers.*`;
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- `cache-hit` is only `true` for exact key matches; PR runs always use `restore-keys` (prefix match against a main SHA), so `cache-hit` was always `false` and both the compare and comment steps were unconditionally skipped. Switched to `cache-matched-key != ''` which is non-empty for both exact and prefix matches.
- Missing `await` on `createComment` caused the action to exit before the HTTP request completed, silently dropping the comment.
- Benchmark output (including memory stats from stderr) and the `critcmp` comparison table are now written to `$GITHUB_STEP_SUMMARY` so results are visible directly on the workflow run page.

## Test plan

- [ ] Merge this to `main` and verify the benchmark run saves a baseline
- [ ] Open a follow-up PR touching `crates/` and verify a comparison comment is posted
- [ ] Check the workflow run summary page for benchmark output