### PR TITLE
feat(analyzer): plumb target PHP version into ProjectAnalyzer

### DIFF
--- a/crates/mir-analyzer/src/lib.rs
+++ b/crates/mir-analyzer/src/lib.rs
@@ -8,6 +8,7 @@ pub mod expr;
 pub mod generic;
 pub mod narrowing;
 pub mod parser;
+pub mod php_version;
 pub mod project;
 pub mod stmt;
 pub mod stubs;
@@ -15,6 +16,7 @@ pub mod taint;
 
 pub use parser::type_from_hint::type_from_hint;
 pub use parser::{DocblockParser, ParsedDocblock};
+pub use php_version::{ParsePhpVersionError, PhpVersion};
 pub use project::{AnalysisResult, ProjectAnalyzer};
 pub use stubs::is_builtin_function;
 

--- a/crates/mir-analyzer/src/php_version.rs
+++ b/crates/mir-analyzer/src/php_version.rs
@@ -1,0 +1,99 @@
+//! Target PHP language version.
+//!
+//! Used by the analyzer and stub loader to make version-conditional decisions
+//! (e.g. filtering stub symbols by `@since`/`@removed` markers). The type is
+//! `Copy` and stores only major/minor — patch level is parsed but discarded,
+//! since language features track the minor release.
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PhpVersion {
+    major: u8,
+    minor: u8,
+}
+
+impl PhpVersion {
+    pub const fn new(major: u8, minor: u8) -> Self {
+        Self { major, minor }
+    }
+
+    pub const fn major(self) -> u8 {
+        self.major
+    }
+
+    pub const fn minor(self) -> u8 {
+        self.minor
+    }
+}
+
+impl Default for PhpVersion {
+    fn default() -> Self {
+        Self::new(8, 2)
+    }
+}
+
+impl fmt::Display for PhpVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid PHP version `{0}`: expected `MAJOR.MINOR` (e.g. `8.2`)")]
+pub struct ParsePhpVersionError(pub String);
+
+impl FromStr for PhpVersion {
+    type Err = ParsePhpVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.trim().split('.');
+        let major = parts
+            .next()
+            .and_then(|p| p.parse::<u8>().ok())
+            .ok_or_else(|| ParsePhpVersionError(s.to_string()))?;
+        let minor = parts.next().and_then(|p| p.parse::<u8>().ok()).unwrap_or(0);
+        // Ignore any patch component — language features track the minor release.
+        Ok(Self::new(major, minor))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_major_minor() {
+        assert_eq!("8.2".parse::<PhpVersion>().unwrap(), PhpVersion::new(8, 2));
+    }
+
+    #[test]
+    fn parses_major_minor_patch() {
+        assert_eq!(
+            "8.3.7".parse::<PhpVersion>().unwrap(),
+            PhpVersion::new(8, 3)
+        );
+    }
+
+    #[test]
+    fn parses_major_only() {
+        assert_eq!("7".parse::<PhpVersion>().unwrap(), PhpVersion::new(7, 0));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!("x.y".parse::<PhpVersion>().is_err());
+        assert!("".parse::<PhpVersion>().is_err());
+    }
+
+    #[test]
+    fn ordered_by_major_then_minor() {
+        assert!(PhpVersion::new(8, 1) < PhpVersion::new(8, 2));
+        assert!(PhpVersion::new(7, 4) < PhpVersion::new(8, 0));
+    }
+
+    #[test]
+    fn displays_as_major_dot_minor() {
+        assert_eq!(PhpVersion::new(8, 3).to_string(), "8.3");
+    }
+}

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 use crate::cache::{hash_content, AnalysisCache};
+use crate::php_version::PhpVersion;
 use mir_codebase::Codebase;
 use mir_issues::Issue;
 use mir_types::Union;
@@ -29,6 +30,9 @@ pub struct ProjectAnalyzer {
     stubs_loaded: std::sync::atomic::AtomicBool,
     /// When true, run dead code detection at the end of analysis.
     pub find_dead_code: bool,
+    /// Target PHP language version. Used for version-conditional decisions
+    /// such as stub filtering.
+    pub php_version: PhpVersion,
 }
 
 impl ProjectAnalyzer {
@@ -40,6 +44,7 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: PhpVersion::default(),
         }
     }
 
@@ -52,6 +57,7 @@ impl ProjectAnalyzer {
             psr4: None,
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: PhpVersion::default(),
         }
     }
 
@@ -70,8 +76,15 @@ impl ProjectAnalyzer {
             psr4: Some(psr4),
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
+            php_version: PhpVersion::default(),
         };
         Ok((analyzer, map))
+    }
+
+    /// Set the target PHP version.
+    pub fn with_php_version(mut self, version: PhpVersion) -> Self {
+        self.php_version = version;
+        self
     }
 
     /// Expose codebase for external use (e.g., pre-loading stubs from CLI).

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -9,7 +9,7 @@ use owo_colors::OwoColorize;
 mod config;
 
 use config::{Baseline, Config, ErrorLevel};
-use mir_analyzer::ProjectAnalyzer;
+use mir_analyzer::{PhpVersion, ProjectAnalyzer};
 use mir_issues::{Issue, Severity};
 
 // ---------------------------------------------------------------------------
@@ -407,6 +407,15 @@ fn main() {
     } else {
         ProjectAnalyzer::new()
     };
+
+    // Resolve target PHP version: CLI overrides config; malformed values warn
+    // and fall back to the default rather than aborting analysis.
+    if let Some(raw) = &config.php_version {
+        match raw.parse::<PhpVersion>() {
+            Ok(v) => analyzer = analyzer.with_php_version(v),
+            Err(e) => eprintln!("mir: {}; using default PHP {}", e, analyzer.php_version),
+        }
+    }
 
     analyzer.find_dead_code = cli.find_dead_code;
 


### PR DESCRIPTION
## Summary
- Adds `mir_analyzer::PhpVersion` — a `Copy` `major.minor` type (default `8.2`) with `FromStr`, `Display`, and `Ord`.
- Adds `ProjectAnalyzer.php_version` + builder setter `with_php_version`.
- CLI now resolves the target version (CLI flag → `mir.xml` `<phpVersion>` → default) and applies it to the analyzer. Previously `config.php_version` was parsed but never reached the analyzer.
- Malformed values print a warning and fall back to the default rather than aborting.

No behavior change yet — the value is stored but not consumed. This unblocks two follow-ups that both need one canonical place to read the target version:

1. **Stub filtering** — skip stub symbols whose `@since`/`@removed` markers fall outside the target.
2. **LSP server** — read `phpVersion` from `initializationOptions` and call `with_php_version` on the shared `ProjectAnalyzer`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all green; 6 new unit tests for `PhpVersion` parsing/ordering/display)
- [ ] Manual: `mir --php-version 8.1 src/` — no regressions vs `main`.
- [ ] Manual: `mir --php-version nonsense src/` — prints a warning, continues with default.