### PR TITLE
chore: bump Cargo.lock to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "blake3",
  "bumpalo",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "dashmap",
  "indexmap",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "serde",


### PR DESCRIPTION
Commits the `Cargo.lock` version bump from 0.9.1 → 0.10.0 that was missing from the release branch merge. Required before tagging `v0.10.0`.