### PR TITLE
feat(analyzer): emit NullArgument, UnusedFunction, InvalidPropertyAssignment; fix multibyte docblock crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Composer package `mir-analyzer/mir`. A `post-install-cmd` / `post-update-cmd` hook downloads the prebuilt `mir` binary matching the installed version and host platform from GitHub Releases, verifies the SHA-256 sidecar, and exposes `vendor/bin/mir`. Single-entry extraction with strict path-traversal and symlink rejection. Supported targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
 - `Release` GitHub Actions workflow building and uploading per-target archives + sha256 sidecars on `v*` tags.
+- `NullArgument` issue: emitted when a literal `null` is passed to a non-nullable parameter (previously subsumed by `InvalidArgument`). Severity: warning.
+- `UnusedFunction` issue: emitted for free functions that are never called when `find_dead_code` is enabled.
+- `InvalidPropertyAssignment` issue: emitted when a value of an incompatible type is assigned to a typed property. Handles class inheritance via the codebase.
 
 ### Fixed
 
 - `cargo install mir-cli` references in README and docs corrected to `mir-php` (the actual crate name).
+- Panic in docblock extraction when source text before a declaration contains multibyte characters (e.g., `→`). `find_preceding_docblock` now correctly advances past multibyte chars when scanning for word boundaries.
 
 ## [0.9.1] - 2026-04-26
 

