### PR TITLE
fix(analyzer): emit DeprecatedCall/DeprecatedMethodCall for top-level statements

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -673,6 +673,39 @@ impl ProjectAnalyzer {
             }
         }
 
+        // Analyze top-level executable statements in global scope.
+        {
+            use crate::context::Context;
+            use crate::stmt::StatementsAnalyzer;
+            use mir_issues::IssueBuffer;
+
+            let mut ctx = Context::new();
+            let mut buf = IssueBuffer::new();
+            let mut sa = StatementsAnalyzer::new(
+                &self.codebase,
+                file.clone(),
+                source,
+                source_map,
+                &mut buf,
+                &mut all_symbols,
+            );
+            for stmt in program.stmts.iter() {
+                match &stmt.kind {
+                    StmtKind::Function(_)
+                    | StmtKind::Class(_)
+                    | StmtKind::Enum(_)
+                    | StmtKind::Interface(_)
+                    | StmtKind::Trait(_)
+                    | StmtKind::Namespace(_)
+                    | StmtKind::Use(_)
+                    | StmtKind::Declare(_) => {}
+                    _ => sa.analyze_stmt(stmt, &mut ctx),
+                }
+            }
+            drop(sa);
+            all_issues.extend(buf.into_issues());
+        }
+
         (all_issues, all_symbols)
     }
 
@@ -974,6 +1007,42 @@ impl ProjectAnalyzer {
                 _ => {}
             }
         }
+
+        // Analyze top-level executable statements in global scope (e.g. function calls
+        // outside any function/class body). Declaration nodes are skipped since they
+        // were already handled above.
+        {
+            use crate::context::Context;
+            use crate::stmt::StatementsAnalyzer;
+            use mir_issues::IssueBuffer;
+
+            let mut ctx = Context::new();
+            let mut buf = IssueBuffer::new();
+            let mut sa = StatementsAnalyzer::new(
+                &self.codebase,
+                file.clone(),
+                source,
+                source_map,
+                &mut buf,
+                all_symbols,
+            );
+            for stmt in program.stmts.iter() {
+                match &stmt.kind {
+                    StmtKind::Function(_)
+                    | StmtKind::Class(_)
+                    | StmtKind::Enum(_)
+                    | StmtKind::Interface(_)
+                    | StmtKind::Trait(_)
+                    | StmtKind::Namespace(_)
+                    | StmtKind::Use(_)
+                    | StmtKind::Declare(_) => {}
+                    _ => sa.analyze_stmt(stmt, &mut ctx),
+                }
+            }
+            drop(sa);
+            all_issues.extend(buf.into_issues());
+        }
+
         all_issues
     }
 

--- a/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function_at_top_level.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_call/reports_deprecated_function_at_top_level.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+/** @deprecated use newGreet() instead */
+function oldGreet(string $name): void {}
+
+oldGreet('Alice');
+===expect===
+UnusedParam: Parameter $name is never used
+DeprecatedCall: Call to deprecated function oldGreet

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method_at_top_level.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_method_at_top_level.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+class Greeter {
+    /** @deprecated use newGreet() instead */
+    public function oldGreet(string $name): void {}
+}
+
+$g = new Greeter();
+$g->oldGreet('Alice');
+===expect===
+UnusedParam: Parameter $name is never used
+DeprecatedMethodCall: Call to deprecated method Greeter::oldGreet

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_self_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_self_method.phpt
@@ -1,0 +1,13 @@
+===source===
+<?php
+class Greeter {
+    /** @deprecated use newGreet() instead */
+    public static function oldGreet(string $name): void {}
+
+    public static function test(): void {
+        self::oldGreet('Alice');
+    }
+}
+===expect===
+UnusedParam: Parameter $name is never used
+DeprecatedMethodCall: Call to deprecated method Greeter::oldGreet

--- a/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_static_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_method_call/reports_deprecated_static_method.phpt
@@ -1,0 +1,13 @@
+===source===
+<?php
+class Greeter {
+    /** @deprecated use newGreet() instead */
+    public static function oldGreet(string $name): void {}
+}
+
+function test(): void {
+    Greeter::oldGreet('Alice');
+}
+===expect===
+UnusedParam: Parameter $name is never used
+DeprecatedMethodCall: Call to deprecated method Greeter::oldGreet


### PR DESCRIPTION
## Summary

- Both `analyze_bodies` and `analyze_bodies_typed` skipped top-level executable statements, so deprecated-function/method warnings were never emitted for call sites outside any function or class body
- Added a second pass in both methods that runs non-declaration top-level statements through a `StatementsAnalyzer` with a global-scope `Context`

## Test plan

- [ ] `deprecated_call::reports_deprecated_function_at_top_level` — function call at file scope
- [ ] `deprecated_method_call::reports_deprecated_method_at_top_level` — instance method call at file scope
- [ ] `deprecated_method_call::reports_deprecated_static_method` — `ClassName::method()` call
- [ ] `deprecated_method_call::reports_deprecated_self_method` — `self::method()` call inside class

Closes #100