### PR TITLE
feat(testing): cross-file .phpt fixtures + fix method name casing in errors

### DIFF
--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -174,7 +174,7 @@ impl<'a> ClassAnalyzer<'a> {
                     .own_methods
                     .iter()
                     .filter(|(_, m)| m.is_abstract)
-                    .map(|(name, _)| name.clone())
+                    .map(|(_, m)| m.name.clone())
                     .collect()
             };
 
@@ -235,7 +235,7 @@ impl<'a> ClassAnalyzer<'a> {
             // get_method (which re-enters self.codebase.interfaces when walking ancestors).
             let method_names: Vec<Arc<str>> =
                 match self.codebase.interfaces.get(iface_fqcn.as_ref()) {
-                    Some(iface) => iface.own_methods.keys().cloned().collect(),
+                    Some(iface) => iface.own_methods.values().map(|m| m.name.clone()).collect(),
                     None => continue,
                 };
 

--- a/crates/mir-analyzer/src/test_utils.rs
+++ b/crates/mir-analyzer/src/test_utils.rs
@@ -2,18 +2,68 @@
 //!
 //! Provides helpers to run `.phpt` fixture files against the analyzer
 //! and compare actual vs expected issues.
+//!
+//! # Fixture formats
+//!
+//! **Single-file** (original format, 250 existing fixtures):
+//! ```text
+//! ===source===
+//! <?php
+//! ...
+//! ===expect===
+//! UndefinedMethod: Method Foo::bar() does not exist
+//! ```
+//!
+//! **Multi-file** (cross-file scenarios):
+//! ```text
+//! ===file:Base.php===
+//! <?php
+//! class Base { ... }
+//! ===file:Child.php===
+//! <?php
+//! class Child extends Base { ... }
+//! ===expect===
+//! Child.php: UndefinedMethod: Method Child::bar() does not exist
+//! ```
+//!
+//! In multi-file fixtures every expect line is prefixed with the originating
+//! filename (`Name.php: Kind: message`) for unambiguous attribution.
+//!
+//! **Multi-file with Composer/PSR-4**:
+//! ```text
+//! ===file:composer.json===
+//! {"autoload":{"psr-4":{"App\\":"src/"}}}
+//! ===file:src/Base.php===
+//! <?php
+//! namespace App;
+//! class Base { ... }
+//! ===file:Child.php===
+//! <?php
+//! class Child extends \App\Base { ... }
+//! ===expect===
+//! Child.php: UndefinedMethod: Method Child::bar() does not exist
+//! ```
+//!
+//! When `composer.json` is present, a `Psr4Map` is built from it. Files under
+//! PSR-4-mapped directories (e.g. `src/`) are written to disk but **not**
+//! passed to `analyze()` — they must be discovered lazily, exactly as they
+//! would be in a real project.
 
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::project::ProjectAnalyzer;
 use mir_issues::{Issue, IssueKind};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Run the full analyzer on an inline PHP string.
-/// Creates a unique temp file, analyzes it, deletes it, and returns all
-/// unsuppressed issues.
+// ---------------------------------------------------------------------------
+// Single-file inline analysis
+// ---------------------------------------------------------------------------
+
+/// Run the full analyzer on an inline PHP string and return all unsuppressed issues.
 pub fn check(src: &str) -> Vec<Issue> {
     check_with_opts(src, false)
 }
@@ -47,81 +97,225 @@ fn check_with_opts(src: &str, find_dead_code: bool) -> Vec<Issue> {
 }
 
 // ---------------------------------------------------------------------------
-// Fixture-based test support
+// Multi-file inline analysis
+// ---------------------------------------------------------------------------
+
+/// Analyze a set of named PHP files together, returning all unsuppressed issues.
+///
+/// Each entry is `(filename, php_source)`. Files are written to a unique temp
+/// directory, analyzed together, then cleaned up.
+///
+/// If a `"composer.json"` entry is included, a `Psr4Map` is built from it.
+/// Files under PSR-4-mapped directories are left for lazy discovery and are
+/// **not** passed to `analyze()` explicitly.
+pub fn check_files(files: &[(&str, &str)]) -> Vec<Issue> {
+    check_files_with_opts(files, false)
+}
+
+/// Like [`check_files`] but also enables the dead-code detector.
+pub fn check_files_dead_code(files: &[(&str, &str)]) -> Vec<Issue> {
+    check_files_with_opts(files, true)
+}
+
+fn check_files_with_opts(files: &[(&str, &str)], find_dead_code: bool) -> Vec<Issue> {
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp_dir = std::env::temp_dir().join(format!("mir_multi_{}", id));
+    std::fs::create_dir_all(&tmp_dir)
+        .unwrap_or_else(|e| panic!("failed to create temp dir {}: {}", tmp_dir.display(), e));
+
+    let paths: Vec<PathBuf> = files
+        .iter()
+        .map(|(name, src)| {
+            let path = tmp_dir.join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .unwrap_or_else(|e| panic!("failed to create dir for {}: {}", name, e));
+            }
+            std::fs::write(&path, src)
+                .unwrap_or_else(|e| panic!("failed to write {}: {}", name, e));
+            path
+        })
+        .collect();
+
+    let tmp_dir_str = tmp_dir.to_string_lossy().into_owned();
+
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.find_dead_code = find_dead_code;
+
+    // When composer.json is present, build a Psr4Map and exclude PSR-4-mapped
+    // files from the explicit analysis list so they are discovered lazily.
+    let has_composer = files.iter().any(|(name, _)| *name == "composer.json");
+    let explicit_paths: Vec<PathBuf> = if has_composer {
+        match crate::composer::Psr4Map::from_composer(&tmp_dir) {
+            Ok(psr4) => {
+                let psr4 = Arc::new(psr4);
+                let psr4_files: HashSet<PathBuf> = psr4.project_files().into_iter().collect();
+                let explicit: Vec<PathBuf> = paths
+                    .iter()
+                    .filter(|p| p.extension().map(|e| e == "php").unwrap_or(false))
+                    .filter(|p| !psr4_files.contains(*p))
+                    .cloned()
+                    .collect();
+                analyzer.psr4 = Some(psr4);
+                explicit
+            }
+            Err(_) => php_files_only(&paths),
+        }
+    } else {
+        php_files_only(&paths)
+    };
+
+    let result = analyzer.analyze(&explicit_paths);
+    std::fs::remove_dir_all(&tmp_dir).ok();
+
+    result
+        .issues
+        .into_iter()
+        .filter(|i| !i.suppressed)
+        .filter(|i| !find_dead_code || i.location.file.as_ref().starts_with(tmp_dir_str.as_str()))
+        .collect()
+}
+
+fn php_files_only(paths: &[PathBuf]) -> Vec<PathBuf> {
+    paths
+        .iter()
+        .filter(|p| p.extension().map(|e| e == "php").unwrap_or(false))
+        .cloned()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Fixture data types
 // ---------------------------------------------------------------------------
 
 /// One expected issue from a `.phpt` fixture's `===expect===` section.
 ///
-/// Format: `KindName: full human-readable message`
+/// - In single-file fixtures `file` is `None`; matching ignores origin.
+/// - In multi-file fixtures `file` is `Some("Name.php")`; the issue must
+///   originate from that file (matched by basename).
 pub struct ExpectedIssue {
+    pub file: Option<String>,
     pub kind_name: String,
     pub message: String,
 }
 
-/// Parse a `.phpt` fixture file into `(php_source, expected_issues)`.
-///
-/// Fixture format:
-/// ```text
-/// ===source===
-/// <?php
-/// ...
-/// ===expect===
-/// UndefinedClass: Class 'UnknownClass' not found
-/// UndefinedFunction: Function 'foo' not found
-/// ```
-/// An empty `===expect===` section means no issues are expected.
-pub fn parse_phpt(content: &str, path: &str) -> (String, Vec<ExpectedIssue>) {
-    let source_marker = "===source===";
-    let expect_marker = "===expect===";
+/// Parsed representation of a `.phpt` fixture.
+pub struct ParsedFixture {
+    /// `(filename, content)` pairs — always at least one entry.
+    pub files: Vec<(String, String)>,
+    pub expected: Vec<ExpectedIssue>,
+    pub is_multi: bool,
+}
 
-    let source_pos = content
-        .find(source_marker)
+// ---------------------------------------------------------------------------
+// Fixture parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a `.phpt` fixture file.
+///
+/// Auto-detects single-file (`===source===`) vs multi-file (`===file:===`) format.
+pub fn parse_phpt(content: &str, path: &str) -> ParsedFixture {
+    if content.contains("===file:") {
+        parse_multi_file(content, path)
+    } else {
+        parse_single_file(content, path)
+    }
+}
+
+fn parse_single_file(content: &str, path: &str) -> ParsedFixture {
+    const SOURCE: &str = "===source===";
+    const EXPECT: &str = "===expect===";
+
+    let src_pos = content
+        .find(SOURCE)
         .unwrap_or_else(|| panic!("fixture {} missing ===source=== section", path));
-    let expect_pos = content
-        .find(expect_marker)
+    let exp_pos = content
+        .find(EXPECT)
         .unwrap_or_else(|| panic!("fixture {} missing ===expect=== section", path));
 
     assert!(
-        source_pos < expect_pos,
+        src_pos < exp_pos,
         "fixture {}: ===source=== must come before ===expect===",
         path
     );
 
-    let source = content[source_pos + source_marker.len()..expect_pos]
-        .trim()
-        .to_string();
-    let expect_section = content[expect_pos + expect_marker.len()..].trim();
+    let source = content[src_pos + SOURCE.len()..exp_pos].trim().to_string();
+    let expect_section = content[exp_pos + EXPECT.len()..].trim();
 
-    let expected: Vec<ExpectedIssue> = expect_section
+    let expected = expect_section
         .lines()
         .map(str::trim)
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .map(|l| parse_expected_line(l, path))
+        .map(|l| parse_single_expect_line(l, path))
         .collect();
 
-    (source, expected)
+    ParsedFixture {
+        files: vec![("_test.php".to_string(), source)],
+        expected,
+        is_multi: false,
+    }
 }
 
-/// Extract only the source section from a fixture file (used in UPDATE_FIXTURES mode
-/// to avoid parsing potentially stale/old-format expect sections).
-fn parse_phpt_source_only(content: &str, path: &str) -> String {
-    let source_marker = "===source===";
-    let expect_marker = "===expect===";
+fn parse_multi_file(content: &str, path: &str) -> ParsedFixture {
+    const FILE_PREFIX: &str = "===file:";
+    const MARKER_CLOSE: &str = "===";
+    const EXPECT: &str = "===expect===";
 
-    let source_pos = content
-        .find(source_marker)
-        .unwrap_or_else(|| panic!("fixture {} missing ===source=== section", path));
     let expect_pos = content
-        .find(expect_marker)
+        .find(EXPECT)
         .unwrap_or_else(|| panic!("fixture {} missing ===expect=== section", path));
 
-    content[source_pos + source_marker.len()..expect_pos]
-        .trim()
-        .to_string()
+    let files_region = &content[..expect_pos];
+    let expect_section = content[expect_pos + EXPECT.len()..].trim();
+
+    let mut files: Vec<(String, String)> = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(marker_rel) = files_region[search_from..].find(FILE_PREFIX) {
+        let marker_abs = search_from + marker_rel;
+        let after_prefix = marker_abs + FILE_PREFIX.len();
+
+        // Locate the closing === of the marker: "===file:Base.php==="
+        let close_rel = files_region[after_prefix..]
+            .find(MARKER_CLOSE)
+            .unwrap_or_else(|| panic!("fixture {}: unclosed ===file: marker", path));
+
+        let file_name = files_region[after_prefix..after_prefix + close_rel].to_string();
+        let content_start = after_prefix + close_rel + MARKER_CLOSE.len();
+
+        // Content runs to the next ===file: marker (or end of files_region).
+        let content_end = files_region[content_start..]
+            .find(FILE_PREFIX)
+            .map(|r| content_start + r)
+            .unwrap_or(files_region.len());
+
+        let file_content = files_region[content_start..content_end].trim().to_string();
+        files.push((file_name, file_content));
+
+        search_from = content_end;
+    }
+
+    assert!(
+        !files.is_empty(),
+        "fixture {}: no ===file:Name=== sections found",
+        path
+    );
+
+    let expected = expect_section
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|l| parse_multi_expect_line(l, path))
+        .collect();
+
+    ParsedFixture {
+        files,
+        expected,
+        is_multi: true,
+    }
 }
 
-fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
-    // Format: "KindName: full human-readable message"
+fn parse_single_expect_line(line: &str, fixture_path: &str) -> ExpectedIssue {
     let parts: Vec<&str> = line.splitn(2, ": ").collect();
     assert_eq!(
         parts.len(),
@@ -131,24 +325,44 @@ fn parse_expected_line(line: &str, fixture_path: &str) -> ExpectedIssue {
         line
     );
     ExpectedIssue {
+        file: None,
         kind_name: parts[0].trim().to_string(),
         message: parts[1].trim().to_string(),
     }
 }
 
-/// Run a `.phpt` fixture file: parse, analyze, and assert the issues match
-/// the `===expect===` section exactly (no missing, no unexpected).
+fn parse_multi_expect_line(line: &str, fixture_path: &str) -> ExpectedIssue {
+    // Format: "FileName.php: KindName: message"
+    let parts: Vec<&str> = line.splitn(3, ": ").collect();
+    assert_eq!(
+        parts.len(),
+        3,
+        "fixture {}: invalid multi-file expect line {:?} — expected \"FileName.php: KindName: message\"",
+        fixture_path,
+        line
+    );
+    ExpectedIssue {
+        file: Some(parts[0].trim().to_string()),
+        kind_name: parts[1].trim().to_string(),
+        message: parts[2].trim().to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture runners
+// ---------------------------------------------------------------------------
+
+/// Run a `.phpt` fixture file and assert issues match the `===expect===` section.
 ///
-/// If the environment variable `UPDATE_FIXTURES` is set to `1`, the fixture
-/// file is rewritten with the actual issues instead of asserting.
+/// Supports single-file (`===source===`), multi-file (`===file:===`), and
+/// multi-file with Composer (`===file:composer.json===`).
 ///
-/// Called by the auto-generated test functions in `build.rs`.
+/// Set `UPDATE_FIXTURES=1` to rewrite the expect section with actual output.
 pub fn run_fixture(path: &str) {
     run_fixture_with_opts(path, false);
 }
 
-/// Like [`run_fixture`] but also enables the dead-code detector for issue kinds
-/// such as `UnusedMethod` and `UnusedProperty` that require it.
+/// Like [`run_fixture`] but also enables the dead-code detector.
 pub fn run_fixture_dead_code(path: &str) {
     run_fixture_with_opts(path, true);
 }
@@ -158,35 +372,43 @@ fn run_fixture_with_opts(path: &str, find_dead_code: bool) {
         .unwrap_or_else(|e| panic!("failed to read fixture {}: {}", path, e));
 
     if std::env::var("UPDATE_FIXTURES").as_deref() == Ok("1") {
-        let source = parse_phpt_source_only(&content, path);
-        let actual = check_with_opts(&source, find_dead_code);
-        rewrite_fixture(path, &content, &actual);
+        update_fixture(path, &content, find_dead_code);
         return;
     }
 
-    let (source, expected) = parse_phpt(&content, path);
-    let actual = check_with_opts(&source, find_dead_code);
+    let fixture = parse_phpt(&content, path);
 
+    let actual = if fixture.is_multi {
+        let file_refs: Vec<(&str, &str)> = fixture
+            .files
+            .iter()
+            .map(|(n, s)| (n.as_str(), s.as_str()))
+            .collect();
+        check_files_with_opts(&file_refs, find_dead_code)
+    } else {
+        check_with_opts(&fixture.files[0].1, find_dead_code)
+    };
+
+    assert_fixture(path, &fixture, &actual);
+}
+
+fn assert_fixture(path: &str, fixture: &ParsedFixture, actual: &[Issue]) {
     let mut failures: Vec<String> = Vec::new();
 
-    for exp in &expected {
-        let found = actual
-            .iter()
-            .any(|a| a.kind.name() == exp.kind_name && a.kind.message() == exp.message.as_str());
-        if !found {
-            failures.push(format!("  MISSING  {}: {}", exp.kind_name, exp.message));
+    for exp in &fixture.expected {
+        if !actual.iter().any(|a| issue_matches(a, exp)) {
+            failures.push(format!(
+                "  MISSING  {}",
+                fmt_expected(exp, fixture.is_multi)
+            ));
         }
     }
 
-    for act in &actual {
-        let expected_it = expected
-            .iter()
-            .any(|e| e.kind_name == act.kind.name() && e.message == act.kind.message());
-        if !expected_it {
+    for act in actual {
+        if !fixture.expected.iter().any(|e| issue_matches(act, e)) {
             failures.push(format!(
-                "  UNEXPECTED {}: {}",
-                act.kind.name(),
-                act.kind.message(),
+                "  UNEXPECTED {}",
+                fmt_actual(act, fixture.is_multi)
             ));
         }
     }
@@ -196,40 +418,126 @@ fn run_fixture_with_opts(path: &str, find_dead_code: bool) {
             "fixture {} FAILED:\n{}\n\nAll actual issues:\n{}",
             path,
             failures.join("\n"),
-            fmt_issues(&actual)
+            fmt_issues(actual, fixture.is_multi)
         );
     }
 }
 
-/// Rewrite the fixture file's `===expect===` section with the actual issues.
-/// Preserves the `===source===` section unchanged.
-fn rewrite_fixture(path: &str, content: &str, actual: &[Issue]) {
-    let source_marker = "===source===";
-    let expect_marker = "===expect===";
+fn issue_matches(actual: &Issue, expected: &ExpectedIssue) -> bool {
+    if actual.kind.name() != expected.kind_name {
+        return false;
+    }
+    if actual.kind.message() != expected.message.as_str() {
+        return false;
+    }
+    if let Some(expected_file) = &expected.file {
+        let actual_basename = Path::new(actual.location.file.as_ref())
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default();
+        if actual_basename.as_ref() != expected_file.as_str() {
+            return false;
+        }
+    }
+    true
+}
 
-    let source_pos = content.find(source_marker).expect("missing ===source===");
-    let expect_pos = content.find(expect_marker).expect("missing ===expect===");
+// ---------------------------------------------------------------------------
+// UPDATE_FIXTURES rewrite
+// ---------------------------------------------------------------------------
 
-    let source_section = &content[source_pos..expect_pos];
+fn update_fixture(path: &str, content: &str, find_dead_code: bool) {
+    if content.contains("===file:") {
+        let fixture = parse_multi_file(content, path);
+        let file_refs: Vec<(&str, &str)> = fixture
+            .files
+            .iter()
+            .map(|(n, s)| (n.as_str(), s.as_str()))
+            .collect();
+        let actual = check_files_with_opts(&file_refs, find_dead_code);
+        rewrite_fixture_multi(path, content, &actual);
+    } else {
+        let source = extract_source_section(content, path);
+        let actual = check_with_opts(&source, find_dead_code);
+        rewrite_fixture_single(path, content, &actual);
+    }
+}
 
-    let mut new_content = String::new();
-    new_content.push_str(source_section);
-    new_content.push_str(expect_marker);
-    new_content.push('\n');
+fn extract_source_section(content: &str, path: &str) -> String {
+    const SOURCE: &str = "===source===";
+    const EXPECT: &str = "===expect===";
+    let src_pos = content
+        .find(SOURCE)
+        .unwrap_or_else(|| panic!("fixture {} missing ===source===", path));
+    let exp_pos = content
+        .find(EXPECT)
+        .unwrap_or_else(|| panic!("fixture {} missing ===expect===", path));
+    content[src_pos + SOURCE.len()..exp_pos].trim().to_string()
+}
 
-    // Sort issues by (line, col, kind) for deterministic output.
+fn rewrite_fixture_single(path: &str, content: &str, actual: &[Issue]) {
+    const SOURCE: &str = "===source===";
+    const EXPECT: &str = "===expect===";
+
+    let src_pos = content.find(SOURCE).expect("missing ===source===");
+    let exp_pos = content.find(EXPECT).expect("missing ===expect===");
+
+    let mut out = content[src_pos..exp_pos].to_string();
+    out.push_str(EXPECT);
+    out.push('\n');
+
     let mut sorted: Vec<&Issue> = actual.iter().collect();
     sorted.sort_by_key(|i| (i.location.line, i.location.col_start, i.kind.name()));
 
     for issue in sorted {
-        new_content.push_str(&format!(
+        out.push_str(&format!(
             "{}: {}\n",
             issue.kind.name(),
             issue.kind.message()
         ));
     }
 
-    std::fs::write(path, &new_content)
+    std::fs::write(path, &out)
+        .unwrap_or_else(|e| panic!("failed to write fixture {}: {}", path, e));
+}
+
+fn rewrite_fixture_multi(path: &str, content: &str, actual: &[Issue]) {
+    const EXPECT: &str = "===expect===";
+
+    let exp_pos = content.find(EXPECT).expect("missing ===expect===");
+
+    let mut out = content[..exp_pos].to_string();
+    out.push_str(EXPECT);
+    out.push('\n');
+
+    let mut sorted: Vec<&Issue> = actual.iter().collect();
+    sorted.sort_by_key(|i| {
+        let basename = Path::new(i.location.file.as_ref())
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        (
+            basename,
+            i.location.line,
+            i.location.col_start,
+            i.kind.name(),
+        )
+    });
+
+    for issue in sorted {
+        let basename = Path::new(issue.location.file.as_ref())
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "{}: {}: {}\n",
+            basename,
+            issue.kind.name(),
+            issue.kind.message()
+        ));
+    }
+
+    std::fs::write(path, &out)
         .unwrap_or_else(|e| panic!("failed to write fixture {}: {}", path, e));
 }
 
@@ -238,7 +546,7 @@ fn rewrite_fixture(path: &str, content: &str, actual: &[Issue]) {
 // ---------------------------------------------------------------------------
 
 /// Assert that `issues` contains at least one issue with the exact `IssueKind`
-/// at `line` and `col_start`. Panics with the full issue list on failure.
+/// at `line` and `col_start`.
 pub fn assert_issue(issues: &[Issue], kind: IssueKind, line: u32, col_start: u16) {
     let found = issues
         .iter()
@@ -249,14 +557,13 @@ pub fn assert_issue(issues: &[Issue], kind: IssueKind, line: u32, col_start: u16
             kind,
             line,
             col_start,
-            fmt_issues(issues),
+            fmt_issues(issues, false),
         );
     }
 }
 
 /// Assert that `issues` contains at least one issue whose `kind.name()` equals
-/// `kind_name`, at `line` and `col_start`. Use this when the exact IssueKind
-/// field values are complex (e.g. type-format strings in InvalidArgument).
+/// `kind_name` at `line` and `col_start`.
 pub fn assert_issue_kind(issues: &[Issue], kind_name: &str, line: u32, col_start: u16) {
     let found = issues.iter().any(|i| {
         i.kind.name() == kind_name && i.location.line == line && i.location.col_start == col_start
@@ -267,13 +574,12 @@ pub fn assert_issue_kind(issues: &[Issue], kind_name: &str, line: u32, col_start
             kind_name,
             line,
             col_start,
-            fmt_issues(issues),
+            fmt_issues(issues, false),
         );
     }
 }
 
 /// Assert that `issues` contains no issue whose `kind.name()` equals `kind_name`.
-/// Panics with the matching issues on failure.
 pub fn assert_no_issue(issues: &[Issue], kind_name: &str) {
     let found: Vec<_> = issues
         .iter()
@@ -283,18 +589,42 @@ pub fn assert_no_issue(issues: &[Issue], kind_name: &str) {
         panic!(
             "Expected no {} issues, but found:\n{}",
             kind_name,
-            fmt_issues(&found.into_iter().cloned().collect::<Vec<_>>()),
+            fmt_issues(&found.into_iter().cloned().collect::<Vec<_>>(), false),
         );
     }
 }
 
-fn fmt_issues(issues: &[Issue]) -> String {
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+fn fmt_expected(exp: &ExpectedIssue, is_multi: bool) -> String {
+    if is_multi {
+        if let Some(f) = &exp.file {
+            return format!("{}: {}: {}", f, exp.kind_name, exp.message);
+        }
+    }
+    format!("{}: {}", exp.kind_name, exp.message)
+}
+
+fn fmt_actual(act: &Issue, is_multi: bool) -> String {
+    if is_multi {
+        let basename = Path::new(act.location.file.as_ref())
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        return format!("{}: {}: {}", basename, act.kind.name(), act.kind.message());
+    }
+    format!("{}: {}", act.kind.name(), act.kind.message())
+}
+
+fn fmt_issues(issues: &[Issue], is_multi: bool) -> String {
     if issues.is_empty() {
         return "  (none)".to_string();
     }
     issues
         .iter()
-        .map(|i| format!("  {}: {}", i.kind.name(), i.kind.message()))
+        .map(|i| format!("  {}", fmt_actual(i, is_multi)))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_interface_type_hint.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_interface_type_hint.phpt
@@ -1,0 +1,17 @@
+===file:Printable.php===
+<?php
+interface Printable {
+    public function print(): void;
+}
+===file:Doc.php===
+<?php
+class Doc implements Printable {
+    public function print(): void { echo "doc"; }
+}
+===file:Printer.php===
+<?php
+function render(Printable $p): void { $p->print(); }
+function test(): void {
+    render(new Doc());
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_subclass_accepted.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_subclass_accepted.phpt
@@ -1,0 +1,13 @@
+===file:Base.php===
+<?php
+class Base {}
+===file:Child.php===
+<?php
+class Child extends Base {}
+===file:Consumer.php===
+<?php
+function accept(Base $x): void { var_dump($x); }
+function test(): void {
+    accept(new Child());
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_wrong_class_passed.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/cross_file_wrong_class_passed.phpt
@@ -1,0 +1,14 @@
+===file:User.php===
+<?php
+class User {}
+===file:Admin.php===
+<?php
+class Admin {}
+===file:Service.php===
+<?php
+function createUser(User $u): void { var_dump($u); }
+function test(): void {
+    createUser(new Admin());
+}
+===expect===
+Service.php: InvalidArgument: Argument $u of createUser() expects 'User', got 'Admin'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_compatible_override.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_compatible_override.phpt
@@ -1,0 +1,11 @@
+===file:Base.php===
+<?php
+class Base {
+    public function process(string $x): void { var_dump($x); }
+}
+===file:Child.php===
+<?php
+class Child extends Base {
+    public function process(string $x): void { var_dump($x); }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_grandchild_narrowing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_grandchild_narrowing.phpt
@@ -1,0 +1,15 @@
+===file:GrandParent.php===
+<?php
+class GrandParent {
+    public function f(string $x): void { var_dump($x); }
+}
+===file:Parent.php===
+<?php
+class ParentClass extends GrandParent {}
+===file:GrandChild.php===
+<?php
+class GrandChild extends ParentClass {
+    public function f(int $x): void { var_dump($x); }
+}
+===expect===
+GrandChild.php: MethodSignatureMismatch: Method GrandChild::f() signature mismatch: parameter $x type 'int' is narrower than parent type 'string'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_narrowing_param_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_narrowing_param_type.phpt
@@ -1,0 +1,12 @@
+===file:Animal.php===
+<?php
+class Animal {
+    public function eat(string $food): void { var_dump($food); }
+}
+===file:Dog.php===
+<?php
+class Dog extends Animal {
+    public function eat(int $food): void { var_dump($food); }
+}
+===expect===
+Dog.php: MethodSignatureMismatch: Method Dog::eat() signature mismatch: parameter $food type 'int' is narrower than parent type 'string'

--- a/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_widening_return_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/method_signature_mismatch/cross_file_widening_return_type.phpt
@@ -1,0 +1,12 @@
+===file:Base.php===
+<?php
+class Base {
+    public function fetch(): string { return ""; }
+}
+===file:Child.php===
+<?php
+class Child extends Base {
+    public function fetch(): ?string { return null; }
+}
+===expect===
+Child.php: MethodSignatureMismatch: Method Child::fetch() signature mismatch: return type 'string|null' is not a subtype of parent 'string'

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_chained_return_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_chained_return_type.phpt
@@ -1,0 +1,19 @@
+===file:Entity.php===
+<?php
+class Entity {
+    public function getName(): string { return ""; }
+}
+===file:Repository.php===
+<?php
+class Repository {
+    public function find(): Entity { return new Entity(); }
+}
+===file:Service.php===
+<?php
+function use_repo(Repository $r): void {
+    $e = $r->find();
+    $e->getName();
+    $e->missing();
+}
+===expect===
+Service.php: UndefinedMethod: Method Entity::missing() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_child_calls_removed_parent_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_child_calls_removed_parent_method.phpt
@@ -1,0 +1,12 @@
+===file:Base.php===
+<?php
+class Base {}
+===file:Child.php===
+<?php
+class Child extends Base {}
+function test(): void {
+    $c = new Child();
+    $c->foo();
+}
+===expect===
+Child.php: UndefinedMethod: Method Child::foo() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_psr4_lazy_loaded_parent_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_psr4_lazy_loaded_parent_method.phpt
@@ -1,0 +1,17 @@
+===file:composer.json===
+{"autoload":{"psr-4":{"App\\":"src/"}}}
+===file:src/Base.php===
+<?php
+namespace App;
+class Base {
+    public function hello(): void {}
+}
+===file:Child.php===
+<?php
+class Child extends \App\Base {}
+function test(): void {
+    $c = new Child();
+    $c->missing();
+}
+===expect===
+Child.php: UndefinedMethod: Method Child::missing() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_three_level_inheritance_missing_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_three_level_inheritance_missing_method.phpt
@@ -1,0 +1,17 @@
+===file:GrandParent.php===
+<?php
+class GrandParent {
+    public function greet(): void {}
+}
+===file:Middle.php===
+<?php
+class Middle extends GrandParent {}
+===file:Child.php===
+<?php
+class Child extends Middle {}
+function test(): void {
+    $c = new Child();
+    $c->missing();
+}
+===expect===
+Child.php: UndefinedMethod: Method Child::missing() does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_three_level_inheritance_valid_call.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/cross_file_three_level_inheritance_valid_call.phpt
@@ -1,0 +1,16 @@
+===file:GrandParent.php===
+<?php
+class GrandParent {
+    public function greet(): void {}
+}
+===file:Middle.php===
+<?php
+class Middle extends GrandParent {}
+===file:Child.php===
+<?php
+class Child extends Middle {}
+function test(): void {
+    $c = new Child();
+    $c->greet();
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/basic.phpt
@@ -5,4 +5,4 @@ abstract class Base {
 }
 class Incomplete extends Base {}
 ===expect===
-UnimplementedAbstractMethod: Class Incomplete must implement abstract method dowork()
+UnimplementedAbstractMethod: Class Incomplete must implement abstract method doWork()

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_abstract_child_skipped.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_abstract_child_skipped.phpt
@@ -1,0 +1,16 @@
+===file:Shape.php===
+<?php
+abstract class Shape {
+    abstract public function area(): float;
+}
+===file:Polygon.php===
+<?php
+abstract class Polygon extends Shape {
+    # area() still abstract — abstract child is fine
+}
+===file:Triangle.php===
+<?php
+class Triangle extends Polygon {
+    public function area(): float { return 0.5; }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_concrete_child_of_abstract_chain_missing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_concrete_child_of_abstract_chain_missing.phpt
@@ -1,0 +1,15 @@
+===file:Shape.php===
+<?php
+abstract class Shape {
+    abstract public function area(): float;
+}
+===file:Polygon.php===
+<?php
+abstract class Polygon extends Shape {}
+===file:Triangle.php===
+<?php
+class Triangle extends Polygon {
+    # area() NOT implemented despite being required
+}
+===expect===
+Triangle.php: UnimplementedAbstractMethod: Class Triangle must implement abstract method area()

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_fully_implemented.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_fully_implemented.phpt
@@ -1,0 +1,11 @@
+===file:Shape.php===
+<?php
+abstract class Shape {
+    abstract public function area(): float;
+}
+===file:Circle.php===
+<?php
+class Circle extends Shape {
+    public function area(): float { return 3.14; }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_missing_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_abstract_method/cross_file_missing_method.phpt
@@ -1,0 +1,13 @@
+===file:Shape.php===
+<?php
+abstract class Shape {
+    abstract public function area(): float;
+    abstract public function perimeter(): float;
+}
+===file:Circle.php===
+<?php
+class Circle extends Shape {
+    public function area(): float { return 3.14; }
+}
+===expect===
+Circle.php: UnimplementedAbstractMethod: Class Circle must implement abstract method perimeter()

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_fully_implemented.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_fully_implemented.phpt
@@ -1,0 +1,13 @@
+===file:Logger.php===
+<?php
+interface Logger {
+    public function log(string $msg): void;
+    public function error(string $msg): void;
+}
+===file:ConsoleLogger.php===
+<?php
+class ConsoleLogger implements Logger {
+    public function log(string $msg): void { echo $msg; }
+    public function error(string $msg): void { echo $msg; }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_interface_extends_interface.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_interface_extends_interface.phpt
@@ -1,0 +1,18 @@
+===file:Readable.php===
+<?php
+interface Readable {
+    public function read(): string;
+}
+===file:ReadWritable.php===
+<?php
+interface ReadWritable extends Readable {
+    public function write(string $data): void;
+}
+===file:Stream.php===
+<?php
+class Stream implements ReadWritable {
+    public function write(string $data): void { var_dump($data); }
+    # read() inherited from Readable is NOT implemented
+}
+===expect===
+Stream.php: UnimplementedInterfaceMethod: Class Stream must implement Readable::read() from interface

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_missing_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_missing_method.phpt
@@ -1,0 +1,13 @@
+===file:Runnable.php===
+<?php
+interface Runnable {
+    public function run(): void;
+    public function stop(): void;
+}
+===file:Task.php===
+<?php
+class Task implements Runnable {
+    public function run(): void {}
+}
+===expect===
+Task.php: UnimplementedInterfaceMethod: Class Task must implement Runnable::stop() from interface

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_multiple_interfaces_one_missing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_multiple_interfaces_one_missing.phpt
@@ -1,0 +1,18 @@
+===file:Serializable.php===
+<?php
+interface Serializable {
+    public function serialize(): string;
+}
+===file:Identifiable.php===
+<?php
+interface Identifiable {
+    public function getId(): int;
+}
+===file:Entity.php===
+<?php
+class Entity implements Serializable, Identifiable {
+    public function serialize(): string { return ""; }
+    # getId() is NOT implemented
+}
+===expect===
+Entity.php: UnimplementedInterfaceMethod: Class Entity must implement Identifiable::getId() from interface

--- a/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_trait_satisfies_interface.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unimplemented_interface_method/cross_file_trait_satisfies_interface.phpt
@@ -1,0 +1,16 @@
+===file:Runnable.php===
+<?php
+interface Runnable {
+    public function run(): void;
+}
+===file:RunsTrait.php===
+<?php
+trait RunsTrait {
+    public function run(): void {}
+}
+===file:Worker.php===
+<?php
+class Worker implements Runnable {
+    use RunsTrait;
+}
+===expect===


### PR DESCRIPTION
## Summary

- Adds a multi-file `.phpt` fixture format so cross-file PHP analysis scenarios can be tested without writing Rust integration tests
- Fixes a bug where `UnimplementedAbstractMethod` and `UnimplementedInterfaceMethod` reported method names in lowercase

## Multi-file fixture format

Uses `===file:Name.php===` sections instead of `===source===`. Expect lines are prefixed with the originating filename for unambiguous attribution:

```
===file:Base.php===
<?php
class Base { public function greet(): void {} }
===file:Child.php===
<?php
class Child extends Base {}
function test(): void { (new Child())->missing(); }
===expect===
Child.php: UndefinedMethod: Method Child::missing() does not exist
```

Including a `===file:composer.json===` section enables PSR-4: files under mapped directories are written to disk but withheld from `analyze()` so they must be discovered lazily — identical to real project behaviour.

Existing single-file fixtures (`===source===`) are unchanged. `UPDATE_FIXTURES=1` works for both formats. `check_files()` is also exposed as a public helper for inline multi-file tests.

## Bug fix

`UnimplementedAbstractMethod` and `UnimplementedInterfaceMethod` extracted method names from `own_methods` map **keys** (normalized to lowercase for PHP's case-insensitive dispatch). The map **values** (`MethodStorage.name`) carry the original declared casing. Two one-line fixes in `class.rs` switch both checks to read from the value. `get_method()` already lowercases internally so lookups are unaffected.

Before: `Class Task must implement Runnable::getid() from interface`
After: `Class Task must implement Runnable::getId() from interface`

## New fixtures (21 total)

Covers boundaries across 5 categories:
- `undefined_method`: 3-level inheritance, chained return type resolution, PSR-4 lazy load
- `unimplemented_interface_method`: cross-file interface, interface-extends-interface, multiple interfaces, trait satisfying interface
- `unimplemented_abstract_method`: abstract chain through intermediate abstract class, concrete grandchild missing method
- `method_signature_mismatch`: parameter narrowing, widening return type, grandchild narrowing through uninvolved middle class
- `invalid_argument`: wrong class type, subclass accepted as parent, interface type hint

## Test plan

- [ ] `cargo test -p mir-analyzer` — all 271 fixture tests pass