### PR TITLE
chore: rename Composer package to miropen/mir-php and release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-04-26
 
 ### Added
 
-- Composer package `mir-php/analyzer`. A `post-install-cmd` / `post-update-cmd` hook downloads the prebuilt `mir` binary matching the installed version and host platform from GitHub Releases, verifies the SHA-256 sidecar, and exposes `vendor/bin/mir`. Single-entry extraction with strict path-traversal and symlink rejection. Supported targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
+- Composer package `miropen/mir-php`. A `post-install-cmd` / `post-update-cmd` hook downloads the prebuilt `mir` binary matching the installed version and host platform from GitHub Releases, verifies the SHA-256 sidecar, and exposes `vendor/bin/mir`. Single-entry extraction with strict path-traversal and symlink rejection. Supported targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
 - `Release` GitHub Actions workflow building and uploading per-target archives + sha256 sidecars on `v*` tags.
 - `NullArgument` issue: emitted when a literal `null` is passed to a non-nullable parameter (previously subsumed by `InvalidArgument`). Severity: warning.
 - `UnusedFunction` issue: emitted for free functions that are never called when `find_dead_code` is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 authors = ["Jorg Sowa <jorg.sowa@gmail.com>"]
@@ -18,10 +18,10 @@ homepage = "https://github.com/jorgsowa/mir"
 
 [workspace.dependencies]
 # Internal crates
-mir-types      = { path = "crates/mir-types",      version = "0.9.1" }
-mir-issues     = { path = "crates/mir-issues",     version = "0.9.1" }
-mir-codebase   = { path = "crates/mir-codebase",   version = "0.9.1" }
-mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.9.1" }
+mir-types      = { path = "crates/mir-types",      version = "0.10.0" }
+mir-issues     = { path = "crates/mir-issues",     version = "0.10.0" }
+mir-codebase   = { path = "crates/mir-codebase",   version = "0.10.0" }
+mir-analyzer   = { path = "crates/mir-analyzer",   version = "0.10.0" }
 
 # PHP parsing
 php-rs-parser = "0.9"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A fast, incremental PHP static analyzer written in Rust, inspired by [Psalm](htt
 ### From Composer (PHP projects)
 
 ```bash
-composer require --dev mir-php/analyzer
+composer require --dev miropen/mir-php
 vendor/bin/mir src/
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mir-php/analyzer",
+    "name": "miropen/mir-php",
     "description": "Fast static analyzer for PHP",
     "type": "library",
     "license": "MIT",

--- a/composer/src/Installer.php
+++ b/composer/src/Installer.php
@@ -21,7 +21,7 @@ use Composer\Script\Event;
  */
 final class Installer
 {
-    private const PACKAGE = 'mir-php/analyzer';
+    private const PACKAGE = 'miropen/mir-php';
     private const REPO = 'jorgsowa/mir';
     private const VERSION_MARKER = '.mir-version';
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,13 +7,13 @@ This guide walks you through installing mir, running your first analysis, and un
 ### From Composer (recommended for PHP projects)
 
 ```bash
-composer require --dev mir-php/analyzer
+composer require --dev miropen/mir-php
 ```
 
 The package is a thin wrapper: a `post-install-cmd` hook downloads the
 prebuilt `mir` binary that matches the installed version and host platform
 from [GitHub Releases](https://github.com/jorgsowa/mir/releases), verifies
-its SHA-256 checksum, and places it at `vendor/mir-php/analyzer/bin/mir`.
+its SHA-256 checksum, and places it at `vendor/miropen/mir-php/bin/mir`.
 Composer exposes it as `vendor/bin/mir`:
 
 ```bash


### PR DESCRIPTION
## Summary

- Renames the Composer package from `mir-php/analyzer` to `miropen/mir-php` in `composer.json`, `Installer.php`, `README.md`, and `docs/getting-started.md`
- Bumps the workspace version from `0.9.1` to `0.10.0` in `Cargo.toml`
- Promotes the `[Unreleased]` changelog section to `[0.10.0] - 2026-04-26`

## Test plan

- [ ] Verify `composer require --dev miropen/mir-php` resolves once published to Packagist
- [ ] Verify `vendor/bin/mir` shim works after install under the new package path
- [ ] Confirm `cargo install mir-php` still works (crate name unchanged)