### PR TITLE
feat: distribute mir as a composer package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build and upload
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          # Default archive name is `$bin-$target.$ext` => `mir-<target>.tar.gz`
+          # (.zip on Windows). Mir\Composer\Installer expects this exact form.
+          bin: mir
+          target: ${{ matrix.target }}
+          manifest_path: crates/mir-cli/Cargo.toml
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Composer package `mir-analyzer/mir`. A `post-install-cmd` / `post-update-cmd` hook downloads the prebuilt `mir` binary matching the installed version and host platform from GitHub Releases, verifies the SHA-256 sidecar, and exposes `vendor/bin/mir`. Single-entry extraction with strict path-traversal and symlink rejection. Supported targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
+- `Release` GitHub Actions workflow building and uploading per-target archives + sha256 sidecars on `v*` tags.
+
+### Fixed
+
+- `cargo install mir-cli` references in README and docs corrected to `mir-php` (the actual crate name).
+
 ## [0.9.1] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,10 +20,22 @@ A fast, incremental PHP static analyzer written in Rust, inspired by [Psalm](htt
 
 ## Installation
 
+### From Composer (PHP projects)
+
+```bash
+composer require --dev mir-analyzer/mir
+vendor/bin/mir src/
+```
+
+A `post-install-cmd` hook downloads the prebuilt binary matching your version
+and host platform from GitHub Releases. See
+[docs/getting-started.md](docs/getting-started.md#installation) for supported
+targets.
+
 ### From crates.io
 
 ```bash
-cargo install mir-cli
+cargo install mir-php
 ```
 
 ### Build from source

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "mir-analyzer/mir",
+    "description": "Fast static analyzer for PHP",
+    "type": "library",
+    "license": "MIT",
+    "homepage": "https://github.com/jorgsowa/mir",
+    "keywords": ["static-analysis", "php", "analyzer", "psalm", "phpstan"],
+    "support": {
+        "issues": "https://github.com/jorgsowa/mir/issues",
+        "source": "https://github.com/jorgsowa/mir"
+    },
+    "require": {
+        "php": ">=8.1",
+        "ext-json": "*",
+        "ext-phar": "*",
+        "ext-zip": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mir\\Composer\\": "composer/src/"
+        }
+    },
+    "bin": [
+        "composer/bin/mir"
+    ],
+    "scripts": {
+        "post-install-cmd": "Mir\\Composer\\Installer::install",
+        "post-update-cmd": "Mir\\Composer\\Installer::install"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/composer/bin/mir
+++ b/composer/bin/mir
@@ -1,0 +1,45 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Shim that forwards execution to the prebuilt mir binary downloaded by
+ * Mir\Composer\Installer at composer install/update time.
+ *
+ * Uses proc_open with an argv array (PHP 7.4+, including Windows on PHP 8.0+)
+ * so arguments are passed without going through a shell — no quoting bugs,
+ * no command injection surface from caller-controlled argv.
+ */
+
+declare(strict_types=1);
+
+$packageRoot = dirname(__DIR__, 2);
+$binaryName = PHP_OS_FAMILY === 'Windows' ? 'mir.exe' : 'mir';
+$binary = $packageRoot . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . $binaryName;
+
+if (!is_file($binary)) {
+    fwrite(
+        STDERR,
+        "mir: prebuilt binary not found at {$binary}.\n"
+        . "Run `composer install` (or `composer update mir-analyzer/mir`) to fetch it.\n",
+    );
+    exit(1);
+}
+
+if (PHP_OS_FAMILY !== 'Windows' && !is_executable($binary)) {
+    @chmod($binary, 0755);
+}
+
+$argv = array_merge([$binary], array_slice($_SERVER['argv'], 1));
+$descriptors = [
+    0 => ['file', 'php://stdin', 'r'],
+    1 => ['file', 'php://stdout', 'w'],
+    2 => ['file', 'php://stderr', 'w'],
+];
+
+$proc = proc_open($argv, $descriptors, $pipes);
+if (!is_resource($proc)) {
+    fwrite(STDERR, "mir: failed to launch {$binary}\n");
+    exit(1);
+}
+
+$status = proc_close($proc);
+exit($status === -1 ? 1 : $status);

--- a/composer/src/Installer.php
+++ b/composer/src/Installer.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mir\Composer;
+
+use Composer\InstalledVersions;
+use Composer\Script\Event;
+
+/**
+ * Downloads the prebuilt mir binary that matches the installed package version
+ * and the host platform, verifies its sha256 checksum against the sidecar
+ * published next to the release asset, and places it in the package's bin/
+ * directory so that the composer/bin/mir shim can exec it.
+ *
+ * Trust model: integrity rests on the GitHub Releases asset and its `.sha256`
+ * sidecar being uncompromised. The sidecar is fetched over the same TLS
+ * channel as the archive, so it protects against transport corruption but not
+ * against a release-pipeline compromise. If a stronger guarantee is required,
+ * sigstore/cosign signing in the release workflow is the standard upgrade.
+ */
+final class Installer
+{
+    private const PACKAGE = 'mir-analyzer/mir';
+    private const REPO = 'jorgsowa/mir';
+    private const VERSION_MARKER = '.mir-version';
+
+    public static function install(Event $event): void
+    {
+        $io = $event->getIO();
+
+        $installPath = self::resolveInstallPath();
+        if ($installPath === null) {
+            // Running inside the source repo itself, or the package isn't
+            // installed via composer — nothing to do.
+            return;
+        }
+
+        $version = self::resolveVersion();
+        if ($version === null) {
+            $io->writeError('<warning>mir: could not determine package version, skipping binary download.</warning>');
+            return;
+        }
+
+        try {
+            [$os, $target] = self::detectPlatform();
+        } catch (\RuntimeException $e) {
+            $io->writeError('<warning>mir: ' . $e->getMessage() . '. Build from source instead.</warning>');
+            return;
+        }
+
+        $binDir = $installPath . '/bin';
+        $isWindows = $os === 'windows';
+        $binaryName = $isWindows ? 'mir.exe' : 'mir';
+        $binaryPath = $binDir . '/' . $binaryName;
+        $markerPath = $binDir . '/' . self::VERSION_MARKER;
+
+        // Skip download if the marker file confirms we already have this
+        // exact version. The marker avoids executing the (potentially
+        // tampered) existing binary just to read its --version.
+        if (
+            is_file($binaryPath)
+            && is_file($markerPath)
+            && trim((string) @file_get_contents($markerPath)) === $version
+        ) {
+            return;
+        }
+
+        $archiveExt = $isWindows ? 'zip' : 'tar.gz';
+        $archiveName = "mir-{$target}.{$archiveExt}";
+        $tag = "v{$version}";
+        $base = sprintf('https://github.com/%s/releases/download/%s', self::REPO, $tag);
+        $archiveUrl = "{$base}/{$archiveName}";
+        $checksumUrl = "{$archiveUrl}.sha256";
+
+        $io->write("<info>mir: downloading {$archiveName} for {$tag}...</info>");
+
+        if (!is_dir($binDir) && !@mkdir($binDir, 0755, true) && !is_dir($binDir)) {
+            throw new \RuntimeException("mir: failed to create {$binDir}");
+        }
+
+        $tmpArchive = self::tempPath('mir-archive-');
+        $tmpExtractDir = self::makeTempDir();
+        try {
+            self::download($archiveUrl, $tmpArchive);
+
+            $expected = self::parseChecksum(self::httpGet($checksumUrl));
+            $actual = hash_file('sha256', $tmpArchive);
+            if ($actual === false || !hash_equals($expected, $actual)) {
+                throw new \RuntimeException(
+                    "mir: checksum mismatch for {$archiveName}"
+                    . " (expected {$expected}, got " . var_export($actual, true) . ')',
+                );
+            }
+
+            $extractedBinary = $isWindows
+                ? self::extractZipEntry($tmpArchive, $tmpExtractDir, $binaryName)
+                : self::extractTarEntry($tmpArchive, $tmpExtractDir, $binaryName);
+
+            self::assertContainedIn($extractedBinary, $tmpExtractDir);
+            if (!is_file($extractedBinary) || is_link($extractedBinary)) {
+                throw new \RuntimeException("mir: extracted entry is not a regular file: {$extractedBinary}");
+            }
+
+            // Atomic-ish replace: copy to a sibling tempfile in $binDir then rename.
+            $stagingPath = $binaryPath . '.new';
+            if (!@copy($extractedBinary, $stagingPath)) {
+                throw new \RuntimeException("mir: failed to write {$stagingPath}");
+            }
+            if (!$isWindows) {
+                @chmod($stagingPath, 0755);
+            }
+            if (!@rename($stagingPath, $binaryPath)) {
+                @unlink($stagingPath);
+                throw new \RuntimeException("mir: failed to install binary at {$binaryPath}");
+            }
+
+            if (@file_put_contents($markerPath, $version . "\n") === false) {
+                $io->writeError('<warning>mir: failed to write version marker; binary will be re-downloaded next install.</warning>');
+            }
+        } finally {
+            @unlink($tmpArchive);
+            self::rmRecursive($tmpExtractDir);
+        }
+
+        $io->write("<info>mir: installed {$tag} to {$binaryPath}</info>");
+    }
+
+    private static function resolveInstallPath(): ?string
+    {
+        if (!class_exists(InstalledVersions::class)) {
+            return null;
+        }
+        if (!InstalledVersions::isInstalled(self::PACKAGE)) {
+            return null;
+        }
+        $path = InstalledVersions::getInstallPath(self::PACKAGE);
+        return $path !== null ? rtrim($path, '/\\') : null;
+    }
+
+    private static function resolveVersion(): ?string
+    {
+        if (!class_exists(InstalledVersions::class) || !InstalledVersions::isInstalled(self::PACKAGE)) {
+            return null;
+        }
+        $pretty = InstalledVersions::getPrettyVersion(self::PACKAGE);
+        if ($pretty === null) {
+            return null;
+        }
+        $pretty = ltrim($pretty, 'v');
+        // Reject branch aliases like "dev-main" — there's no matching release.
+        if (!preg_match('/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/', $pretty)) {
+            return null;
+        }
+        return $pretty;
+    }
+
+    /**
+     * @return array{0:string,1:string} [os, rust-target-triple]
+     */
+    private static function detectPlatform(): array
+    {
+        $os = match (PHP_OS_FAMILY) {
+            'Linux' => 'linux',
+            'Darwin' => 'darwin',
+            'Windows' => 'windows',
+            default => throw new \RuntimeException('unsupported OS: ' . PHP_OS_FAMILY),
+        };
+
+        $machine = strtolower(trim((string) php_uname('m')));
+        $arch = match (true) {
+            in_array($machine, ['x86_64', 'amd64', 'x64'], true) => 'x86_64',
+            in_array($machine, ['aarch64', 'arm64'], true) => 'aarch64',
+            default => throw new \RuntimeException("unsupported architecture: {$machine}"),
+        };
+
+        $target = match ([$os, $arch]) {
+            ['linux', 'x86_64'] => 'x86_64-unknown-linux-gnu',
+            ['linux', 'aarch64'] => 'aarch64-unknown-linux-gnu',
+            ['darwin', 'x86_64'] => 'x86_64-apple-darwin',
+            ['darwin', 'aarch64'] => 'aarch64-apple-darwin',
+            ['windows', 'x86_64'] => 'x86_64-pc-windows-msvc',
+            default => throw new \RuntimeException("no prebuilt binary for {$os}-{$arch}"),
+        };
+
+        return [$os, $target];
+    }
+
+    private static function download(string $url, string $dest): void
+    {
+        $fh = fopen($dest, 'wb');
+        if ($fh === false) {
+            throw new \RuntimeException("mir: cannot write to {$dest}");
+        }
+        try {
+            $ctx = self::httpContext(60);
+            $src = @fopen($url, 'rb', false, $ctx);
+            if ($src === false) {
+                throw new \RuntimeException("mir: failed to download {$url}");
+            }
+            try {
+                if (stream_copy_to_stream($src, $fh) === false) {
+                    throw new \RuntimeException("mir: download stream failed for {$url}");
+                }
+            } finally {
+                fclose($src);
+            }
+        } finally {
+            fclose($fh);
+        }
+    }
+
+    private static function httpGet(string $url): string
+    {
+        $data = @file_get_contents($url, false, self::httpContext(30));
+        if ($data === false) {
+            throw new \RuntimeException("mir: failed to fetch {$url}");
+        }
+        return $data;
+    }
+
+    /** @return resource */
+    private static function httpContext(int $timeout)
+    {
+        return stream_context_create([
+            'http' => [
+                'follow_location' => 1,
+                'max_redirects' => 5,
+                'header' => "User-Agent: mir-composer-installer\r\n",
+                'timeout' => $timeout,
+                'ignore_errors' => false,
+            ],
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
+        ]);
+    }
+
+    private static function parseChecksum(string $content): string
+    {
+        $first = strtok($content, "\n");
+        if ($first === false) {
+            throw new \RuntimeException('mir: empty checksum file');
+        }
+        $hash = strtolower(trim((string) strtok($first, " \t")));
+        if (!preg_match('/^[0-9a-f]{64}$/', $hash)) {
+            throw new \RuntimeException('mir: malformed sha256 checksum');
+        }
+        return $hash;
+    }
+
+    /**
+     * Validate that a relative archive entry name does not attempt path
+     * traversal, absolute paths, or NUL injection. Applied to every entry
+     * before extraction.
+     */
+    private static function isSafeEntryName(string $name): bool
+    {
+        if ($name === '' || strlen($name) > 1024) {
+            return false;
+        }
+        if (str_contains($name, "\0")) {
+            return false;
+        }
+        // No absolute paths (POSIX or Windows-style).
+        if ($name[0] === '/' || $name[0] === '\\') {
+            return false;
+        }
+        if (preg_match('/^[A-Za-z]:[\\\\\/]/', $name)) {
+            return false;
+        }
+        // No `..` segments.
+        $normalized = str_replace('\\', '/', $name);
+        foreach (explode('/', $normalized) as $segment) {
+            if ($segment === '..') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Extract a single named entry from a tar.gz archive into $destDir, after
+     * validating every entry's name. Returns the absolute path to the
+     * extracted file inside $destDir.
+     */
+    private static function extractTarEntry(string $archive, string $destDir, string $entryName): string
+    {
+        if (!class_exists(\PharData::class)) {
+            throw new \RuntimeException('mir: ext-phar is required to extract tar.gz archives');
+        }
+
+        // Phar normalizes paths to their realpath in the stream URL (e.g. on
+        // macOS `/tmp` becomes `/private/tmp`), so resolve before computing
+        // the prefix used to derive relative entry names.
+        $archiveReal = realpath($archive);
+        if ($archiveReal === false) {
+            throw new \RuntimeException("mir: archive disappeared before extraction: {$archive}");
+        }
+        $phar = new \PharData($archiveReal);
+        $found = false;
+        $pharPrefix = 'phar://' . $archiveReal . '/';
+        $iterator = new \RecursiveIteratorIterator($phar, \RecursiveIteratorIterator::SELF_FIRST);
+        foreach ($iterator as $path => $file) {
+            /** @var \PharFileInfo $file */
+            $full = (string) $path;
+            $relative = str_starts_with($full, $pharPrefix)
+                ? substr($full, strlen($pharPrefix))
+                : $full;
+            if (!self::isSafeEntryName($relative)) {
+                throw new \RuntimeException("mir: rejected unsafe archive entry: {$relative}");
+            }
+            if ($file->isLink()) {
+                throw new \RuntimeException("mir: rejected symlink archive entry: {$relative}");
+            }
+            if (!$file->isFile() && !$file->isDir()) {
+                throw new \RuntimeException("mir: rejected non-regular archive entry: {$relative}");
+            }
+            if ($relative === $entryName) {
+                $found = true;
+            }
+        }
+        if (!$found) {
+            throw new \RuntimeException("mir: archive does not contain {$entryName}");
+        }
+        $phar->extractTo($destDir, $entryName, true);
+        unset($phar);
+
+        return $destDir . '/' . $entryName;
+    }
+
+    /**
+     * Extract a single named entry from a zip archive into $destDir, after
+     * validating every entry's name. Returns the absolute path to the
+     * extracted file.
+     */
+    private static function extractZipEntry(string $archive, string $destDir, string $entryName): string
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            throw new \RuntimeException('mir: ext-zip is required to extract Windows archives');
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($archive) !== true) {
+            throw new \RuntimeException("mir: failed to open zip {$archive}");
+        }
+        try {
+            $found = false;
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $name = $zip->getNameIndex($i);
+                if ($name === false || !self::isSafeEntryName($name)) {
+                    throw new \RuntimeException('mir: rejected unsafe archive entry: ' . var_export($name, true));
+                }
+                if ($name === $entryName) {
+                    $found = true;
+                }
+            }
+            if (!$found) {
+                throw new \RuntimeException("mir: archive does not contain {$entryName}");
+            }
+            if ($zip->extractTo($destDir, [$entryName]) !== true) {
+                throw new \RuntimeException('mir: failed to extract zip entry');
+            }
+        } finally {
+            $zip->close();
+        }
+
+        return $destDir . '/' . $entryName;
+    }
+
+    /**
+     * Confirm that $candidate, after symlink resolution, is contained inside
+     * $parent. Defends against extractors that might honor symlinks pointing
+     * outside the staging directory.
+     */
+    private static function assertContainedIn(string $candidate, string $parent): void
+    {
+        $realParent = realpath($parent);
+        if ($realParent === false) {
+            throw new \RuntimeException("mir: staging directory disappeared: {$parent}");
+        }
+        $candidateDir = dirname($candidate);
+        $realCandidateDir = realpath($candidateDir);
+        if ($realCandidateDir === false) {
+            throw new \RuntimeException("mir: extracted file's directory missing: {$candidate}");
+        }
+        $sep = DIRECTORY_SEPARATOR;
+        $needle = rtrim($realParent, $sep) . $sep;
+        if (
+            $realCandidateDir !== $realParent
+            && !str_starts_with($realCandidateDir . $sep, $needle)
+        ) {
+            throw new \RuntimeException("mir: extracted path escaped staging dir: {$candidate}");
+        }
+    }
+
+    private static function tempPath(string $prefix): string
+    {
+        $path = tempnam(sys_get_temp_dir(), $prefix);
+        if ($path === false) {
+            throw new \RuntimeException('mir: failed to create temporary file');
+        }
+        return $path;
+    }
+
+    private static function makeTempDir(): string
+    {
+        $base = sys_get_temp_dir();
+        for ($i = 0; $i < 8; $i++) {
+            $candidate = $base . DIRECTORY_SEPARATOR . 'mir-extract-' . bin2hex(random_bytes(8));
+            if (@mkdir($candidate, 0700)) {
+                return $candidate;
+            }
+        }
+        throw new \RuntimeException('mir: failed to create temporary directory');
+    }
+
+    private static function rmRecursive(string $path): void
+    {
+        if (!is_dir($path) || is_link($path)) {
+            @unlink($path);
+            return;
+        }
+        $entries = @scandir($path);
+        if ($entries !== false) {
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                self::rmRecursive($path . DIRECTORY_SEPARATOR . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,31 @@ This guide walks you through installing mir, running your first analysis, and un
 
 ## Installation
 
-### From crates.io (recommended)
+### From Composer (recommended for PHP projects)
 
 ```bash
-cargo install mir-cli
+composer require --dev mir-analyzer/mir
+```
+
+The package is a thin wrapper: a `post-install-cmd` hook downloads the
+prebuilt `mir` binary that matches the installed version and host platform
+from [GitHub Releases](https://github.com/jorgsowa/mir/releases), verifies
+its SHA-256 checksum, and places it at `vendor/mir-analyzer/mir/bin/mir`.
+Composer exposes it as `vendor/bin/mir`:
+
+```bash
+vendor/bin/mir src/
+```
+
+Prebuilt binaries are published for `x86_64-unknown-linux-gnu`,
+`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`,
+and `x86_64-pc-windows-msvc`. On other platforms install with `cargo` or
+build from source.
+
+### From crates.io
+
+```bash
+cargo install mir-php
 ```
 
 ### Build from source


### PR DESCRIPTION
## Summary

Adds a Composer wrapper (`mir-analyzer/mir`) so PHP projects can install mir without `cargo`:

```bash
composer require --dev mir-analyzer/mir
vendor/bin/mir src/
```

The package contains no analyzer logic. A `post-install-cmd` / `post-update-cmd` hook downloads the prebuilt `mir` binary that matches the installed version and host platform from GitHub Releases, verifies its `.sha256` sidecar, and exposes it as `vendor/bin/mir`.

Also includes `.github/workflows/release.yml` that builds and uploads per-target archives + sha256 sidecars on `v*` tags via `taiki-e/upload-rust-binary-action` for: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.

Drive-by: corrected stale `cargo install mir-cli` references in README and docs to `mir-php` (the actual crate name in `crates/mir-cli/Cargo.toml`).

## Security hardening

- **Single-entry extraction.** Installer enumerates archive entries and rejects any with absolute paths, `..` segments, NUL bytes, Windows drive letters, symlinks, or non-regular types. Only the expected `mir` / `mir.exe` entry is extracted, into a fresh `0700` tempdir. Manually verified with a Python-crafted tar containing `../escape/mir` — extraction is rejected and no file escapes.
- **Containment check.** After extraction, `realpath` confirms the file is inside the staging directory before copy.
- **Atomic-ish install** via `<binary>.new` + `rename`.
- **No exec of pre-existing binary.** Version is tracked with a `bin/.mir-version` marker file, so the installer never has to run the previous (potentially tampered) binary just to read `--version`.
- **Composer bin shim** uses `proc_open` with an argv array (no shell), avoiding shell-quoting bugs / argv injection. Works cross-platform on PHP 8.1+.
- **TLS** peer + name verification pinned in the HTTP context.

## Trust model

Integrity rests on GitHub Releases and the release workflow being uncompromised. The `.sha256` sidecar is fetched over the same TLS channel as the archive — it protects against transport corruption only. Sigstore / cosign signing in the release workflow is the standard upgrade if stronger guarantees are required later. (Comment in `Installer.php` calls this out.)

## Test plan

- [ ] After this lands, tag a `v0.9.2` (or whatever) so the release workflow runs and uploads archives + `.sha256` files.
- [ ] Register `mir-analyzer/mir` on Packagist (pointing at this repo).
- [ ] In a scratch PHP project: `composer require --dev mir-analyzer/mir:^0.9` and confirm `vendor/bin/mir --version` works on linux-x86_64 and darwin-arm64.
- [ ] Confirm `composer install` inside this repo itself is a no-op (the installer detects it's the source repo via `InstalledVersions::isInstalled` and returns early).