### PR TITLE
perf(analyzer): reduce allocations, parallelize class analysis, add short-name indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -623,6 +624,7 @@ dependencies = [
  "blake3",
  "bumpalo",
  "criterion",
+ "dashmap",
  "indexmap",
  "mir-codebase",
  "mir-issues",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ smallvec = { version = "1", features = ["union", "serde"] }
 
 # Concurrency
 rayon   = "1"
-dashmap = "6"
+dashmap = { version = "6", features = ["serde"] }
 
 # Serialization
 serde      = { version = "1", features = ["derive"] }

--- a/crates/mir-analyzer/Cargo.toml
+++ b/crates/mir-analyzer/Cargo.toml
@@ -19,6 +19,7 @@ indexmap      = { workspace = true }
 rayon         = { workspace = true }
 thiserror     = { workspace = true }
 blake3        = { workspace = true }
+dashmap       = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 quick-xml     = "0.39"

--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -5,8 +5,10 @@
 /// and Pass 2 analysis is skipped for that file.
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 
 use mir_issues::Issue;
@@ -55,12 +57,15 @@ struct CacheFile {
 }
 
 /// Thread-safe, disk-backed cache for per-file analysis results.
+///
+/// `entries` uses a `DashMap` so concurrent Pass-2 `put` calls from rayon
+/// threads avoid serializing on a single global mutex.
 pub struct AnalysisCache {
     cache_dir: PathBuf,
-    entries: Mutex<HashMap<String, CacheEntry>>,
+    entries: DashMap<String, CacheEntry>,
     /// Reverse dependency graph loaded from disk (from the previous run).
     reverse_deps: Mutex<HashMap<String, HashSet<String>>>,
-    dirty: Mutex<bool>,
+    dirty: AtomicBool,
 }
 
 impl AnalysisCache {
@@ -72,9 +77,9 @@ impl AnalysisCache {
         let file = Self::load(cache_dir);
         Self {
             cache_dir: cache_dir.to_path_buf(),
-            entries: Mutex::new(file.entries),
+            entries: DashMap::from_iter(file.entries),
             reverse_deps: Mutex::new(file.reverse_deps),
-            dirty: Mutex::new(false),
+            dirty: AtomicBool::new(false),
         }
     }
 
@@ -89,8 +94,7 @@ impl AnalysisCache {
     /// `(symbol_key, start_byte, end_byte)` entries to replay into
     /// `Codebase::symbol_reference_locations`.
     pub fn get(&self, file_path: &str, content_hash: &str) -> Option<CacheHit> {
-        let entries = self.entries.lock().unwrap();
-        entries.get(file_path).and_then(|e| {
+        self.entries.get(file_path).and_then(|e| {
             if e.content_hash == content_hash {
                 Some((e.issues.clone(), e.reference_locations.clone()))
             } else {
@@ -109,8 +113,7 @@ impl AnalysisCache {
         issues: Vec<Issue>,
         reference_locations: Vec<(String, u32, u32)>,
     ) {
-        let mut entries = self.entries.lock().unwrap();
-        entries.insert(
+        self.entries.insert(
             file_path.to_string(),
             CacheEntry {
                 content_hash,
@@ -118,24 +121,22 @@ impl AnalysisCache {
                 reference_locations,
             },
         );
-        *self.dirty.lock().unwrap() = true;
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     /// Persist the in-memory cache to `{cache_dir}/cache.json`.
     /// This is a no-op if nothing changed since the last flush.
     pub fn flush(&self) {
-        let dirty = {
-            let mut d = self.dirty.lock().unwrap();
-            let was = *d;
-            *d = false;
-            was
-        };
-        if !dirty {
+        if !self.dirty.swap(false, Ordering::AcqRel) {
             return;
         }
         let cache_file = self.cache_dir.join("cache.json");
         let file = CacheFile {
-            entries: self.entries.lock().unwrap().clone(),
+            entries: self
+                .entries
+                .iter()
+                .map(|e| (e.key().clone(), e.value().clone()))
+                .collect(),
             reverse_deps: self.reverse_deps.lock().unwrap().clone(),
         };
         if let Ok(json) = serde_json::to_string(&file) {
@@ -146,7 +147,7 @@ impl AnalysisCache {
     /// Replace the reverse dependency graph (called after each Pass 1).
     pub fn set_reverse_deps(&self, deps: HashMap<String, HashSet<String>>) {
         *self.reverse_deps.lock().unwrap() = deps;
-        *self.dirty.lock().unwrap() = true;
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     /// BFS from each changed file through the reverse dep graph.
@@ -174,7 +175,7 @@ impl AnalysisCache {
             result
         };
 
-        // Phase 2: evict (reverse_deps lock released above, entries lock taken per file).
+        // Phase 2: evict (reverse_deps lock released above).
         let count = to_evict.len();
         for file in &to_evict {
             self.evict(file);
@@ -184,9 +185,8 @@ impl AnalysisCache {
 
     /// Remove a single file's cache entry.
     pub fn evict(&self, file_path: &str) {
-        let mut entries = self.entries.lock().unwrap();
-        entries.remove(file_path);
-        *self.dirty.lock().unwrap() = true;
+        self.entries.remove(file_path);
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-analyzer/src/call/args.rs
+++ b/crates/mir-analyzer/src/call/args.rs
@@ -430,18 +430,16 @@ fn named_object_subtype(arg: &Union, param: &Union, ea: &ExpressionAnalyzer<'_>)
             }
 
             if !arg_fqcn.contains('\\') && !ea.codebase.type_exists(&resolved_arg) {
-                for entry in ea.codebase.classes.iter() {
-                    if entry.value().short_name.as_ref() == arg_fqcn.as_ref() {
-                        let actual_fqcn = entry.key().clone();
-                        if ea
+                if let Some(actual_fqcn) = ea.codebase.class_by_short_name.get(arg_fqcn.as_ref()) {
+                    let actual_fqcn = actual_fqcn.clone();
+                    if ea
+                        .codebase
+                        .extends_or_implements(actual_fqcn.as_ref(), &resolved_param)
+                        || ea
                             .codebase
-                            .extends_or_implements(actual_fqcn.as_ref(), &resolved_param)
-                            || ea
-                                .codebase
-                                .extends_or_implements(actual_fqcn.as_ref(), param_fqcn.as_ref())
-                        {
-                            return true;
-                        }
+                            .extends_or_implements(actual_fqcn.as_ref(), param_fqcn.as_ref())
+                    {
+                        return true;
                     }
                 }
             }

--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -10,6 +10,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use rayon::prelude::*;
+
 use mir_codebase::storage::{MethodStorage, Visibility};
 use mir_codebase::Codebase;
 use mir_issues::{Issue, IssueKind, Location};
@@ -38,11 +40,11 @@ impl<'a> ClassAnalyzer<'a> {
     pub fn with_files(
         codebase: &'a Codebase,
         files: HashSet<Arc<str>>,
-        file_data: &'a [(Arc<str>, String)],
+        file_data: &'a [(Arc<str>, String, String)],
     ) -> Self {
         let sources: HashMap<Arc<str>, &'a str> = file_data
             .iter()
-            .map(|(f, s)| (f.clone(), s.as_str()))
+            .map(|(f, s, _)| (f.clone(), s.as_str()))
             .collect();
         Self {
             codebase,
@@ -53,8 +55,6 @@ impl<'a> ClassAnalyzer<'a> {
 
     /// Run all class-level checks and return every discovered issue.
     pub fn analyze_all(&self) -> Vec<Issue> {
-        let mut issues = Vec::new();
-
         let class_keys: Vec<Arc<str>> = self
             .codebase
             .classes
@@ -62,90 +62,100 @@ impl<'a> ClassAnalyzer<'a> {
             .map(|e| e.key().clone())
             .collect();
 
-        for fqcn in &class_keys {
-            let cls = match self.codebase.classes.get(fqcn.as_ref()) {
-                Some(c) => c,
-                None => continue,
-            };
+        // Per-class checks are independent — run them in parallel.
+        let mut issues: Vec<Issue> = class_keys
+            .par_iter()
+            .flat_map(|fqcn| {
+                let mut class_issues = Vec::new();
 
-            // Skip classes from vendor / stub files — only check user-analyzed files
-            if !self.analyzed_files.is_empty() {
-                let in_analyzed = cls
-                    .location
-                    .as_ref()
-                    .map(|loc| self.analyzed_files.contains(&loc.file))
-                    .unwrap_or(false);
-                if !in_analyzed {
-                    continue;
-                }
-            }
+                let cls = match self.codebase.classes.get(fqcn.as_ref()) {
+                    Some(c) => c,
+                    None => return class_issues,
+                };
 
-            // ---- 1. Final-class extension check / deprecated parent check ------
-            if let Some(parent_fqcn) = &cls.parent {
-                if let Some(parent) = self.codebase.classes.get(parent_fqcn.as_ref()) {
-                    if parent.is_final {
-                        let loc = issue_location(
-                            cls.location.as_ref(),
-                            fqcn,
-                            cls.location
-                                .as_ref()
-                                .and_then(|l| self.sources.get(&l.file).copied()),
-                        );
-                        let mut issue = Issue::new(
-                            IssueKind::FinalClassExtended {
-                                parent: parent_fqcn.to_string(),
-                                child: fqcn.to_string(),
-                            },
-                            loc,
-                        );
-                        if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources)
-                        {
-                            issue = issue.with_snippet(snippet);
-                        }
-                        issues.push(issue);
-                    }
-                    if let Some(msg) = parent.deprecated.clone() {
-                        let loc = issue_location(
-                            cls.location.as_ref(),
-                            fqcn,
-                            cls.location
-                                .as_ref()
-                                .and_then(|l| self.sources.get(&l.file).copied()),
-                        );
-                        let mut issue = Issue::new(
-                            IssueKind::DeprecatedClass {
-                                name: parent_fqcn.to_string(),
-                                message: Some(msg).filter(|m| !m.is_empty()),
-                            },
-                            loc,
-                        );
-                        if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources)
-                        {
-                            issue = issue.with_snippet(snippet);
-                        }
-                        issues.push(issue);
+                // Skip classes from vendor / stub files — only check user-analyzed files
+                if !self.analyzed_files.is_empty() {
+                    let in_analyzed = cls
+                        .location
+                        .as_ref()
+                        .map(|loc| self.analyzed_files.contains(&loc.file))
+                        .unwrap_or(false);
+                    if !in_analyzed {
+                        return class_issues;
                     }
                 }
-            }
 
-            // Skip abstract classes for "must implement" checks
-            if cls.is_abstract {
-                // Still check override compatibility for abstract classes
-                self.check_overrides(&cls, &mut issues);
-                continue;
-            }
+                // ---- 1. Final-class extension check / deprecated parent check ------
+                if let Some(parent_fqcn) = &cls.parent {
+                    if let Some(parent) = self.codebase.classes.get(parent_fqcn.as_ref()) {
+                        if parent.is_final {
+                            let loc = issue_location(
+                                cls.location.as_ref(),
+                                fqcn,
+                                cls.location
+                                    .as_ref()
+                                    .and_then(|l| self.sources.get(&l.file).copied()),
+                            );
+                            let mut issue = Issue::new(
+                                IssueKind::FinalClassExtended {
+                                    parent: parent_fqcn.to_string(),
+                                    child: fqcn.to_string(),
+                                },
+                                loc,
+                            );
+                            if let Some(snippet) =
+                                extract_snippet(cls.location.as_ref(), &self.sources)
+                            {
+                                issue = issue.with_snippet(snippet);
+                            }
+                            class_issues.push(issue);
+                        }
+                        if let Some(msg) = parent.deprecated.clone() {
+                            let loc = issue_location(
+                                cls.location.as_ref(),
+                                fqcn,
+                                cls.location
+                                    .as_ref()
+                                    .and_then(|l| self.sources.get(&l.file).copied()),
+                            );
+                            let mut issue = Issue::new(
+                                IssueKind::DeprecatedClass {
+                                    name: parent_fqcn.to_string(),
+                                    message: Some(msg).filter(|m| !m.is_empty()),
+                                },
+                                loc,
+                            );
+                            if let Some(snippet) =
+                                extract_snippet(cls.location.as_ref(), &self.sources)
+                            {
+                                issue = issue.with_snippet(snippet);
+                            }
+                            class_issues.push(issue);
+                        }
+                    }
+                }
 
-            // ---- 2. Abstract parent methods must be implemented ----------------
-            self.check_abstract_methods_implemented(&cls, &mut issues);
+                // Skip abstract classes for "must implement" checks
+                if cls.is_abstract {
+                    // Still check override compatibility for abstract classes
+                    self.check_overrides(&cls, &mut class_issues);
+                    return class_issues;
+                }
 
-            // ---- 3. Interface methods must be implemented ----------------------
-            self.check_interface_methods_implemented(&cls, &mut issues);
+                // ---- 2. Abstract parent methods must be implemented ----------------
+                self.check_abstract_methods_implemented(&cls, &mut class_issues);
 
-            // ---- 4. Method override compatibility ------------------------------
-            self.check_overrides(&cls, &mut issues);
-        }
+                // ---- 3. Interface methods must be implemented ----------------------
+                self.check_interface_methods_implemented(&cls, &mut class_issues);
 
-        // ---- 5. Circular inheritance detection --------------------------------
+                // ---- 4. Method override compatibility ------------------------------
+                self.check_overrides(&cls, &mut class_issues);
+
+                class_issues
+            })
+            .collect();
+
+        // ---- 5. Circular inheritance detection (must remain serial — uses shared memoization) ---
         self.check_circular_class_inheritance(&mut issues);
         self.check_circular_interface_inheritance(&mut issues);
 

--- a/crates/mir-analyzer/src/diagnostics.rs
+++ b/crates/mir-analyzer/src/diagnostics.rs
@@ -114,21 +114,18 @@ pub(crate) fn check_name_class(
 }
 
 fn is_pseudo_type(name: &str) -> bool {
-    matches!(
-        name.to_lowercase().as_str(),
-        "self"
-            | "static"
-            | "parent"
-            | "null"
-            | "true"
-            | "false"
-            | "never"
-            | "void"
-            | "mixed"
-            | "object"
-            | "callable"
-            | "iterable"
-    )
+    name.eq_ignore_ascii_case("self")
+        || name.eq_ignore_ascii_case("static")
+        || name.eq_ignore_ascii_case("parent")
+        || name.eq_ignore_ascii_case("null")
+        || name.eq_ignore_ascii_case("true")
+        || name.eq_ignore_ascii_case("false")
+        || name.eq_ignore_ascii_case("never")
+        || name.eq_ignore_ascii_case("void")
+        || name.eq_ignore_ascii_case("mixed")
+        || name.eq_ignore_ascii_case("object")
+        || name.eq_ignore_ascii_case("callable")
+        || name.eq_ignore_ascii_case("iterable")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mir-analyzer/src/pass2.rs
+++ b/crates/mir-analyzer/src/pass2.rs
@@ -325,10 +325,10 @@ impl<'a> Pass2Driver<'a> {
             .or_else(|| self.codebase.functions.get(fn_name).map(|r| r.clone()))
             .or_else(|| {
                 self.codebase
-                    .functions
-                    .iter()
-                    .find(|e| e.short_name.as_ref() == fn_name)
-                    .map(|e| e.value().clone())
+                    .fn_by_short_name
+                    .get(fn_name)
+                    .and_then(|fqn| self.codebase.functions.get(fqn.as_ref()))
+                    .map(|r| r.clone())
             });
 
         let fqn = func_opt.as_ref().map(|f| f.fqn.clone());
@@ -535,10 +535,10 @@ impl<'a> Pass2Driver<'a> {
             .or_else(|| self.codebase.functions.get(fn_name).map(|r| r.clone()))
             .or_else(|| {
                 self.codebase
-                    .functions
-                    .iter()
-                    .find(|e| e.short_name.as_ref() == fn_name)
-                    .map(|e| e.value().clone())
+                    .fn_by_short_name
+                    .get(fn_name)
+                    .and_then(|fqn| self.codebase.functions.get(fqn.as_ref()))
+                    .map(|r| r.clone())
             });
 
         let fqn = func_opt.as_ref().map(|f| f.fqn.clone());

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -119,11 +119,17 @@ impl ProjectAnalyzer {
         // ---- Load PHP built-in stubs (before Pass 1 so user code can override)
         self.load_stubs();
 
-        // ---- Pass 1: read files in parallel ----------------------------------
-        let file_data: Vec<(Arc<str>, String)> = paths
+        // ---- Pass 1: read files and hash them in parallel -------------------
+        // The triple (path, content, blake3_hash) is carried through the pipeline
+        // so the hash is computed once and reused in both the cache pre-check and
+        // Pass 2 cache lookup, avoiding a second BLAKE3 pass over every file.
+        let file_data: Vec<(Arc<str>, String, String)> = paths
             .par_iter()
             .filter_map(|path| match std::fs::read_to_string(path) {
-                Ok(src) => Some((Arc::from(path.to_string_lossy().as_ref()), src)),
+                Ok(src) => {
+                    let h = hash_content(&src);
+                    Some((Arc::from(path.to_string_lossy().as_ref()), src, h))
+                }
                 Err(e) => {
                     eprintln!("Cannot read {}: {}", path.display(), e);
                     None
@@ -135,9 +141,8 @@ impl ProjectAnalyzer {
         if let Some(cache) = &self.cache {
             let changed: Vec<String> = file_data
                 .par_iter()
-                .filter_map(|(f, src)| {
-                    let h = hash_content(src);
-                    if cache.get(f, &h).is_none() {
+                .filter_map(|(f, _, h)| {
+                    if cache.get(f, h).is_none() {
                         Some(f.to_string())
                     } else {
                         None
@@ -152,7 +157,7 @@ impl ProjectAnalyzer {
         // ---- Pass 1: combined pre-index + definition collection (parallel) -----
         let pass1_results: Vec<(Vec<Issue>, Vec<Issue>)> = file_data
             .par_iter()
-            .map(|(file, src)| {
+            .map(|(file, src, _h)| {
                 use php_ast::ast::StmtKind;
                 let arena = bumpalo::Bump::new();
                 let result = php_rs_parser::parse(&arena, src);
@@ -308,7 +313,7 @@ impl ProjectAnalyzer {
 
         // ---- Class-level checks (M11) ----------------------------------------
         let analyzed_file_set: std::collections::HashSet<std::sync::Arc<str>> =
-            file_data.iter().map(|(f, _)| f.clone()).collect();
+            file_data.iter().map(|(f, _, _)| f.clone()).collect();
         let class_issues =
             crate::class::ClassAnalyzer::with_files(&self.codebase, analyzed_file_set, &file_data)
                 .analyze_all();
@@ -317,11 +322,10 @@ impl ProjectAnalyzer {
         // ---- Pass 2: analyze function/method bodies in parallel (M14) --------
         let pass2_results: Vec<(Vec<Issue>, Vec<crate::symbol::ResolvedSymbol>)> = file_data
             .par_iter()
-            .map(|(file, src)| {
+            .map(|(file, src, h)| {
                 let driver = Pass2Driver::new(&self.codebase, self.resolved_php_version());
                 let result = if let Some(cache) = &self.cache {
-                    let h = hash_content(src);
-                    if let Some((cached_issues, ref_locs)) = cache.get(file, &h) {
+                    if let Some((cached_issues, ref_locs)) = cache.get(file, h) {
                         self.codebase
                             .replay_reference_locations(file.clone(), &ref_locs);
                         (cached_issues, Vec::new())
@@ -335,7 +339,7 @@ impl ProjectAnalyzer {
                             &parsed.source_map,
                         );
                         let ref_locs = extract_reference_locations(&self.codebase, file);
-                        cache.put(file, h, issues.clone(), ref_locs);
+                        cache.put(file, h.clone(), issues.clone(), ref_locs);
                         (issues, symbols)
                     }
                 } else {
@@ -416,9 +420,16 @@ impl ProjectAnalyzer {
                 break;
             }
 
-            for (fqcn, path) in to_load {
-                loaded.insert(fqcn);
-                if let Ok(src) = std::fs::read_to_string(&path) {
+            for (fqcn, _) in &to_load {
+                loaded.insert(fqcn.clone());
+            }
+
+            let batch_issues: Vec<Vec<Issue>> = to_load
+                .par_iter()
+                .filter_map(|(_, path)| {
+                    let Ok(src) = std::fs::read_to_string(path) else {
+                        return None;
+                    };
                     let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
                     let arena = bumpalo::Bump::new();
                     let result = php_rs_parser::parse(&arena, &src);
@@ -428,9 +439,11 @@ impl ProjectAnalyzer {
                         &src,
                         &result.source_map,
                     );
-                    let issues = collector.collect(&result.program);
-                    all_issues.extend(issues);
-                }
+                    Some(collector.collect(&result.program))
+                })
+                .collect();
+            for issues in batch_issues {
+                all_issues.extend(issues);
             }
 
             self.codebase.invalidate_finalization();

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -62,11 +62,18 @@ fn record_ref(
             entries.push(span);
         }
     }
-    {
-        let mut refs = file_refs.entry(file_id).or_default();
-        if !refs.contains(&sym_id) {
-            refs.push(sym_id);
-        }
+    // No dedup on file_refs: duplicates are harmless since remove_file_definitions
+    // uses retain() which is idempotent, and compact_reference_index clears this map.
+    file_refs.entry(file_id).or_default().push(sym_id);
+}
+
+/// Return a lowercase version of `s` without allocating when `s` is already lowercase.
+#[inline]
+fn ensure_method_name_lowercase(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.bytes().any(|b| b.is_ascii_uppercase()) {
+        std::borrow::Cow::Owned(s.to_lowercase())
+    } else {
+        std::borrow::Cow::Borrowed(s)
     }
 }
 
@@ -187,6 +194,16 @@ pub struct Codebase {
     /// are available.
     pub known_symbols: DashSet<Arc<str>>,
 
+    /// Secondary index: function short name → FQN. Populated in parallel with
+    /// `functions` during Pass 1 and stub loading. Allows O(1) resolution of
+    /// unqualified function calls instead of a full `functions.iter()` scan.
+    pub fn_by_short_name: DashMap<Arc<str>, Arc<str>>,
+
+    /// Secondary index: class short name → FQCN. Populated in parallel with
+    /// `classes` during Pass 1 and stub loading. Allows O(1) resolution of
+    /// unqualified class names instead of a full `classes.iter()` scan.
+    pub class_by_short_name: DashMap<Arc<str>, Arc<str>>,
+
     /// Per-file `use` alias maps: alias → FQCN.  Populated during Pass 1.
     ///
     /// Key: absolute file path (as `Arc<str>`).
@@ -228,6 +245,8 @@ impl Codebase {
             if let Some(f) = &file {
                 self.symbol_to_file.insert(cls.fqcn.clone(), f.clone());
             }
+            self.class_by_short_name
+                .insert(cls.short_name.clone(), cls.fqcn.clone());
             self.classes.insert(cls.fqcn.clone(), cls);
         }
         for iface in slice.interfaces {
@@ -252,6 +271,8 @@ impl Codebase {
             if let Some(f) = &file {
                 self.symbol_to_file.insert(func.fqn.clone(), f.clone());
             }
+            self.fn_by_short_name
+                .insert(func.short_name.clone(), func.fqn.clone());
             self.functions.insert(func.fqn.clone(), func);
         }
         for (name, ty) in slice.constants {
@@ -408,11 +429,23 @@ impl Codebase {
 
         // Remove each symbol from its respective map and from symbol_to_file
         for sym in &symbols {
-            self.classes.remove(sym.as_ref());
+            if let Some((_, cls)) = self.classes.remove(sym.as_ref()) {
+                // Only evict the short-name entry when it points at this FQCN, so that
+                // a class with the same short name in another file is not affected.
+                self.class_by_short_name
+                    .remove_if(cls.short_name.as_ref(), |_, fqcn| {
+                        fqcn.as_ref() == cls.fqcn.as_ref()
+                    });
+            }
             self.interfaces.remove(sym.as_ref());
             self.traits.remove(sym.as_ref());
             self.enums.remove(sym.as_ref());
-            self.functions.remove(sym.as_ref());
+            if let Some((_, func)) = self.functions.remove(sym.as_ref()) {
+                self.fn_by_short_name
+                    .remove_if(func.short_name.as_ref(), |_, fqn| {
+                        fqn.as_ref() == func.fqn.as_ref()
+                    });
+            }
             self.constants.remove(sym.as_ref());
             self.symbol_to_file.remove(sym.as_ref());
             self.known_symbols.remove(sym.as_ref());
@@ -752,8 +785,8 @@ impl Codebase {
     /// Resolve a method, walking up the full inheritance chain (own → traits → ancestors).
     pub fn get_method(&self, fqcn: &str, method_name: &str) -> Option<Arc<MethodStorage>> {
         // PHP method names are case-insensitive — normalize to lowercase for all lookups.
-        let method_lower = method_name.to_lowercase();
-        let method_name = method_lower.as_str();
+        let method_lower = ensure_method_name_lowercase(method_name);
+        let method_name = method_lower.as_ref();
 
         // --- Class: own methods → own traits → ancestor classes/traits/interfaces ---
         if let Some(cls) = self.classes.get(fqcn) {
@@ -1074,9 +1107,8 @@ impl Codebase {
                 return resolved.clone();
             }
             // Fall back to case-insensitive alias lookup
-            let name_lower = name.to_lowercase();
             for (alias, resolved) in imports.iter() {
-                if alias.to_lowercase() == name_lower {
+                if alias.eq_ignore_ascii_case(name) {
                     return resolved.clone();
                 }
             }
@@ -1174,7 +1206,8 @@ impl Codebase {
 
     /// Mark a method as referenced from user code.
     pub fn mark_method_referenced(&self, fqcn: &str, method_name: &str) {
-        let key = format!("{}::{}", fqcn, method_name.to_lowercase());
+        let method_lower = ensure_method_name_lowercase(method_name);
+        let key = format!("{}::{}", fqcn, method_lower);
         let id = self.symbol_interner.intern_str(&key);
         self.referenced_methods.insert(id);
     }
@@ -1193,7 +1226,8 @@ impl Codebase {
     }
 
     pub fn is_method_referenced(&self, fqcn: &str, method_name: &str) -> bool {
-        let key = format!("{}::{}", fqcn, method_name.to_lowercase());
+        let method_lower = ensure_method_name_lowercase(method_name);
+        let key = format!("{}::{}", fqcn, method_lower);
         match self.symbol_interner.get_id(&key) {
             Some(id) => self.referenced_methods.contains(&id),
             None => false,
@@ -1225,7 +1259,8 @@ impl Codebase {
         start: u32,
         end: u32,
     ) {
-        let key = format!("{}::{}", fqcn, method_name.to_lowercase());
+        let method_lower = ensure_method_name_lowercase(method_name);
+        let key = format!("{}::{}", fqcn, method_lower);
         self.ensure_expanded();
         let sym_id = self.symbol_interner.intern_str(&key);
         let file_id = self.file_interner.intern(file);


### PR DESCRIPTION
## Summary

- **Hash once, reuse everywhere**: BLAKE3 file hash is computed once during I/O and carried through the pipeline, eliminating a redundant re-hash of every file in both the cache pre-check and Pass 2 cache lookup.
- **Parallel class checks**: `ClassAnalyzer::analyze_all` per-class checks now run in parallel via rayon (circular-inheritance detection stays serial — it uses shared memoization).
- **Parallel PSR-4 lazy-load**: The inner file-load loop in `lazy_load_missing_classes` is now parallel, so autoloaded dependencies are parsed concurrently.
- **Lock-free cache writes**: `AnalysisCache::entries` replaced `Mutex<HashMap>` with `DashMap`, removing contention when rayon threads concurrently write cache entries during Pass 2. The `dirty` flag moved from `Mutex<bool>` to `AtomicBool`.
- **O(1) short-name resolution**: Added `fn_by_short_name` and `class_by_short_name` secondary indexes to `Codebase`, replacing full `DashMap::iter()` scans when resolving unqualified function/class names.
- **Avoid `to_lowercase()` allocs**: `get_method`, `mark_method_referenced`, and related methods skip the heap allocation when the name is already lowercase (the common case for PHP identifiers stored in the codebase).
- **No-alloc type-hint checks**: `is_pseudo_type` uses `eq_ignore_ascii_case`; `resolve_class_name` alias fallback uses `eq_ignore_ascii_case` — both previously allocated a lowercased string on every call.
- **Leaner `record_ref`**: The `Vec::contains` guard on `file_symbol_references` is dropped; exact-duplicate span deduplication on the symbol side is preserved (tested).

## What was intentionally left out

- **Double parsing** (Pass 1 + Pass 2): eliminating it requires restructuring arena lifetimes across the parallel closures — a separate, larger PR.
- **`Context::clone()` on branches**: needs profiling to confirm it's a real bottleneck before adding CoW complexity.
- **Parallel file discovery**: would add a new `jwalk` dependency for marginal gain compared to the parallel I/O that already follows it.

## Test plan

- [ ] `cargo test` — all tests pass
- [ ] `cargo clippy` — clean
- [ ] `cargo fmt` — clean
- [ ] Run `cargo bench --bench analyze_real_world` against a Laravel fixture before/after to confirm no regression (benchmark fixture requires `bash crates/mir-analyzer/benches/download-fixtures.sh`)