### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1]
+## [0.7.1] - 2026-04-22
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Date the `[0.7.1]` CHANGELOG entry as `2026-04-22` so it matches the format of prior releases.
- Version bump (`0.7.0` → `0.7.1`) and changelog body were already merged as part of #253.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy` (pre-commit hook)
- [ ] CI green on this PR