### PR TITLE
fix(undefined_class): detect missing class in 7 previously-silent code paths

### DIFF
--- a/crates/mir-analyzer/src/call.rs
+++ b/crates/mir-analyzer/src/call.rs
@@ -731,8 +731,17 @@ impl CallAnalyzer {
                 );
                 Union::mixed()
             }
+        } else if !ea.codebase.type_exists(&fqcn)
+            && !matches!(fqcn.as_str(), "self" | "static" | "parent")
+        {
+            ea.emit(
+                IssueKind::UndefinedClass { name: fqcn },
+                Severity::Error,
+                call.class.span,
+            );
+            Union::mixed()
         } else {
-            // Unknown/external class or class with unscanned ancestor — do not emit false positive
+            // Class exists but has unknown ancestor — method may be inherited; suppress
             Union::mixed()
         }
     }

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -742,8 +742,19 @@ impl<'a> ExpressionAnalyzer<'a> {
                 prop_ty
             }
 
-            ExprKind::StaticPropertyAccess(_spa) => {
-                // Class::$prop
+            ExprKind::StaticPropertyAccess(spa) => {
+                if let ExprKind::Identifier(id) = &spa.class.kind {
+                    let resolved = self.codebase.resolve_class_name(&self.file, id.as_ref());
+                    if !matches!(resolved.as_str(), "self" | "static" | "parent")
+                        && !self.codebase.type_exists(&resolved)
+                    {
+                        self.emit(
+                            IssueKind::UndefinedClass { name: resolved },
+                            Severity::Error,
+                            spa.class.span,
+                        );
+                    }
+                }
                 Union::mixed()
             }
 
@@ -778,7 +789,11 @@ impl<'a> ExpressionAnalyzer<'a> {
                 };
 
                 if !self.codebase.type_exists(&fqcn) {
-                    // UndefinedClass is reported elsewhere; avoid double-reporting
+                    self.emit(
+                        IssueKind::UndefinedClass { name: fqcn },
+                        Severity::Error,
+                        cca.class.span,
+                    );
                     return Union::mixed();
                 }
 

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -826,6 +826,16 @@ impl<'a> ExpressionAnalyzer<'a> {
 
             // --- Closures / arrow functions --------------------------------
             ExprKind::Closure(c) => {
+                // Check param and return type hints for undefined classes.
+                for param in c.params.iter() {
+                    if let Some(hint) = &param.type_hint {
+                        self.check_type_hint(hint);
+                    }
+                }
+                if let Some(hint) = &c.return_type {
+                    self.check_type_hint(hint);
+                }
+
                 let params = ast_params_to_fn_params_resolved(
                     &c.params,
                     ctx.self_fqcn.as_deref(),
@@ -906,6 +916,16 @@ impl<'a> ExpressionAnalyzer<'a> {
             }
 
             ExprKind::ArrowFunction(af) => {
+                // Check param and return type hints for undefined classes.
+                for param in af.params.iter() {
+                    if let Some(hint) = &param.type_hint {
+                        self.check_type_hint(hint);
+                    }
+                }
+                if let Some(hint) = &af.return_type {
+                    self.check_type_hint(hint);
+                }
+
                 let params = ast_params_to_fn_params_resolved(
                     &af.params,
                     ctx.self_fqcn.as_deref(),
@@ -1425,6 +1445,48 @@ impl<'a> ExpressionAnalyzer<'a> {
         let col = self.source[line_start_byte..byte_offset].chars().count() as u16;
 
         (line, col)
+    }
+
+    /// Walk a type hint and emit `UndefinedClass` for any named type not in the codebase.
+    fn check_type_hint(&mut self, hint: &php_ast::ast::TypeHint<'_, '_>) {
+        use php_ast::ast::TypeHintKind;
+        match &hint.kind {
+            TypeHintKind::Named(name) => {
+                let name_str = crate::parser::name_to_string(name);
+                if matches!(
+                    name_str.to_lowercase().as_str(),
+                    "self"
+                        | "static"
+                        | "parent"
+                        | "null"
+                        | "true"
+                        | "false"
+                        | "never"
+                        | "void"
+                        | "mixed"
+                        | "object"
+                        | "callable"
+                        | "iterable"
+                ) {
+                    return;
+                }
+                let resolved = self.codebase.resolve_class_name(&self.file, &name_str);
+                if !self.codebase.type_exists(&resolved) {
+                    self.emit(
+                        IssueKind::UndefinedClass { name: resolved },
+                        Severity::Error,
+                        hint.span,
+                    );
+                }
+            }
+            TypeHintKind::Nullable(inner) => self.check_type_hint(inner),
+            TypeHintKind::Union(parts) | TypeHintKind::Intersection(parts) => {
+                for part in parts.iter() {
+                    self.check_type_hint(part);
+                }
+            }
+            TypeHintKind::Keyword(_, _) => {}
+        }
     }
 
     pub fn emit(&mut self, kind: IssueKind, severity: Severity, span: php_ast::Span) {

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -843,6 +843,19 @@ impl ProjectAnalyzer {
         }
 
         for member in decl.members.iter() {
+            if let php_ast::ast::ClassMemberKind::Property(prop) = &member.kind {
+                if let Some(hint) = &prop.type_hint {
+                    check_type_hint_classes(
+                        hint,
+                        &self.codebase,
+                        file,
+                        source,
+                        source_map,
+                        all_issues,
+                    );
+                }
+                continue;
+            }
             let php_ast::ast::ClassMemberKind::Method(method) = &member.kind else {
                 continue;
             };
@@ -1195,6 +1208,19 @@ impl ProjectAnalyzer {
         }
 
         for member in decl.members.iter() {
+            if let php_ast::ast::ClassMemberKind::Property(prop) = &member.kind {
+                if let Some(hint) = &prop.type_hint {
+                    check_type_hint_classes(
+                        hint,
+                        &self.codebase,
+                        file,
+                        source,
+                        source_map,
+                        all_issues,
+                    );
+                }
+                continue;
+            }
             let php_ast::ast::ClassMemberKind::Method(method) = &member.kind else {
                 continue;
             };

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use php_ast::ast::StmtKind;
 
 use mir_codebase::Codebase;
-use mir_issues::{IssueBuffer, IssueKind};
+use mir_issues::{Issue, IssueBuffer, IssueKind, Location};
 use mir_types::{ArrayKey, Atomic, Union};
 
 use crate::context::Context;
@@ -802,6 +802,10 @@ impl<'a> StatementsAnalyzer<'a> {
                 let mut non_diverging_catches: Vec<Context> = vec![];
                 for catch in tc.catches.iter() {
                     let mut catch_ctx = catch_base.clone();
+                    // Check that all caught exception types exist.
+                    for catch_ty in catch.types.iter() {
+                        self.check_name_undefined_class(catch_ty);
+                    }
                     if let Some(var) = catch.var {
                         // Bind the caught exception variable; union all caught types
                         let exc_ty = if catch.types.is_empty() {
@@ -1073,6 +1077,30 @@ impl<'a> StatementsAnalyzer<'a> {
         let col = self.source[line_start_byte..byte_offset].chars().count() as u16;
 
         (line, col)
+    }
+
+    /// Emit `UndefinedClass` for a `Name` AST node if the resolved class does not exist.
+    fn check_name_undefined_class(&mut self, name: &php_ast::ast::Name<'_, '_>) {
+        let raw = crate::parser::name_to_string(name);
+        let resolved = self.codebase.resolve_class_name(&self.file, &raw);
+        if matches!(resolved.as_str(), "self" | "static" | "parent") {
+            return;
+        }
+        if self.codebase.type_exists(&resolved) {
+            return;
+        }
+        let span = name.span();
+        let (line, col_start) = self.offset_to_line_col(span.start);
+        let (_, col_end) = self.offset_to_line_col(span.end);
+        self.issues.add(Issue::new(
+            IssueKind::UndefinedClass { name: resolved },
+            Location {
+                file: self.file.clone(),
+                line,
+                col_start,
+                col_end: col_end.max(col_start + 1),
+            },
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/arrow_fn_param_type_hint_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/arrow_fn_param_type_hint_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+$fn = fn(Foo $x) => $x;
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/catch_type_cross_file_missing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/catch_type_cross_file_missing.phpt
@@ -1,0 +1,19 @@
+===file:Exceptions.php===
+<?php
+namespace App;
+class RealException extends \Exception {}
+===file:Handler.php===
+<?php
+use App\RealException;
+use App\MissingException;
+function handle(): void {
+    try {
+        throw new \Exception();
+    } catch (RealException $e) {
+    } catch (MissingException $e) {
+    }
+}
+===expect===
+Handler.php: UndefinedClass: Class App\MissingException does not exist
+Handler.php: UnusedVariable: Variable $e is never read
+Handler.php: UnusedVariable: Variable $e is never read

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/catch_type_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/catch_type_via_use.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+use Vendor\Missing\MyException;
+function f(): void {
+    try {
+        throw new \Exception();
+    } catch (MyException $e) {
+    }
+}
+===expect===
+UndefinedClass: Class Vendor\Missing\MyException does not exist
+UnusedVariable: Variable $e is never read

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/closure_param_type_hint_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/closure_param_type_hint_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+$fn = function(Foo $x): void {};
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/closure_return_type_hint_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/closure_return_type_hint_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+$fn = function(): Foo {};
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_cross_file_exists.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_cross_file_exists.phpt
@@ -1,0 +1,11 @@
+===file:Dep.php===
+<?php
+namespace Vendor\Lib;
+class Dep {}
+===file:Main.php===
+<?php
+use Vendor\Lib\Dep;
+class Bar {
+    public Dep $prop;
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_cross_file_missing.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_cross_file_missing.phpt
@@ -1,0 +1,12 @@
+===file:Dep.php===
+<?php
+namespace Vendor\Lib;
+class Dep {}
+===file:Main.php===
+<?php
+use Vendor\Lib\Missing;
+class Bar {
+    public Missing $prop;
+}
+===expect===
+Main.php: UndefinedClass: Class Vendor\Lib\Missing does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/property_type_hint_via_use.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+class Bar {
+    public Foo $prop;
+}
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/static_const_access_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/static_const_access_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+echo Foo::BAR;
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/static_method_call_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/static_method_call_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+Foo::bar();
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist

--- a/crates/mir-analyzer/tests/fixtures/undefined_class/static_property_access_via_use.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_class/static_property_access_via_use.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+use Vendor\Missing\Foo;
+echo Foo::$bar;
+===expect===
+UndefinedClass: Class Vendor\Missing\Foo does not exist


### PR DESCRIPTION
## Summary

- Property type hints (`public Missing $prop`) were never checked against the codebase
- Catch block types (`catch (Missing $e)`) were resolved for binding but not validated
- Closure/arrow-function param and return type hints were inferred but not existence-checked
- `Foo::BAR`, `Foo::bar()`, and `Foo::$prop` silently returned `mixed` instead of emitting `UndefinedClass`

Adds 11 `.phpt` fixtures covering each path (single-file, cross-file missing, and cross-file positive regression guards).

Closes #3