### PR TITLE
fix(issues): promote PossiblyUndefinedVariable to Warning severity

### DIFF
--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -106,7 +106,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                             IssueKind::PossiblyUndefinedVariable {
                                 name: name_str.to_string(),
                             },
-                            Severity::Info,
+                            Severity::Warning,
                             expr.span,
                         );
                     } else if name_str == "this" {

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/foreach_body_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/foreach_body_error.phpt
@@ -1,0 +1,10 @@
+===file===
+<?php
+function foo(array $items): string {
+    foreach ($items as $item) {
+        $last = $item;
+    }
+    return $last;
+}
+===expect===
+PossiblyUndefinedVariable: Variable $last might not be defined

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/nested_if_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/nested_if_error.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+function foo(bool $a, bool $b): int {
+    if ($a) {
+        if ($b) {
+            $x = 1;
+        }
+    }
+    return $x;
+}
+===expect===
+PossiblyUndefinedVariable: Variable $x might not be defined

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/try_catch_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/try_catch_error.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+function foo(): string {
+    try {
+        $result = strtolower("hi");
+    } catch (\Exception $e) {
+        // does not assign $result
+    }
+    return $result;
+}
+===expect===
+PossiblyUndefinedVariable: Variable $result might not be defined

--- a/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/while_body_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/possibly_undefined_variable/while_body_error.phpt
@@ -1,0 +1,11 @@
+===file===
+<?php
+function foo(bool $c): int {
+    while ($c) {
+        $x = 1;
+        $c = false;
+    }
+    return $x;
+}
+===expect===
+PossiblyUndefinedVariable: Variable $x might not be defined

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -361,9 +361,11 @@ impl IssueKind {
             | IssueKind::MissingThrowsDocblock { .. }
             | IssueKind::UnusedVariable { .. } => Severity::Warning,
 
-            // Possibly-null / possibly-undefined (only shown in strict mode, level ≥ 7)
-            IssueKind::PossiblyUndefinedVariable { .. }
-            | IssueKind::PossiblyNullArgument { .. }
+            // PossiblyUndefined: shown at default error level (same as Warning)
+            IssueKind::PossiblyUndefinedVariable { .. } => Severity::Warning,
+
+            // Possibly-null (only shown in strict mode, level ≥ 7)
+            IssueKind::PossiblyNullArgument { .. }
             | IssueKind::PossiblyNullPropertyFetch { .. }
             | IssueKind::PossiblyNullMethodCall { .. }
             | IssueKind::PossiblyNullArrayAccess => Severity::Info,


### PR DESCRIPTION
## Summary

- `PossiblyUndefinedVariable` was `Severity::Info`, hidden by default (requires `error_level >= 7` or `--show-info`); promoting it to `Severity::Warning` makes it visible at the default error level
- Adds fixture tests for foreach loop, while loop, try/catch, and nested-if patterns to document that detection already worked correctly for those cases

Closes #4