### PR TITLE
feat(analyzer): detect unreachable code after return/throw/exit/die

### DIFF
--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1123,6 +1123,7 @@ impl<'a> ExpressionAnalyzer<'a> {
                 if let Some(e) = opt {
                     self.analyze(e, ctx);
                 }
+                ctx.diverges = true;
                 Union::single(Atomic::TNever)
             }
 

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -66,6 +66,34 @@ impl<'a> StatementsAnalyzer<'a> {
             let suppressions = self.extract_statement_suppressions(stmt.span);
             let before = self.issues.issue_count();
 
+            if ctx.diverges {
+                let (line, col_start) = self.offset_to_line_col(stmt.span.start);
+                let col_end = if stmt.span.start < stmt.span.end {
+                    let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                    end_col
+                } else {
+                    col_start + 1
+                };
+                self.issues.add(
+                    Issue::new(
+                        IssueKind::UnreachableCode,
+                        Location {
+                            file: self.file.clone(),
+                            line,
+                            col_start,
+                            col_end: col_end.max(col_start + 1),
+                        },
+                    )
+                    .with_snippet(
+                        crate::parser::span_text(self.source, stmt.span).unwrap_or_default(),
+                    ),
+                );
+                if !suppressions.is_empty() {
+                    self.issues.suppress_range(before, &suppressions);
+                }
+                break;
+            }
+
             // Extract @var annotation for this statement.
             let var_annotation = self.extract_var_annotation(stmt.span);
 

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/after_die.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/after_die.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+function foo(): void {
+    die('fatal');
+    $x = 2;
+}
+===expect===
+UnreachableCode: Unreachable code detected

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/after_exit.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/after_exit.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+function foo(): void {
+    exit(1);
+    $x = 2;
+}
+===expect===
+UnreachableCode: Unreachable code detected

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/after_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/after_return.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+function foo(): int {
+    return 1;
+    $x = 2;
+}
+===expect===
+UnreachableCode: Unreachable code detected

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/after_throw.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/after_throw.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+function foo(): void {
+    throw new RuntimeException('error');
+    $x = 2;
+}
+===expect===
+UnreachableCode: Unreachable code detected

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/does_not_cross_closure_boundary.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/does_not_cross_closure_boundary.phpt
@@ -1,0 +1,10 @@
+===file===
+<?php
+function foo(): void {
+    return;
+    $cb = function (): void {
+        $x = 1;
+    };
+}
+===expect===
+UnreachableCode: Unreachable code detected

--- a/crates/mir-analyzer/tests/fixtures/unreachable_code/does_not_flag_reachable_code.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unreachable_code/does_not_flag_reachable_code.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+function foo(): int {
+    $x = 2;
+    return $x;
+}
+===expect===
+


### PR DESCRIPTION
## Summary

- Emit `UnreachableCode` for the first statement following a terminator (`return`, `throw`, `exit`, `die`) in the same block
- `exit`/`die` now set `ctx.diverges = true` in the expression analyzer, consistent with how `return` and `throw` already behave
- Scope boundaries are respected: nested closures use a fresh context and are not affected by divergence in the outer block

Closes #10