### PR TITLE
feat(analyzer): emit DeprecatedClass for instantiation and extension of deprecated classes

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -80,7 +80,7 @@ impl<'a> ClassAnalyzer<'a> {
                 }
             }
 
-            // ---- 1. Final-class extension check --------------------------------
+            // ---- 1. Final-class extension check / deprecated parent check ------
             if let Some(parent_fqcn) = &cls.parent {
                 if let Some(parent) = self.codebase.classes.get(parent_fqcn.as_ref()) {
                     if parent.is_final {
@@ -95,6 +95,26 @@ impl<'a> ClassAnalyzer<'a> {
                             IssueKind::FinalClassExtended {
                                 parent: parent_fqcn.to_string(),
                                 child: fqcn.to_string(),
+                            },
+                            loc,
+                        );
+                        if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources)
+                        {
+                            issue = issue.with_snippet(snippet);
+                        }
+                        issues.push(issue);
+                    }
+                    if parent.is_deprecated {
+                        let loc = issue_location(
+                            cls.location.as_ref(),
+                            fqcn,
+                            cls.location
+                                .as_ref()
+                                .and_then(|l| self.sources.get(&l.file).copied()),
+                        );
+                        let mut issue = Issue::new(
+                            IssueKind::DeprecatedClass {
+                                name: parent_fqcn.to_string(),
                             },
                             loc,
                         );

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -572,6 +572,17 @@ impl<'a> ExpressionAnalyzer<'a> {
                                 n.class.span,
                             );
                         } else if self.codebase.type_exists(&fqcn) {
+                            if let Some(cls) = self.codebase.classes.get(fqcn.as_ref()) {
+                                if cls.is_deprecated {
+                                    self.emit(
+                                        IssueKind::DeprecatedClass {
+                                            name: fqcn.to_string(),
+                                        },
+                                        Severity::Info,
+                                        n.class.span,
+                                    );
+                                }
+                            }
                             // Check constructor arguments
                             if let Some(ctor) = self.codebase.get_method(&fqcn, "__construct") {
                                 crate::call::check_constructor_args(

--- a/crates/mir-analyzer/tests/fixtures/deprecated_class/does_not_report_non_deprecated_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_class/does_not_report_non_deprecated_class.phpt
@@ -1,0 +1,9 @@
+===source===
+<?php
+class ActiveClass {}
+
+function test(): void {
+    $obj = new ActiveClass();
+}
+===expect===
+UnusedVariable: Variable $obj is never read

--- a/crates/mir-analyzer/tests/fixtures/deprecated_class/reports_deprecated_class_extension.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_class/reports_deprecated_class_extension.phpt
@@ -1,0 +1,8 @@
+===source===
+<?php
+/** @deprecated use NewBase instead */
+class OldBase {}
+
+class Child extends OldBase {}
+===expect===
+DeprecatedClass: Class OldBase is deprecated

--- a/crates/mir-analyzer/tests/fixtures/deprecated_class/reports_deprecated_class_instantiation.phpt
+++ b/crates/mir-analyzer/tests/fixtures/deprecated_class/reports_deprecated_class_instantiation.phpt
@@ -1,0 +1,11 @@
+===source===
+<?php
+/** @deprecated use NewClass instead */
+class OldClass {}
+
+function test(): void {
+    $obj = new OldClass();
+}
+===expect===
+UnusedVariable: Variable $obj is never read
+DeprecatedClass: Class OldClass is deprecated


### PR DESCRIPTION
## Summary

- Emits `DeprecatedClass` when `new ClassName()` is used and the class is marked `@deprecated`
- Emits `DeprecatedClass` when a class extends a `@deprecated` parent class
- Adds 3 test fixtures covering both cases and the non-deprecated baseline

Closes #124

## Test plan

- [ ] `cargo test deprecated_class` — all 3 new fixtures pass
- [ ] `cargo test` — full suite passes with no regressions