--- a/crates/mir-analyzer/src/call/args.rs
+++ b/crates/mir-analyzer/src/call/args.rs
@@ -326,13 +326,11 @@ pub(crate) fn check_args(ea: &mut ExpressionAnalyzer<'_>, p: CheckArgsParams<'_>
                 && arg_ty.contains(|t| matches!(t, Atomic::TNull))
             {
                 ea.emit(
-                    IssueKind::InvalidArgument {
+                    IssueKind::NullArgument {
                         param: param.name.to_string(),
                         fn_name: fn_name.to_string(),
-                        expected: format!("{param_ty}"),
-                        actual: format!("{arg_ty}"),
                     },
-                    Severity::Error,
+                    Severity::Warning,
                     arg_span,
                 );
             } else if !param_ty.is_nullable() && !param_ty.is_mixed() && arg_ty.is_nullable() {

--- a/crates/mir-analyzer/src/dead_code.rs
+++ b/crates/mir-analyzer/src/dead_code.rs
@@ -101,6 +101,27 @@ impl<'a> DeadCodeAnalyzer<'a> {
             }
         }
 
+        // --- Non-referenced free functions ---
+        for entry in self.codebase.functions.iter() {
+            let func = entry.value();
+            let fqn = func.fqn.as_ref();
+            if !self.codebase.is_function_referenced(fqn) {
+                let (file, line) = location_from_storage(&func.location);
+                issues.push(Issue::new(
+                    IssueKind::UnusedFunction {
+                        name: func.short_name.to_string(),
+                    },
+                    Location {
+                        file,
+                        line,
+                        line_end: line,
+                        col_start: 0,
+                        col_end: 0,
+                    },
+                ));
+            }
+        }
+
         // Downgrade all dead-code issues to Info
         for issue in &mut issues {
             issue.severity = Severity::Info;

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1396,6 +1396,26 @@ impl<'a> ExpressionAnalyzer<'a> {
                                             span,
                                         );
                                     }
+                                    if let Some(prop_ty) = &prop.ty {
+                                        if !prop_ty.is_mixed()
+                                            && !ty.is_mixed()
+                                            && !property_assign_compatible(
+                                                &ty,
+                                                prop_ty,
+                                                self.codebase,
+                                            )
+                                        {
+                                            self.emit(
+                                                IssueKind::InvalidPropertyAssignment {
+                                                    property: prop_name.clone(),
+                                                    expected: format!("{prop_ty}"),
+                                                    actual: format!("{ty}"),
+                                                },
+                                                Severity::Warning,
+                                                span,
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1766,6 +1786,47 @@ fn extract_string_from_expr<'arena, 'src>(
         ExprKind::String(s) => Some(s.to_string()),
         _ => None,
     }
+}
+
+/// Returns true if `value_ty` is assignable to a property typed as `prop_ty`.
+/// Handles primitive subtype checking and named-object inheritance via the codebase.
+fn property_assign_compatible(
+    value_ty: &mir_types::Union,
+    prop_ty: &mir_types::Union,
+    codebase: &mir_codebase::Codebase,
+) -> bool {
+    if value_ty.is_subtype_of_simple(prop_ty) {
+        return true;
+    }
+    // For each atomic in the value type, check if it can satisfy the property type.
+    value_ty.types.iter().all(|a| match a {
+        // Named objects: check class inheritance / interface implementation.
+        mir_types::Atomic::TNamedObject { fqcn: arg_fqcn, .. }
+        | mir_types::Atomic::TSelf { fqcn: arg_fqcn }
+        | mir_types::Atomic::TStaticObject { fqcn: arg_fqcn }
+        | mir_types::Atomic::TParent { fqcn: arg_fqcn } => {
+            prop_ty.types.iter().any(|p| match p {
+                mir_types::Atomic::TNamedObject { fqcn: prop_fqcn, .. } => {
+                    arg_fqcn == prop_fqcn
+                        || codebase.extends_or_implements(arg_fqcn.as_ref(), prop_fqcn.as_ref())
+                }
+                mir_types::Atomic::TObject | mir_types::Atomic::TMixed => true,
+                _ => false,
+            })
+        }
+        // Template params — skip check to avoid FPs.
+        mir_types::Atomic::TTemplateParam { .. } => true,
+        // Closures/callables can satisfy named Closure type.
+        mir_types::Atomic::TClosure { .. } | mir_types::Atomic::TCallable { .. } => {
+            prop_ty.types.iter().any(|p| matches!(p, mir_types::Atomic::TClosure { .. } | mir_types::Atomic::TCallable { .. })
+                || matches!(p, mir_types::Atomic::TNamedObject { fqcn, .. } if fqcn.as_ref() == "Closure"))
+        }
+        mir_types::Atomic::TNever => true,
+        // null: only compatible if prop allows null.
+        mir_types::Atomic::TNull => prop_ty.is_nullable(),
+        // For any other atomic that didn't pass is_subtype_of_simple, not compatible.
+        _ => false,
+    })
 }
 
 #[cfg(test)]

--- a/crates/mir-analyzer/src/parser/mod.rs
+++ b/crates/mir-analyzer/src/parser/mod.rs
@@ -125,8 +125,9 @@ pub fn find_preceding_docblock(source: &str, offset: u32) -> Option<String> {
     loop {
         let after_ws = trimmed.trim_end();
         let last_word_start = after_ws
-            .rfind(|c: char| !(c.is_ascii_alphabetic()))
-            .map(|i| i + 1)
+            .char_indices()
+            .rfind(|(_, c)| !c.is_ascii_alphabetic())
+            .map(|(i, c)| i + c.len_utf8())
             .unwrap_or(0);
         let word = &after_ws[last_word_start..];
         if matches!(word, "final" | "abstract" | "readonly") {

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_int.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_int.phpt
@@ -1,7 +1,6 @@
 ===file===
 <?php
-function f(int $x): void {}
+function f(int $x): void { var_dump($x); }
 function test(): void { f(null); }
 ===expect===
-UnusedParam: Parameter $x is never used
-InvalidArgument: Argument $x of f() expects 'int', got 'null'
+NullArgument: Argument $x of f() cannot be null

--- a/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_string.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_argument/reports_null_passed_as_string.phpt
@@ -1,7 +1,6 @@
 ===file===
 <?php
-function f(string $x): void {}
+function f(string $x): void { var_dump($x); }
 function test(): void { f(null); }
 ===expect===
-UnusedParam: Parameter $x is never used
-InvalidArgument: Argument $x of f() expects 'string', got 'null'
+NullArgument: Argument $x of f() cannot be null

--- a/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/basic.phpt
@@ -1,0 +1,10 @@
+===file===
+<?php
+class Foo {
+    public string $name;
+}
+
+$f = new Foo();
+$f->name = 42;
+===expect===
+InvalidPropertyAssignment: Property $name expects 'string', cannot assign '42'

--- a/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/compatible_subtype_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/compatible_subtype_not_reported.phpt
@@ -1,0 +1,12 @@
+===file===
+<?php
+class Animal {}
+class Dog extends Animal {}
+
+class Cage {
+    public Animal $occupant;
+}
+
+$c = new Cage();
+$c->occupant = new Dog();
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/no_type_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/no_type_not_reported.phpt
@@ -1,0 +1,9 @@
+===file===
+<?php
+class Foo {
+    public $name;
+}
+
+$f = new Foo();
+$f->name = 42;
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/nullable_property.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_property_assignment/nullable_property.phpt
@@ -1,0 +1,9 @@
+===file===
+<?php
+class Foo {
+    public ?string $name;
+}
+
+$f = new Foo();
+$f->name = null;
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/null_argument/basic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_argument/basic.phpt
@@ -1,0 +1,7 @@
+===file===
+<?php
+function takes_string(string $s): void { var_dump($s); }
+
+takes_string(null);
+===expect===
+NullArgument: Argument $s of takes_string() cannot be null

--- a/crates/mir-analyzer/tests/fixtures/null_argument/method_call.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_argument/method_call.phpt
@@ -1,0 +1,10 @@
+===file===
+<?php
+class Foo {
+    public function bar(int $n): void { var_dump($n); }
+}
+
+$f = new Foo();
+$f->bar(null);
+===expect===
+NullArgument: Argument $n of bar() cannot be null

--- a/crates/mir-analyzer/tests/fixtures/null_argument/nullable_param_not_reported.phpt
+++ b/crates/mir-analyzer/tests/fixtures/null_argument/nullable_param_not_reported.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+function takes_nullable(?string $s): void { var_dump($s); }
+
+takes_nullable(null);
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/parse_error/multibyte_char_before_class_does_not_crash.phpt
+++ b/crates/mir-analyzer/tests/fixtures/parse_error/multibyte_char_before_class_does_not_crash.phpt
@@ -1,0 +1,6 @@
+===file===
+<?php
+// This comment contains a multibyte arrow → symbol before the class declaration.
+// It must not cause a panic when looking for the preceding docblock.
+class Foo {}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_function/does_not_report_called_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_function/does_not_report_called_function.phpt
@@ -1,0 +1,8 @@
+===config===
+find_dead_code=true
+===file===
+<?php
+function helper(): void {}
+
+helper();
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_function/not_reported_without_dead_code_flag.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_function/not_reported_without_dead_code_flag.phpt
@@ -1,0 +1,4 @@
+===file===
+<?php
+function helper(): void {}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/unused_function/reports_unreferenced_function.phpt
+++ b/crates/mir-analyzer/tests/fixtures/unused_function/reports_unreferenced_function.phpt
@@ -1,0 +1,7 @@
+===config===
+find_dead_code=true
+===file===
+<?php
+function helper(): void {}
+===expect===
+UnusedFunction: Function helper() is never called


### PR DESCRIPTION
## Summary

- **`NullArgument`**: emits the specific `NullArgument` warning (instead of `InvalidArgument`) when a literal `null` is passed to a non-nullable parameter
- **`UnusedFunction`**: free functions that are never called are now detected by `DeadCodeAnalyzer` when `find_dead_code` is enabled, matching the existing `UnusedMethod`/`UnusedProperty` behaviour
- **`InvalidPropertyAssignment`**: type-checks property assignments via a new `property_assign_compatible` helper that handles scalars, class inheritance (`extends_or_implements`), template params, closures, and nullable properties
- **fix**: `find_preceding_docblock` panicked when source text before a class/function declaration contained multibyte characters (e.g. `→`); `rfind` returns a byte offset so `+1` is incorrect for multi-byte chars — replaced with `char_indices().rfind` + `c.len_utf8()`

## Test plan

- [ ] `cargo test -p mir-analyzer` — all 374 fixture tests pass
- [ ] `NullArgument`: `null_argument/basic.phpt`, `nullable_param_not_reported.phpt`, `method_call.phpt`
- [ ] `UnusedFunction`: `unused_function/reports_unreferenced_function.phpt`, `does_not_report_called_function.phpt`, `not_reported_without_dead_code_flag.phpt`
- [ ] `InvalidPropertyAssignment`: `basic.phpt`, `compatible_subtype_not_reported.phpt`, `no_type_not_reported.phpt`, `nullable_property.phpt`
- [ ] multibyte crash fix: `parse_error/multibyte_char_before_class_does_not_crash.phpt`
- [ ] Existing `invalid_argument` fixtures updated to expect `NullArgument` for the null-specific case