### PR TITLE
fix(analyzer): do-while with continue no longer triggers false RedundantCondition

### DIFF
--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -400,6 +400,10 @@ impl<'a> StatementsAnalyzer<'a> {
                     self.codebase,
                     &self.file,
                 );
+                // Capture narrowing-only unreachability before body analysis —
+                // body divergence (continue/return/throw) must not trigger
+                // RedundantCondition for valid conditions.
+                let then_unreachable_from_narrowing = then_ctx.diverges;
                 // Skip analyzing a statically-unreachable branch (prevents false
                 // positives in dead branches caused by overly conservative types).
                 if !then_ctx.diverges {
@@ -493,6 +497,7 @@ impl<'a> StatementsAnalyzer<'a> {
                     self.codebase,
                     &self.file,
                 );
+                let else_unreachable_from_narrowing = else_ctx.diverges;
                 if !else_ctx.diverges {
                     if let Some(else_branch) = &if_stmt.else_branch {
                         self.analyze_stmt(else_branch, &mut else_ctx);
@@ -500,7 +505,9 @@ impl<'a> StatementsAnalyzer<'a> {
                 }
 
                 // Emit RedundantCondition if narrowing proves one branch is statically unreachable.
-                if !pre_diverges && (then_ctx.diverges || else_ctx.diverges) {
+                if !pre_diverges
+                    && (then_unreachable_from_narrowing || else_unreachable_from_narrowing)
+                {
                     let (line, col_start) = self.offset_to_line_col(if_stmt.condition.span.start);
                     let col_end = if if_stmt.condition.span.start < if_stmt.condition.span.end {
                         let (_end_line, end_col) =

--- a/crates/mir-analyzer/tests/fixtures/redundant_condition/does_not_report_do_while_control_var.phpt
+++ b/crates/mir-analyzer/tests/fixtures/redundant_condition/does_not_report_do_while_control_var.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+function foo(): void {
+    do {
+        $run = false;
+        if (time() % 3 === 0) {
+            continue;
+        }
+        $run = true;
+    } while ($run);
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_variable/do_while_control_var_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_variable/do_while_control_var_not_reported.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+function foo(): void {
+    do {
+        $run = false;
+        if (time() % 3 === 0) {
+            continue;
+        }
+        $run = true;
+    } while ($run);
+}
+===expect===


### PR DESCRIPTION
## Summary

- Fixes a false positive where `if (...) { continue; }` inside a `do-while` loop body was incorrectly flagged as `RedundantCondition`
- The root cause: the check used `then_ctx.diverges` **after** body analysis, so a `continue`/`return`/`throw` in the then-branch would make it look like the condition was provably true/false — even when it wasn't
- Fix: capture the `diverges` state right after narrowing (before body analysis) and use that snapshot for the `RedundantCondition` decision

## Test plan

- [x] New fixture `redundant_condition/does_not_report_do_while_control_var.phpt` — the exact pattern from issue #149 no longer emits `RedundantCondition`
- [x] New fixture `unused_variable/do_while_control_var_not_reported.phpt` — `$run` is not flagged as unused
- [x] All existing `redundant_condition` fixtures still pass (legitimate cases still detected)
- [x] Full test suite passes

Closes #149