### PR TITLE
chore: update php-rs-parser/php-ast to 0.9.4 and adopt new AST fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "php-ast"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4dec5c8aadf9386b60ecc8744944f3f364b696b28b2ea42b19822d1cbd34028"
+checksum = "02cefd278d319800f8c8d01250dc6d219f4283a0faa663f0975e93af82619243"
 dependencies = [
  "bumpalo",
  "serde",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "php-lexer"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6147f218d7d82fdd131768b7c1155d611e5df9504571dd17fdf6e407d25cf7"
+checksum = "85216a04b4c5bb9435723a8c28578e134256744620bb1805bfe4fe18f70a4309"
 dependencies = [
  "memchr",
  "php-ast",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "php-rs-parser"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfed336cf633e615ea802559f025c6ecf53b635a97c09fe389aee13c7d90b8b2"
+checksum = "6f9c80822d2208b25d08ffebc4ff9813e0a2e6a4e4e08dcc1ac57929560c6e6e"
 dependencies = [
  "bumpalo",
  "memchr",

--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -825,6 +825,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 name: c.name.into(),
                                 ty: Union::mixed(),
                                 visibility: c.visibility.map(|v| Self::convert_visibility(Some(v))),
+                                is_final: c.is_final,
                                 location: Some(self.location(member.span.start, member.span.end)),
                             };
                             own_constants.insert(c.name.into(), constant);
@@ -1015,6 +1016,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     visibility: c
                                         .visibility
                                         .map(|v| Self::convert_visibility(Some(v))),
+                                    is_final: c.is_final,
                                     location: Some(
                                         self.location(member.span.start, member.span.end),
                                     ),
@@ -1170,6 +1172,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     name: c.name.into(),
                                     ty: Union::mixed(),
                                     visibility: None,
+                                    is_final: c.is_final,
                                     location: Some(
                                         self.location(member.span.start, member.span.end),
                                     ),
@@ -1258,6 +1261,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     name: c.name.into(),
                                     ty: Union::mixed(),
                                     visibility: None,
+                                    is_final: c.is_final,
                                     location: Some(
                                         self.location(member.span.start, member.span.end),
                                     ),
@@ -1281,15 +1285,19 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
             }
 
             StmtKind::Const(items) => {
-                // Check the stmt-level docblock for @since/@removed (ConstItem has no doc_comment).
-                let const_doc =
-                    crate::parser::find_preceding_docblock(self.source, stmt.span.start)
-                        .map(|t| crate::parser::DocblockParser::parse(&t))
-                        .unwrap_or_default();
-                if !self.version_allows(&const_doc) {
-                    return ControlFlow::Continue(());
-                }
                 for item in items.iter() {
+                    let const_doc = item
+                        .doc_comment
+                        .as_ref()
+                        .map(|c| crate::parser::DocblockParser::parse(c.text))
+                        .or_else(|| {
+                            crate::parser::find_preceding_docblock(self.source, item.span.start)
+                                .map(|t| crate::parser::DocblockParser::parse(&t))
+                        })
+                        .unwrap_or_default();
+                    if !self.version_allows(&const_doc) {
+                        continue;
+                    }
                     let fqn: Arc<str> = if let Some(ns) = &self.namespace {
                         format!("{}\\{}", ns, item.name).into()
                     } else {

--- a/crates/mir-codebase/src/codebase.rs
+++ b/crates/mir-codebase/src/codebase.rs
@@ -739,6 +739,7 @@ impl Codebase {
                     name: Arc::from(const_name),
                     ty: mir_types::Union::mixed(),
                     visibility: None,
+                    is_final: false,
                     location: None,
                 });
             }

--- a/crates/mir-codebase/src/storage.rs
+++ b/crates/mir-codebase/src/storage.rs
@@ -166,6 +166,8 @@ pub struct ConstantStorage {
     pub name: Arc<str>,
     pub ty: Union,
     pub visibility: Option<Visibility>,
+    #[serde(default)]
+    pub is_final: bool,
     pub location: Option<Location>,
 }
 


### PR DESCRIPTION
## Summary

- Bumps `php-ast`, `php-lexer`, and `php-rs-parser` from 0.9.3 → 0.9.4
- Adds `is_final: bool` to `ConstantStorage` and wires it up from the new `ClassConstDecl::is_final` AST field across all four collection sites (class, interface, trait, and enum constants)
- Replaces the stmt-level docblock lookup for `StmtKind::Const` with per-item `ConstItem::doc_comment` (new in 0.9.4), falling back to `find_preceding_docblock`; this makes `@since`/`@removed` filtering precise per constant rather than all-or-nothing per `const` statement

## What changed in php-rs-parser 0.9.4

- `ClassConstDecl` gains `is_final: bool` — the `final` modifier on PHP 8.1+ constants was previously parsed but dropped before reaching the AST
- `ConstItem` gains `doc_comment: Option<Comment>` — top-level constants now carry their doc comment in the AST node

## Test plan

- [ ] `cargo test` passes (374 analyzer tests, 101 codebase tests, all others green)
- [ ] `cargo build --release` succeeds