### PR TITLE
feat(sarif): improve SARIF output for GitHub Code Scanning parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Location.line_end` field — all issues now carry an end line number, enabling multi-line range highlighting in editors and code scanning tools.
+- SARIF output: `region.endLine` populated from `line_end`.
+- SARIF output: results now include `rank` (Error → 90, Warning → 95, Info → 99) matching Psalm's scoring range.
+- SARIF output: rules now include `properties.tags` (`"security"` for taint issues, `"maintainability"` for all others).
+
+### Fixed
+
+- SARIF output: `startColumn`/`endColumn` are now correctly 1-based per SARIF 2.1.0 §3.30.5 (previously off by one).
+- SARIF output: rules now include `defaultConfiguration.level` so the GitHub Code Scanning rules panel shows severity.
+- SARIF output: results now include `partialFingerprints.primaryLocationLineHash` (FNV-1a of rule name + snippet) so GitHub Code Scanning can track findings across commits.
+
 ## [0.9.0] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "blake3",
  "bumpalo",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "dashmap",
  "indexmap",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "indexmap",
  "serde",

--- a/crates/mir-analyzer/src/class.rs
+++ b/crates/mir-analyzer/src/class.rs
@@ -838,9 +838,21 @@ fn issue_location(
                 loc.col
             };
 
+            let line_end = if let Some(src) = source {
+                if loc.end > loc.start {
+                    let end_offset = (loc.end as usize).min(src.len());
+                    src[..end_offset].bytes().filter(|&b| b == b'\n').count() as u32 + 1
+                } else {
+                    loc.line
+                }
+            } else {
+                loc.line
+            };
+
             Location {
                 file: loc.file.clone(),
                 line: loc.line,
+                line_end,
                 col_start,
                 col_end,
             }
@@ -848,6 +860,7 @@ fn issue_location(
         None => Location {
             file: fqcn.clone(),
             line: 1,
+            line_end: 1,
             col_start: 0,
             col_end: 0,
         },

--- a/crates/mir-analyzer/src/dead_code.rs
+++ b/crates/mir-analyzer/src/dead_code.rs
@@ -69,6 +69,7 @@ impl<'a> DeadCodeAnalyzer<'a> {
                         Location {
                             file,
                             line,
+                            line_end: line,
                             col_start: 0,
                             col_end: 0,
                         },
@@ -91,6 +92,7 @@ impl<'a> DeadCodeAnalyzer<'a> {
                         Location {
                             file,
                             line,
+                            line_end: line,
                             col_start: 0,
                             col_end: 0,
                         },

--- a/crates/mir-analyzer/src/diagnostics.rs
+++ b/crates/mir-analyzer/src/diagnostics.rs
@@ -51,12 +51,11 @@ pub(crate) fn check_type_hint_classes<'arena, 'src>(
             let resolved = codebase.resolve_class_name(file.as_ref(), &name_str);
             if !codebase.type_exists(&resolved) {
                 let (line, col_start) = offset_to_line_col(source, hint.span.start, source_map);
-                let col_end = if hint.span.start < hint.span.end {
-                    let (_end_line, end_col) =
-                        offset_to_line_col(source, hint.span.end, source_map);
-                    end_col
+                let (line_end, col_end) = if hint.span.start < hint.span.end {
+                    let (end_line, end_col) = offset_to_line_col(source, hint.span.end, source_map);
+                    (end_line, end_col)
                 } else {
-                    col_start
+                    (line, col_start)
                 };
                 issues.push(
                     mir_issues::Issue::new(
@@ -64,6 +63,7 @@ pub(crate) fn check_type_hint_classes<'arena, 'src>(
                         mir_issues::Location {
                             file: file.clone(),
                             line,
+                            line_end,
                             col_start,
                             col_end: col_end.max(col_start + 1),
                         },
@@ -97,13 +97,14 @@ pub(crate) fn check_name_class(
     if !codebase.type_exists(&resolved) {
         let span = name.span();
         let (line, col_start) = offset_to_line_col(source, span.start, source_map);
-        let (_, col_end) = offset_to_line_col(source, span.end, source_map);
+        let (line_end, col_end) = offset_to_line_col(source, span.end, source_map);
         issues.push(
             mir_issues::Issue::new(
                 mir_issues::IssueKind::UndefinedClass { name: resolved },
                 mir_issues::Location {
                     file: file.clone(),
                     line,
+                    line_end,
                     col_start,
                     col_end: col_end.max(col_start + 1),
                 },
@@ -165,6 +166,7 @@ pub(crate) fn emit_unused_params(
                     mir_issues::Location {
                         file: file.clone(),
                         line: 1,
+                        line_end: 1,
                         col_start: 0,
                         col_end: 0,
                     },
@@ -202,6 +204,7 @@ pub(crate) fn emit_unused_variables(
                 mir_issues::Location {
                     file: file.clone(),
                     line: 1,
+                    line_end: 1,
                     col_start: 0,
                     col_end: 0,
                 },

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1511,13 +1511,11 @@ impl<'a> ExpressionAnalyzer<'a> {
     pub fn emit(&mut self, kind: IssueKind, severity: Severity, span: php_ast::Span) {
         let (line, col_start) = self.offset_to_line_col(span.start);
 
-        // Calculate col_end: if span.end is on the same line, use its char-count column;
-        // otherwise use col_start (single-line range for diagnostics)
-        let col_end = if span.start < span.end {
-            let (_end_line, end_col) = self.offset_to_line_col(span.end);
-            end_col
+        let (line_end, col_end) = if span.start < span.end {
+            let (end_line, end_col) = self.offset_to_line_col(span.end);
+            (end_line, end_col)
         } else {
-            col_start
+            (line, col_start)
         };
 
         let mut issue = Issue::new(
@@ -1525,6 +1523,7 @@ impl<'a> ExpressionAnalyzer<'a> {
             Location {
                 file: self.file.clone(),
                 line,
+                line_end,
                 col_start,
                 col_end: col_end.max(col_start + 1),
             },

--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -269,6 +269,7 @@ impl ProjectAnalyzer {
                             mir_issues::Location {
                                 file: file.clone(),
                                 line: 1,
+                                line_end: 1,
                                 col_start: 0,
                                 col_end: 0,
                             },
@@ -474,6 +475,7 @@ impl ProjectAnalyzer {
                 mir_issues::Location {
                     file: file.clone(),
                     line: 1,
+                    line_end: 1,
                     col_start: 0,
                     col_end: 0,
                 },

--- a/crates/mir-analyzer/src/stmt.rs
+++ b/crates/mir-analyzer/src/stmt.rs
@@ -68,11 +68,11 @@ impl<'a> StatementsAnalyzer<'a> {
 
             if ctx.diverges {
                 let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                let col_end = if stmt.span.start < stmt.span.end {
-                    let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
-                    end_col
+                let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                    let (end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                    (end_line, end_col)
                 } else {
-                    col_start + 1
+                    (line, col_start + 1)
                 };
                 self.issues.add(
                     Issue::new(
@@ -80,6 +80,7 @@ impl<'a> StatementsAnalyzer<'a> {
                         Location {
                             file: self.file.clone(),
                             line,
+                            line_end,
                             col_start,
                             col_end: col_end.max(col_start + 1),
                         },
@@ -165,17 +166,18 @@ impl<'a> StatementsAnalyzer<'a> {
                     // Taint check (M19): echoing tainted data → XSS
                     if crate::taint::is_expr_tainted(expr, ctx) {
                         let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                        let col_end = if stmt.span.start < stmt.span.end {
-                            let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
-                            end_col
+                        let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                            let (end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                            (end_line, end_col)
                         } else {
-                            col_start
+                            (line, col_start)
                         };
                         let mut issue = mir_issues::Issue::new(
                             IssueKind::TaintedHtml,
                             mir_issues::Location {
                                 file: self.file.clone(),
                                 line,
+                                line_end,
                                 col_start,
                                 col_end: col_end.max(col_start + 1),
                             },
@@ -244,11 +246,11 @@ impl<'a> StatementsAnalyzer<'a> {
                                 && !named_object_return_compatible(&declared.remove_null(), &check_ty.remove_null(), self.codebase, &self.file))
                         {
                             let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                            let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
-                                end_col
+                            let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                                let (end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                                (end_line, end_col)
                             } else {
-                                col_start
+                                (line, col_start)
                             };
                             self.issues.add(
                                 mir_issues::Issue::new(
@@ -259,6 +261,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                     mir_issues::Location {
                                         file: self.file.clone(),
                                         line,
+                                        line_end,
                                         col_start,
                                         col_end: col_end.max(col_start + 1),
                                     },
@@ -277,11 +280,11 @@ impl<'a> StatementsAnalyzer<'a> {
                     if let Some(declared) = &ctx.fn_return_type.clone() {
                         if !declared.is_void() && !declared.is_mixed() {
                             let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                            let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
-                                end_col
+                            let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                                let (end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                                (end_line, end_col)
                             } else {
-                                col_start
+                                (line, col_start)
                             };
                             self.issues.add(
                                 mir_issues::Issue::new(
@@ -292,6 +295,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                     mir_issues::Location {
                                         file: self.file.clone(),
                                         line,
+                                        line_end,
                                         col_start,
                                         col_end: col_end.max(col_start + 1),
                                     },
@@ -334,12 +338,12 @@ impl<'a> StatementsAnalyzer<'a> {
                                 || (!self.codebase.type_exists(&resolved) && !self.codebase.type_exists(fqcn));
                             if !is_throwable {
                                 let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                                let col_end = if stmt.span.start < stmt.span.end {
-                                    let (_end_line, end_col) =
+                                let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                                    let (end_line, end_col) =
                                         self.offset_to_line_col(stmt.span.end);
-                                    end_col
+                                    (end_line, end_col)
                                 } else {
-                                    col_start
+                                    (line, col_start)
                                 };
                                 self.issues.add(mir_issues::Issue::new(
                                     IssueKind::InvalidThrow {
@@ -348,6 +352,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                     mir_issues::Location {
                                         file: self.file.clone(),
                                         line,
+                                        line_end,
                                         col_start,
                                         col_end: col_end.max(col_start + 1),
                                     },
@@ -372,12 +377,12 @@ impl<'a> StatementsAnalyzer<'a> {
                                 || self.codebase.has_unknown_ancestor(fqcn);
                             if !is_throwable {
                                 let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                                let col_end = if stmt.span.start < stmt.span.end {
-                                    let (_end_line, end_col) =
+                                let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                                    let (end_line, end_col) =
                                         self.offset_to_line_col(stmt.span.end);
-                                    end_col
+                                    (end_line, end_col)
                                 } else {
-                                    col_start
+                                    (line, col_start)
                                 };
                                 self.issues.add(mir_issues::Issue::new(
                                     IssueKind::InvalidThrow {
@@ -386,6 +391,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                     mir_issues::Location {
                                         file: self.file.clone(),
                                         line,
+                                        line_end,
                                         col_start,
                                         col_end: col_end.max(col_start + 1),
                                     },
@@ -395,11 +401,11 @@ impl<'a> StatementsAnalyzer<'a> {
                         mir_types::Atomic::TMixed | mir_types::Atomic::TObject => {}
                         _ => {
                             let (line, col_start) = self.offset_to_line_col(stmt.span.start);
-                            let col_end = if stmt.span.start < stmt.span.end {
-                                let (_end_line, end_col) = self.offset_to_line_col(stmt.span.end);
-                                end_col
+                            let (line_end, col_end) = if stmt.span.start < stmt.span.end {
+                                let (end_line, end_col) = self.offset_to_line_col(stmt.span.end);
+                                (end_line, end_col)
                             } else {
-                                col_start
+                                (line, col_start)
                             };
                             self.issues.add(mir_issues::Issue::new(
                                 IssueKind::InvalidThrow {
@@ -408,6 +414,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                 mir_issues::Location {
                                     file: self.file.clone(),
                                     line,
+                                    line_end,
                                     col_start,
                                     col_end: col_end.max(col_start + 1),
                                 },
@@ -484,13 +491,14 @@ impl<'a> StatementsAnalyzer<'a> {
                     {
                         let (line, col_start) =
                             self.offset_to_line_col(elseif.condition.span.start);
-                        let col_end = if elseif.condition.span.start < elseif.condition.span.end {
-                            let (_end_line, end_col) =
-                                self.offset_to_line_col(elseif.condition.span.end);
-                            end_col
-                        } else {
-                            col_start
-                        };
+                        let (line_end, col_end) =
+                            if elseif.condition.span.start < elseif.condition.span.end {
+                                let (end_line, end_col) =
+                                    self.offset_to_line_col(elseif.condition.span.end);
+                                (end_line, end_col)
+                            } else {
+                                (line, col_start)
+                            };
                         let elseif_cond_type = self
                             .expr_analyzer(ctx)
                             .analyze(&elseif.condition, &mut ctx.fork());
@@ -502,6 +510,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                 mir_issues::Location {
                                     file: self.file.clone(),
                                     line,
+                                    line_end,
                                     col_start,
                                     col_end: col_end.max(col_start + 1),
                                 },
@@ -544,13 +553,14 @@ impl<'a> StatementsAnalyzer<'a> {
                     && (then_unreachable_from_narrowing || else_unreachable_from_narrowing)
                 {
                     let (line, col_start) = self.offset_to_line_col(if_stmt.condition.span.start);
-                    let col_end = if if_stmt.condition.span.start < if_stmt.condition.span.end {
-                        let (_end_line, end_col) =
-                            self.offset_to_line_col(if_stmt.condition.span.end);
-                        end_col
-                    } else {
-                        col_start
-                    };
+                    let (line_end, col_end) =
+                        if if_stmt.condition.span.start < if_stmt.condition.span.end {
+                            let (end_line, end_col) =
+                                self.offset_to_line_col(if_stmt.condition.span.end);
+                            (end_line, end_col)
+                        } else {
+                            (line, col_start)
+                        };
                     self.issues.add(
                         mir_issues::Issue::new(
                             IssueKind::RedundantCondition {
@@ -559,6 +569,7 @@ impl<'a> StatementsAnalyzer<'a> {
                             mir_issues::Location {
                                 file: self.file.clone(),
                                 line,
+                                line_end,
                                 col_start,
                                 col_end: col_end.max(col_start + 1),
                             },
@@ -1117,12 +1128,13 @@ impl<'a> StatementsAnalyzer<'a> {
         }
         let span = name.span();
         let (line, col_start) = self.offset_to_line_col(span.start);
-        let (_, col_end) = self.offset_to_line_col(span.end);
+        let (line_end, col_end) = self.offset_to_line_col(span.end);
         self.issues.add(Issue::new(
             IssueKind::UndefinedClass { name: resolved },
             Location {
                 file: self.file.clone(),
                 line,
+                line_end,
                 col_start,
                 col_end: col_end.max(col_start + 1),
             },

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -828,24 +828,48 @@ fn xml_escape(s: &str) -> String {
 // SARIF output (GitHub Code Scanning compatible)
 // ---------------------------------------------------------------------------
 
+/// FNV-1a 64-bit hash for stable partial fingerprints without extra dependencies.
+fn fnv1a(data: &str) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in data.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x00000100000001b3);
+    }
+    hash
+}
+
 fn format_sarif(issues: &[&Issue]) -> String {
-    // Build the set of unique rules (issue kinds)
-    let mut rule_ids: Vec<String> = issues
-        .iter()
-        .map(|i| i.kind.name().to_string())
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .collect();
+    // Build unique rules with their default severity for rule-level metadata.
+    let mut rule_map: std::collections::HashMap<String, Severity> =
+        std::collections::HashMap::new();
+    for issue in issues {
+        rule_map
+            .entry(issue.kind.name().to_string())
+            .or_insert_with(|| issue.kind.default_severity());
+    }
+    let mut rule_ids: Vec<String> = rule_map.keys().cloned().collect();
     rule_ids.sort_unstable();
 
     let rules_json: Vec<serde_json::Value> = rule_ids
         .iter()
         .map(|id| {
+            let level = match rule_map[id] {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "note",
+            };
+            let tag = if id.starts_with("Tainted") {
+                "security"
+            } else {
+                "maintainability"
+            };
             serde_json::json!({
                 "id": id,
                 "name": id,
                 "shortDescription": { "text": id },
-                "helpUri": "https://github.com/adamspychala/mir",
+                "helpUri": "https://github.com/jorgsowa/mir",
+                "defaultConfiguration": { "level": level },
+                "properties": { "tags": [tag] },
             })
         })
         .collect();
@@ -858,10 +882,32 @@ fn format_sarif(issues: &[&Issue]) -> String {
                 Severity::Warning => "warning",
                 Severity::Info => "note",
             };
+
+            // Fingerprint based on issue kind + snippet content (not location) so
+            // GitHub Code Scanning can track findings across renames/reformats.
+            let fingerprint_input = format!(
+                "{}:{}",
+                issue.kind.name(),
+                issue.snippet.as_deref().unwrap_or("")
+            );
+            let fingerprint = format!("{:016x}", fnv1a(&fingerprint_input));
+
+            // rank: Error → 90, Warning → 95, Info → 99 (matches Psalm's 90–99 range).
+            let rank = match issue.severity {
+                Severity::Error => 90.0_f64,
+                Severity::Warning => 95.0,
+                Severity::Info => 99.0,
+            };
+
+            // SARIF 2.1.0 §3.30.5: columns are 1-based; col_start/col_end are 0-based.
             serde_json::json!({
                 "ruleId": issue.kind.name(),
                 "level": level,
+                "rank": rank,
                 "message": { "text": issue.kind.message() },
+                "partialFingerprints": {
+                    "primaryLocationLineHash": fingerprint,
+                },
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": {
@@ -870,8 +916,9 @@ fn format_sarif(issues: &[&Issue]) -> String {
                         },
                         "region": {
                             "startLine": issue.location.line,
-                            "startColumn": issue.location.col_start,
-                            "endColumn": issue.location.col_end,
+                            "endLine": issue.location.line_end,
+                            "startColumn": issue.location.col_start + 1,
+                            "endColumn": issue.location.col_end + 1,
                         }
                     }
                 }]
@@ -886,7 +933,7 @@ fn format_sarif(issues: &[&Issue]) -> String {
             "tool": {
                 "driver": {
                     "name": "mir",
-                    "informationUri": "https://github.com/adamspychala/mir",
+                    "informationUri": "https://github.com/jorgsowa/mir",
                     "rules": rules_json,
                 }
             },

--- a/crates/mir-issues/src/lib.rs
+++ b/crates/mir-issues/src/lib.rs
@@ -37,6 +37,8 @@ impl fmt::Display for Severity {
 pub struct Location {
     pub file: Arc<str>,
     pub line: u32,
+    /// Last line of the issue range (inclusive, 1-based). Equal to `line` for single-line issues.
+    pub line_end: u32,
     /// 0-based Unicode char-count (code-point) column of the issue start.
     pub col_start: u16,
     /// 0-based Unicode char-count (code-point) column of the issue end (exclusive).


### PR DESCRIPTION
## Summary

- Add `line_end` to `Location` — issues now carry a full source range (start + end line), enabling multi-line range highlighting in editors and code scanning tools. All emitters updated to populate it from span end offsets.
- SARIF `region` now includes `endLine` alongside the existing `startLine`.
- Fix column off-by-one: `startColumn`/`endColumn` are now correctly 1-based per SARIF 2.1.0 §3.30.5 (previously 0-based).
- Add `rank` to results (Error → 90, Warning → 95, Info → 99) matching Psalm's scoring range.
- Add `properties.tags` to rules (`"security"` for taint issues, `"maintainability"` for all others).
- Add `defaultConfiguration.level` per rule so the GitHub Code Scanning rules panel shows correct severity.
- Add `partialFingerprints.primaryLocationLineHash` (FNV-1a of rule name + snippet) so GitHub Code Scanning can track findings across commits without re-opening resolved issues.

## Test plan

- [ ] All existing tests pass (`cargo test --workspace`)
- [ ] Run `mir --format sarif` on a PHP project and validate the output against the [SARIF 2.1.0 schema](https://github.com/oasis-tcs/sarif-spec/blob/master/Schemata/sarif-schema-2.1.0.json)
- [ ] Upload SARIF to a GitHub repository via the Code Scanning API and verify findings appear with correct severity, rank, and tags
- [ ] Confirm multi-line issues (e.g. a multi-line return statement) show `endLine > startLine`