### PR TITLE
feat(fixtures): add test for param used via reference assignment

### DIFF
--- a/crates/mir-analyzer/tests/fixtures/unused_param/ref_assignment_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_param/ref_assignment_not_reported.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+final class MyClass {
+    private \stdClass $config;
+
+    public function __construct(\stdClass $config) {
+        $this->config = &$config;
+    }
+}
+===expect===


### PR DESCRIPTION
## Summary

- Adds a new `UnusedParam` fixture confirming that a constructor parameter used exclusively via `$this->prop = &$param` (reference assignment) is not incorrectly flagged as unused.

## Test plan

- [ ] `cargo test --test fixtures unused_param` passes