### PR TITLE
fix(analyzer): null literal passed to non-nullable param now emits InvalidArgument

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -874,26 +874,31 @@ fn check_args(ea: &mut ExpressionAnalyzer<'_>, p: CheckArgsParams<'_>) {
             } else {
                 raw_param_ty
             };
-            // Null check: param is not nullable but arg could be null
-            if !param_ty.is_nullable() && arg_ty.is_nullable() {
+            // Null check: param is not nullable but arg could be null.
+            // Check definite null (single TNull) before possibly-null union to emit the
+            // correct severity: a literal `null` is InvalidArgument, not PossiblyNullArgument.
+            if !param_ty.is_nullable()
+                && !param_ty.is_mixed()
+                && arg_ty.is_single()
+                && arg_ty.contains(|t| matches!(t, Atomic::TNull))
+            {
+                ea.emit(
+                    IssueKind::InvalidArgument {
+                        param: param.name.to_string(),
+                        fn_name: fn_name.to_string(),
+                        expected: format!("{}", param_ty),
+                        actual: format!("{}", arg_ty),
+                    },
+                    Severity::Error,
+                    arg_span,
+                );
+            } else if !param_ty.is_nullable() && !param_ty.is_mixed() && arg_ty.is_nullable() {
                 ea.emit(
                     IssueKind::PossiblyNullArgument {
                         param: param.name.to_string(),
                         fn_name: fn_name.to_string(),
                     },
                     Severity::Info,
-                    arg_span,
-                );
-            } else if !param_ty.is_nullable()
-                && arg_ty.contains(|t| matches!(t, Atomic::TNull))
-                && arg_ty.is_single()
-            {
-                ea.emit(
-                    IssueKind::NullArgument {
-                        param: param.name.to_string(),
-                        fn_name: fn_name.to_string(),
-                    },
-                    Severity::Error,
                     arg_span,
                 );
             }

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/does_not_report_null_passed_to_mixed_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/does_not_report_null_passed_to_mixed_param.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function f(mixed $x): void {}
+function test(): void { f(null); }
+===expect===
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/does_not_report_null_passed_to_nullable_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/does_not_report_null_passed_to_nullable_param.phpt
@@ -1,0 +1,6 @@
+===source===
+<?php
+function f(?string $x): void {}
+function test(): void { f(null); }
+===expect===
+UnusedParam: Parameter $x is never used

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_int.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function f(int $x): void {}
+function test(): void { f(null); }
+===expect===
+UnusedParam: Parameter $x is never used
+InvalidArgument: Argument $x of f() expects 'int', got 'null'

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_string.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_string.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+function f(string $x): void {}
+function test(): void { f(null); }
+===expect===
+UnusedParam: Parameter $x is never used
+InvalidArgument: Argument $x of f() expects 'string', got 'null'


### PR DESCRIPTION
Fixes #43.

## Summary

- `is_nullable()` returns `true` for a single `TNull`, so the `PossiblyNullArgument` (info severity) branch always fired before the `NullArgument` branch, leaving it unreachable
- Reordered checks so definite null (single `TNull`) is detected first and emits `InvalidArgument` (error severity); a union containing null (e.g. `string|null`) still emits `PossiblyNullArgument`
- Added `!param_ty.is_mixed()` guard to both null-check branches — `mixed` does not include `TNull` so `is_nullable()` returns false for it, which caused false `InvalidArgument` / `PossiblyNullArgument` emissions

## Test plan

- [x] `reports_null_passed_as_string` — `f(null)` where param is `string` emits `InvalidArgument`
- [x] `reports_null_passed_as_int` — same for `int` param
- [x] `does_not_report_null_passed_to_nullable_param` — `f(null)` where param is `?string` emits no error
- [x] `does_not_report_null_passed_to_mixed_param` — `f(null)` where param is `mixed` emits no error