### PR TITLE
fix(method): eliminate 10 false-positive UndefinedMethod reports

### DIFF
--- a/crates/mir-analyzer/src/call/args.rs
+++ b/crates/mir-analyzer/src/call/args.rs
@@ -96,7 +96,13 @@ pub(crate) fn check_method_visibility(
     match method.visibility {
         Visibility::Private => {
             let caller_fqcn = ctx.self_fqcn.as_deref().unwrap_or("");
-            if caller_fqcn != method.fqcn.as_ref() {
+            let from_trait = ea.codebase.traits.contains_key(method.fqcn.as_ref());
+            let allowed = caller_fqcn == method.fqcn.as_ref()
+                || (from_trait
+                    && ea
+                        .codebase
+                        .extends_or_implements(caller_fqcn, method.fqcn.as_ref()));
+            if !allowed {
                 ea.emit(
                     IssueKind::UndefinedMethod {
                         class: method.fqcn.to_string(),

--- a/crates/mir-analyzer/src/call/method.rs
+++ b/crates/mir-analyzer/src/call/method.rs
@@ -28,7 +28,7 @@ impl CallAnalyzer {
         let obj_ty = ea.analyze(call.object, ctx);
 
         let method_name = match &call.method.kind {
-            ExprKind::Identifier(name) | ExprKind::Variable(name) => name.as_str(),
+            ExprKind::Identifier(name) => name.as_str(),
             _ => return Union::mixed(),
         };
 

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_dynamic_method_via_variable.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_dynamic_method_via_variable.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+class Foo {
+    public function hello(): void {}
+}
+/** @param array<string> $names */
+function test(Foo $foo, array $names): void {
+    foreach ($names as $name) {
+        $foo->{$name}();
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_private_trait_method_from_using_class.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/does_not_report_private_trait_method_from_using_class.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+trait MyTrait {
+    private function privateMethod(): void {}
+}
+class MyClass {
+    use MyTrait;
+    public function run(): void {
+        $this->privateMethod();
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/undefined_method/reports_private_class_method_called_from_subclass.phpt
+++ b/crates/mir-analyzer/tests/fixtures/undefined_method/reports_private_class_method_called_from_subclass.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+class Base {
+    private function secret(): void {}
+}
+class Child extends Base {
+    public function run(): void {
+        $this->secret();
+    }
+}
+===expect===
+UndefinedMethod: Method Base::secret() does not exist


### PR DESCRIPTION
## Summary

- **Dynamic method calls** (`$obj->{$var}()`) were spuriously triggering `UndefinedMethod` because `ExprKind::Variable` was matched alongside `ExprKind::Identifier` and the variable's name was used as a static method name to look up. Removed the `Variable` arm so dynamic calls return `mixed` without a lookup.
- **Private trait methods** called from a class that uses the trait were incorrectly flagged as inaccessible. The private-visibility check used exact FQCN equality (caller class vs. method's defining trait), which always fails across the class/trait boundary. Fixed by mirroring the protected-visibility logic: allow access when `extends_or_implements` confirms the caller uses the defining trait (trait FQCNs are already in `all_parents`).

Tested against `symfony/console`: `UndefinedMethod` reports drop from **23 → 13**.

Closes #5