### PR TITLE
perf(structural): short-name indexes, lock-free cache, parallel class/PSR-4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "blake3",
  "bumpalo",
  "criterion",
+ "dashmap",
  "indexmap",
  "mir-codebase",
  "mir-issues",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ smallvec = { version = "1", features = ["union", "serde"] }
 rayon   = "1"
 dashmap = "6"
 
+
 # Serialization
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mir-analyzer/Cargo.toml
+++ b/crates/mir-analyzer/Cargo.toml
@@ -19,6 +19,7 @@ indexmap      = { workspace = true }
 rayon         = { workspace = true }
 thiserror     = { workspace = true }
 blake3        = { workspace = true }
+dashmap       = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 quick-xml     = "0.39"

--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -5,8 +5,10 @@
 /// and Pass 2 analysis is skipped for that file.
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 
 use mir_issues::Issue;
@@ -55,12 +57,15 @@ struct CacheFile {
 }
 
 /// Thread-safe, disk-backed cache for per-file analysis results.
+///
+/// `entries` uses a `DashMap` so concurrent Pass-2 `put` calls from rayon
+/// threads avoid serializing on a single global mutex.
 pub struct AnalysisCache {
     cache_dir: PathBuf,
-    entries: Mutex<HashMap<String, CacheEntry>>,
+    entries: DashMap<String, CacheEntry>,
     /// Reverse dependency graph loaded from disk (from the previous run).
     reverse_deps: Mutex<HashMap<String, HashSet<String>>>,
-    dirty: Mutex<bool>,
+    dirty: AtomicBool,
 }
 
 impl AnalysisCache {
@@ -72,9 +77,9 @@ impl AnalysisCache {
         let file = Self::load(cache_dir);
         Self {
             cache_dir: cache_dir.to_path_buf(),
-            entries: Mutex::new(file.entries),
+            entries: DashMap::from_iter(file.entries),
             reverse_deps: Mutex::new(file.reverse_deps),
-            dirty: Mutex::new(false),
+            dirty: AtomicBool::new(false),
         }
     }
 
@@ -89,8 +94,7 @@ impl AnalysisCache {
     /// `(symbol_key, start_byte, end_byte)` entries to replay into
     /// `Codebase::symbol_reference_locations`.
     pub fn get(&self, file_path: &str, content_hash: &str) -> Option<CacheHit> {
-        let entries = self.entries.lock().unwrap();
-        entries.get(file_path).and_then(|e| {
+        self.entries.get(file_path).and_then(|e| {
             if e.content_hash == content_hash {
                 Some((e.issues.clone(), e.reference_locations.clone()))
             } else {
@@ -109,8 +113,7 @@ impl AnalysisCache {
         issues: Vec<Issue>,
         reference_locations: Vec<(String, u32, u32)>,
     ) {
-        let mut entries = self.entries.lock().unwrap();
-        entries.insert(
+        self.entries.insert(
             file_path.to_string(),
             CacheEntry {
                 content_hash,
@@ -118,24 +121,22 @@ impl AnalysisCache {
                 reference_locations,
             },
         );
-        *self.dirty.lock().unwrap() = true;
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     /// Persist the in-memory cache to `{cache_dir}/cache.json`.
     /// This is a no-op if nothing changed since the last flush.
     pub fn flush(&self) {
-        let dirty = {
-            let mut d = self.dirty.lock().unwrap();
-            let was = *d;
-            *d = false;
-            was
-        };
-        if !dirty {
+        if !self.dirty.swap(false, Ordering::AcqRel) {
             return;
         }
         let cache_file = self.cache_dir.join("cache.json");
         let file = CacheFile {
-            entries: self.entries.lock().unwrap().clone(),
+            entries: self
+                .entries
+                .iter()
+                .map(|e| (e.key().clone(), e.value().clone()))
+                .collect(),
             reverse_deps: self.reverse_deps.lock().unwrap().clone(),
         };
         if let Ok(json) = serde_json::to_string(&file) {
@@ -146,7 +147,7 @@ impl AnalysisCache {
     /// Replace the reverse dependency graph (called after each Pass 1).
     pub fn set_reverse_deps(&self, deps: HashMap<String, HashSet<String>>) {
         *self.reverse_deps.lock().unwrap() = deps;
-        *self.dirty.lock().unwrap() = true;
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     /// BFS from each changed file through the reverse dep graph.
@@ -174,7 +175,7 @@ impl AnalysisCache {
             result
         };
 
-        // Phase 2: evict (reverse_deps lock released above, entries lock taken per file).
+        // Phase 2: evict (reverse_deps lock released above).
         let count = to_evict.len();
         for file in &to_evict {
             self.evict(file);
@@ -184,9 +185,8 @@ impl AnalysisCache {
 
     /// Remove a single file's cache entry.
     pub fn evict(&self, file_path: &str) {
-        let mut entries = self.entries.lock().unwrap();
-        entries.remove(file_path);
-        *self.dirty.lock().unwrap() = true;
+        self.entries.remove(file_path);
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/mir-analyzer/src/call/args.rs
+++ b/crates/mir-analyzer/src/call/args.rs
@@ -531,18 +531,16 @@ fn named_object_subtype(arg: &Union, param: &Union, ea: &ExpressionAnalyzer<'_>)
             }
 
             if !arg_fqcn.contains('\\') && !ea.codebase.type_exists(&resolved_arg) {
-                for entry in ea.codebase.classes.iter() {
-                    if entry.value().short_name.as_ref() == arg_fqcn.as_ref() {
-                        let actual_fqcn = entry.key().clone();
-                        if ea
+                if let Some(actual_fqcn) = ea.codebase.class_by_short_name.get(arg_fqcn.as_ref()) {
+                    let actual_fqcn = actual_fqcn.clone();
+                    if ea
+                        .codebase
+                        .extends_or_implements(actual_fqcn.as_ref(), &resolved_param)
+                        || ea
                             .codebase
-                            .extends_or_implements(actual_fqcn.as_ref(), &resolved_param)
-                            || ea
-                                .codebase
-                                .extends_or_implements(actual_fqcn.as_ref(), param_fqcn.as_ref())
-                        {
-                            return true;
-                        }
+                            .extends_or_implements(actual_fqcn.as_ref(), param_fqcn.as_ref())
+                    {
+                        return true;
                     }
                 }
             }

--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -10,6 +10,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use rayon::prelude::*;
+
 use mir_codebase::storage::{MethodStorage, Visibility};
 use mir_codebase::Codebase;
 use mir_issues::{Issue, IssueKind, Location};
@@ -53,8 +55,6 @@ impl<'a> ClassAnalyzer<'a> {
 
     /// Run all class-level checks and return every discovered issue.
     pub fn analyze_all(&self) -> Vec<Issue> {
-        let mut issues = Vec::new();
-
         let class_keys: Vec<Arc<str>> = self
             .codebase
             .classes
@@ -62,90 +62,100 @@ impl<'a> ClassAnalyzer<'a> {
             .map(|e| e.key().clone())
             .collect();
 
-        for fqcn in &class_keys {
-            let cls = match self.codebase.classes.get(fqcn.as_ref()) {
-                Some(c) => c,
-                None => continue,
-            };
+        // Per-class checks are independent — run them in parallel.
+        let mut issues: Vec<Issue> = class_keys
+            .par_iter()
+            .flat_map(|fqcn| {
+                let mut class_issues = Vec::new();
 
-            // Skip classes from vendor / stub files — only check user-analyzed files
-            if !self.analyzed_files.is_empty() {
-                let in_analyzed = cls
-                    .location
-                    .as_ref()
-                    .map(|loc| self.analyzed_files.contains(&loc.file))
-                    .unwrap_or(false);
-                if !in_analyzed {
-                    continue;
-                }
-            }
+                let cls = match self.codebase.classes.get(fqcn.as_ref()) {
+                    Some(c) => c,
+                    None => return class_issues,
+                };
 
-            // ---- 1. Final-class extension check / deprecated parent check ------
-            if let Some(parent_fqcn) = &cls.parent {
-                if let Some(parent) = self.codebase.classes.get(parent_fqcn.as_ref()) {
-                    if parent.is_final {
-                        let loc = issue_location(
-                            cls.location.as_ref(),
-                            fqcn,
-                            cls.location
-                                .as_ref()
-                                .and_then(|l| self.sources.get(&l.file).copied()),
-                        );
-                        let mut issue = Issue::new(
-                            IssueKind::FinalClassExtended {
-                                parent: parent_fqcn.to_string(),
-                                child: fqcn.to_string(),
-                            },
-                            loc,
-                        );
-                        if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources)
-                        {
-                            issue = issue.with_snippet(snippet);
-                        }
-                        issues.push(issue);
-                    }
-                    if let Some(msg) = parent.deprecated.clone() {
-                        let loc = issue_location(
-                            cls.location.as_ref(),
-                            fqcn,
-                            cls.location
-                                .as_ref()
-                                .and_then(|l| self.sources.get(&l.file).copied()),
-                        );
-                        let mut issue = Issue::new(
-                            IssueKind::DeprecatedClass {
-                                name: parent_fqcn.to_string(),
-                                message: Some(msg).filter(|m| !m.is_empty()),
-                            },
-                            loc,
-                        );
-                        if let Some(snippet) = extract_snippet(cls.location.as_ref(), &self.sources)
-                        {
-                            issue = issue.with_snippet(snippet);
-                        }
-                        issues.push(issue);
+                // Skip classes from vendor / stub files — only check user-analyzed files
+                if !self.analyzed_files.is_empty() {
+                    let in_analyzed = cls
+                        .location
+                        .as_ref()
+                        .map(|loc| self.analyzed_files.contains(&loc.file))
+                        .unwrap_or(false);
+                    if !in_analyzed {
+                        return class_issues;
                     }
                 }
-            }
 
-            // Skip abstract classes for "must implement" checks
-            if cls.is_abstract {
-                // Still check override compatibility for abstract classes
-                self.check_overrides(&cls, &mut issues);
-                continue;
-            }
+                // ---- 1. Final-class extension check / deprecated parent check ------
+                if let Some(parent_fqcn) = &cls.parent {
+                    if let Some(parent) = self.codebase.classes.get(parent_fqcn.as_ref()) {
+                        if parent.is_final {
+                            let loc = issue_location(
+                                cls.location.as_ref(),
+                                fqcn,
+                                cls.location
+                                    .as_ref()
+                                    .and_then(|l| self.sources.get(&l.file).copied()),
+                            );
+                            let mut issue = Issue::new(
+                                IssueKind::FinalClassExtended {
+                                    parent: parent_fqcn.to_string(),
+                                    child: fqcn.to_string(),
+                                },
+                                loc,
+                            );
+                            if let Some(snippet) =
+                                extract_snippet(cls.location.as_ref(), &self.sources)
+                            {
+                                issue = issue.with_snippet(snippet);
+                            }
+                            class_issues.push(issue);
+                        }
+                        if let Some(msg) = parent.deprecated.clone() {
+                            let loc = issue_location(
+                                cls.location.as_ref(),
+                                fqcn,
+                                cls.location
+                                    .as_ref()
+                                    .and_then(|l| self.sources.get(&l.file).copied()),
+                            );
+                            let mut issue = Issue::new(
+                                IssueKind::DeprecatedClass {
+                                    name: parent_fqcn.to_string(),
+                                    message: Some(msg).filter(|m| !m.is_empty()),
+                                },
+                                loc,
+                            );
+                            if let Some(snippet) =
+                                extract_snippet(cls.location.as_ref(), &self.sources)
+                            {
+                                issue = issue.with_snippet(snippet);
+                            }
+                            class_issues.push(issue);
+                        }
+                    }
+                }
 
-            // ---- 2. Abstract parent methods must be implemented ----------------
-            self.check_abstract_methods_implemented(&cls, &mut issues);
+                // Skip abstract classes for "must implement" checks
+                if cls.is_abstract {
+                    // Still check override compatibility for abstract classes
+                    self.check_overrides(&cls, &mut class_issues);
+                    return class_issues;
+                }
 
-            // ---- 3. Interface methods must be implemented ----------------------
-            self.check_interface_methods_implemented(&cls, &mut issues);
+                // ---- 2. Abstract parent methods must be implemented ----------------
+                self.check_abstract_methods_implemented(&cls, &mut class_issues);
 
-            // ---- 4. Method override compatibility ------------------------------
-            self.check_overrides(&cls, &mut issues);
-        }
+                // ---- 3. Interface methods must be implemented ----------------------
+                self.check_interface_methods_implemented(&cls, &mut class_issues);
 
-        // ---- 5. Circular inheritance detection --------------------------------
+                // ---- 4. Method override compatibility ------------------------------
+                self.check_overrides(&cls, &mut class_issues);
+
+                class_issues
+            })
+            .collect();
+
+        // ---- 5. Circular inheritance detection (must remain serial — uses shared memoization) ---
         self.check_circular_class_inheritance(&mut issues);
         self.check_circular_interface_inheritance(&mut issues);
 

--- a/crates/mir-analyzer/src/pass2.rs
+++ b/crates/mir-analyzer/src/pass2.rs
@@ -367,10 +367,10 @@ impl<'a> Pass2Driver<'a> {
             .or_else(|| self.codebase.functions.get(fn_name).map(|r| r.clone()))
             .or_else(|| {
                 self.codebase
-                    .functions
-                    .iter()
-                    .find(|e| e.short_name.as_ref() == fn_name)
-                    .map(|e| e.value().clone())
+                    .fn_by_short_name
+                    .get(fn_name)
+                    .and_then(|fqn| self.codebase.functions.get(fqn.as_ref()))
+                    .map(|r| r.clone())
             });
 
         let fqn = func_opt.as_ref().map(|f| f.fqn.clone());
@@ -577,10 +577,10 @@ impl<'a> Pass2Driver<'a> {
             .or_else(|| self.codebase.functions.get(fn_name).map(|r| r.clone()))
             .or_else(|| {
                 self.codebase
-                    .functions
-                    .iter()
-                    .find(|e| e.short_name.as_ref() == fn_name)
-                    .map(|e| e.value().clone())
+                    .fn_by_short_name
+                    .get(fn_name)
+                    .and_then(|fqn| self.codebase.functions.get(fqn.as_ref()))
+                    .map(|r| r.clone())
             });
 
         let fqn = func_opt.as_ref().map(|f| f.fqn.clone());

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -420,9 +420,16 @@ impl ProjectAnalyzer {
                 break;
             }
 
-            for (fqcn, path) in to_load {
-                loaded.insert(fqcn);
-                if let Ok(src) = std::fs::read_to_string(&path) {
+            for (fqcn, _) in &to_load {
+                loaded.insert(fqcn.clone());
+            }
+
+            let batch_issues: Vec<Vec<Issue>> = to_load
+                .par_iter()
+                .filter_map(|(_, path)| {
+                    let Ok(src) = std::fs::read_to_string(path) else {
+                        return None;
+                    };
                     let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
                     let arena = bumpalo::Bump::new();
                     let result = php_rs_parser::parse(&arena, &src);
@@ -432,9 +439,11 @@ impl ProjectAnalyzer {
                         &src,
                         &result.source_map,
                     );
-                    let issues = collector.collect(&result.program);
-                    all_issues.extend(issues);
-                }
+                    Some(collector.collect(&result.program))
+                })
+                .collect();
+            for issues in batch_issues {
+                all_issues.extend(issues);
             }
 
             self.codebase.invalidate_finalization();

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -193,6 +193,16 @@ pub struct Codebase {
     /// are available.
     pub known_symbols: DashSet<Arc<str>>,
 
+    /// Secondary index: function short name → FQN. Populated in parallel with
+    /// `functions` during Pass 1 and stub loading. Allows O(1) resolution of
+    /// unqualified function calls instead of a full `functions.iter()` scan.
+    pub fn_by_short_name: DashMap<Arc<str>, Arc<str>>,
+
+    /// Secondary index: class short name → FQCN. Populated in parallel with
+    /// `classes` during Pass 1 and stub loading. Allows O(1) resolution of
+    /// unqualified class names instead of a full `classes.iter()` scan.
+    pub class_by_short_name: DashMap<Arc<str>, Arc<str>>,
+
     /// Per-file `use` alias maps: alias → FQCN.  Populated during Pass 1.
     ///
     /// Key: absolute file path (as `Arc<str>`).
@@ -234,6 +244,8 @@ impl Codebase {
             if let Some(f) = &file {
                 self.symbol_to_file.insert(cls.fqcn.clone(), f.clone());
             }
+            self.class_by_short_name
+                .insert(cls.short_name.clone(), cls.fqcn.clone());
             self.classes.insert(cls.fqcn.clone(), cls);
         }
         for iface in slice.interfaces {
@@ -258,6 +270,8 @@ impl Codebase {
             if let Some(f) = &file {
                 self.symbol_to_file.insert(func.fqn.clone(), f.clone());
             }
+            self.fn_by_short_name
+                .insert(func.short_name.clone(), func.fqn.clone());
             self.functions.insert(func.fqn.clone(), func);
         }
         for (name, ty) in slice.constants {
@@ -414,11 +428,23 @@ impl Codebase {
 
         // Remove each symbol from its respective map and from symbol_to_file
         for sym in &symbols {
-            self.classes.remove(sym.as_ref());
+            if let Some((_, cls)) = self.classes.remove(sym.as_ref()) {
+                // Only evict the short-name entry when it points at this FQCN, so that
+                // a class with the same short name in another file is not affected.
+                self.class_by_short_name
+                    .remove_if(cls.short_name.as_ref(), |_, fqcn| {
+                        fqcn.as_ref() == cls.fqcn.as_ref()
+                    });
+            }
             self.interfaces.remove(sym.as_ref());
             self.traits.remove(sym.as_ref());
             self.enums.remove(sym.as_ref());
-            self.functions.remove(sym.as_ref());
+            if let Some((_, func)) = self.functions.remove(sym.as_ref()) {
+                self.fn_by_short_name
+                    .remove_if(func.short_name.as_ref(), |_, fqn| {
+                        fqn.as_ref() == func.fqn.as_ref()
+                    });
+            }
             self.constants.remove(sym.as_ref());
             self.symbol_to_file.remove(sym.as_ref());
             self.known_symbols.remove(sym.as_ref());


### PR DESCRIPTION
## Summary

Structural changes extracted from #263, rebased on #268 and fixed to pass all 338 tests (34 new fixtures were added after #263 branched).

**Stack**: this PR targets `perf/simplifications` (#268). After #268 is merged to `main`, retarget this PR to `main`.

- **Short-name indexes**: `fn_by_short_name` and `class_by_short_name` secondary indexes on `Codebase` replace full `DashMap::iter()` scans when resolving unqualified function/class names (O(1) vs O(n)). Indexes are maintained on every `inject_stub_slice` call and evicted precisely on `remove_file_definitions`.

- **Lock-free cache**: `AnalysisCache::entries` replaced `Mutex<HashMap>` with `DashMap`, removing contention when rayon threads write cache entries concurrently during Pass 2. `dirty` moved to `AtomicBool`. Note: dashmap `serde` feature intentionally **not** enabled — the flush path already serializes via a plain `HashMap`, and enabling it caused an unexpected test regression (mixin resolution).

- **Parallel class analysis**: `ClassAnalyzer::analyze_all` per-class checks now run via `rayon::par_iter`. Circular-inheritance detection stays serial — it uses shared memoization.

- **Parallel PSR-4 lazy-load**: The inner file-load loop in `lazy_load_missing_classes` is now parallel, so autoloaded dependencies are parsed concurrently.

## Fixes vs original #263

- Preserved `analyze_trait_decl` calls in `pass2.rs` (added by #264 after #263 branched — removing them broke 3 `undefined_function::*_trait_method_body` tests).
- Preserved generic type param compatibility logic in `call/args.rs` (added after #263 branched — removing it broke 3 `generic_variance` tests).
- Dropped `features = ["serde"]` from the dashmap workspace dep — it was unused (cache serialization converts to `HashMap` first) and broke the `docblock_parity::magic_properties_methods_and_mixin` test.

## Test plan

- [x] `cargo test` — all 338 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [ ] `cargo bench --bench analyze_real_world` — benchmark needed to confirm whether the structural changes help or hurt (the original #263 showed regressions in the combined benchmark; this PR isolates them so each can be evaluated separately)