### PR TITLE
fix(analyzer): strip leading backslash from use-imports and detect composer.json from path arg

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -348,7 +348,9 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
 
             StmtKind::Use(use_decl) => {
                 for item in use_decl.uses.iter() {
-                    let full_name = name_to_string(&item.name);
+                    let full_name = name_to_string(&item.name)
+                        .trim_start_matches('\\')
+                        .to_string();
                     let alias = item
                         .alias
                         .unwrap_or_else(|| full_name.rsplit('\\').next().unwrap_or(&full_name));

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -156,7 +156,9 @@ impl ProjectAnalyzer {
                             match &stmt.kind {
                                 StmtKind::Use(use_decl) => {
                                     for item in use_decl.uses.iter() {
-                                        let full_name = crate::parser::name_to_string(&item.name);
+                                        let full_name = crate::parser::name_to_string(&item.name)
+                                            .trim_start_matches('\\')
+                                            .to_string();
                                         let alias = item.alias.unwrap_or_else(|| {
                                             full_name.rsplit('\\').next().unwrap_or(&full_name)
                                         });

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -187,8 +187,29 @@ fn main() {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     // --- Composer auto-detection -------------------------------------------
-    if cli.paths.is_empty() && cwd.join("composer.json").exists() {
-        let (mut analyzer, map) = match ProjectAnalyzer::from_composer(&cwd) {
+    // Trigger when: no paths given and cwd has composer.json, OR a single
+    // directory argument is given that contains a composer.json.
+    let composer_root: Option<PathBuf> = if cli.paths.is_empty() {
+        if cwd.join("composer.json").exists() {
+            Some(cwd.clone())
+        } else {
+            None
+        }
+    } else if cli.paths.len() == 1 {
+        let p = cli.paths[0]
+            .canonicalize()
+            .unwrap_or_else(|_| cli.paths[0].clone());
+        if p.is_dir() && p.join("composer.json").exists() {
+            Some(p)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(ref composer_root) = composer_root {
+        let (mut analyzer, map) = match ProjectAnalyzer::from_composer(composer_root) {
             Ok(pair) => pair,
             Err(e) => {
                 eprintln!("mir: composer error: {}", e);
@@ -222,7 +243,7 @@ fn main() {
             .collect();
 
         // Filter out ignored directories from project files
-        let cwd_abs = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let cwd_abs = composer_root.clone();
         let files: Vec<PathBuf> = map
             .project_files()
             .into_iter()


### PR DESCRIPTION
## Summary

- **`use \ClassName` false-positives fixed** — `use \ArrayAccess;` (globally-qualified use statement) was storing `\ArrayAccess` as the resolved alias instead of `ArrayAccess` in both the definition collector (`collector.rs`) and the project pre-indexer (`project.rs`). The leading `\` is now stripped when building the import map, matching PHP's semantics where `use \Foo` and `use Foo` are equivalent.

- **Composer auto-detection now works with a path argument** — Previously composer auto-detection (vendor scanning, PSR-4 file discovery) only triggered when running `mir` with no arguments from the project root. Now it also triggers when a single directory is passed that contains a `composer.json` (e.g. `mir /path/to/app-server`). This drops `UndefinedClass` from ~1990 to ~72 on the app-server codebase.

## Test plan

- [ ] `use \ArrayAccess;` followed by `implements ArrayAccess` no longer emits `UndefinedClass`
- [ ] `mir /path/to/project` with a `composer.json` in that directory scans vendor and reports `(from composer.json)` in the output
- [ ] `mir` with no args still works as before (cwd composer.json detection unchanged)