### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **PHP-first stub pipeline** — stubs are now authored as PHP source files under `stubs/{ext}/` with `stub.toml` manifests and transformed into Rust via the new `mir-stubs-gen` codegen tool, replacing the monolithic hand-written `stubs.rs`. (#243)
 - **First-party stubs for 30 PHP extensions** — bundled stubs cover common extensions (curl, pdo, json, mbstring, etc.), loaded into the codebase at startup. (#246)
+- **19 additional bundled-with-PHP extensions** — calendar, exif, ftp, gd, gettext, opcache, pgsql, phar, readline, shmop, soap, sqlite3, sysvmsg, sysvsem, sysvshm, tidy, xmlreader, xmlwriter, xsl. (#251)
 - **`UndefinedConstant` issue** — the analyzer now emits `UndefinedConstant` for references to undefined global and class constants. (#242)
 - **Target PHP version plumbed into `ProjectAnalyzer`** — the analyzer accepts a target PHP version to gate version-specific behavior. (#249)
 
 ### Changed
 
 - Upgraded php-rs-parser and php-ast to 0.9; upgraded toml, quick-xml, and criterion to latest. (#245)
+
+### Performance
+
+- **BLAKE3 for cache hashing** — replaced SHA-256 with BLAKE3 for the incremental cache and deduplicated per-file hashing. (#244)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-21
+
+### Added
+
+- **PHP-first stub pipeline** — stubs are now authored as PHP source files under `stubs/{ext}/` with `stub.toml` manifests and transformed into Rust via the new `mir-stubs-gen` codegen tool, replacing the monolithic hand-written `stubs.rs`. (#243)
+- **First-party stubs for 30 PHP extensions** — bundled stubs cover common extensions (curl, pdo, json, mbstring, etc.), loaded into the codebase at startup. (#246)
+- **`UndefinedConstant` issue** — the analyzer now emits `UndefinedConstant` for references to undefined global and class constants. (#242)
+- **Target PHP version plumbed into `ProjectAnalyzer`** — the analyzer accepts a target PHP version to gate version-specific behavior. (#249)
+
+### Changed
+
+- Upgraded php-rs-parser and php-ast to 0.9; upgraded toml, quick-xml, and criterion to latest. (#245)
+
+### Fixed
+
+- **Leading backslash in `use` imports** — fully qualified use-imports (`use \Foo\Bar;`) now resolve correctly by stripping the leading backslash. (#247)
+- **`composer.json` detection from path argument** — when invoked with a path argument, mir now walks up from that path to locate `composer.json` instead of only checking the CWD. (#247)
+
+### CI
+
+- Jobs are now gated (lint → stubs-up-to-date → test) and a dedicated step verifies that regenerated stubs match the committed generated files. (#250)
+
 ## [0.6.0] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "dashmap",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "mir-stubs-gen"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Jorg Sowa <jorg.sowa@gmail.com>"]
@@ -19,10 +19,10 @@ homepage = "https://github.com/jorgsowa/mir"
 
 [workspace.dependencies]
 # Internal crates
-mir-types      = { path = "crates/mir-types",      version = "0.6.0" }
-mir-issues     = { path = "crates/mir-issues",     version = "0.6.0" }
-mir-codebase   = { path = "crates/mir-codebase",   version = "0.6.0" }
-mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.6.0" }
+mir-types      = { path = "crates/mir-types",      version = "0.7.0" }
+mir-issues     = { path = "crates/mir-issues",     version = "0.7.0" }
+mir-codebase   = { path = "crates/mir-codebase",   version = "0.7.0" }
+mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.7.0" }
 
 # PHP parsing
 php-rs-parser = "0.9"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Docs](https://img.shields.io/badge/docs-jorgsowa.github.io%2Fmir-blue)](https://jorgsowa.github.io/mir/)
 
+> ⚠️ **Experimental.** mir is under active development and not yet production-ready. APIs, CLI flags, issue codes, and output formats may change between releases; expect false positives and rough edges.
+
 A fast, incremental PHP static analyzer written in Rust, inspired by [Psalm](https://psalm.dev).
 
 ## Features


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.6.0 to 0.7.0 and update `CHANGELOG.md` with entries for #242, #243, #244, #245, #246, #247, #249, #250, #251.
- Add experimental-state notice to the top of `README.md`.

## Test plan

- [ ] CI passes (fmt, clippy, stubs-up-to-date, tests on ubuntu + macOS)
- [ ] Tag `v0.7.0` after merge