### PR TITLE
feat(analyzer): emit InvalidDocblock for malformed type annotations

### DIFF
--- a/crates/mir-analyzer/src/collector.rs
+++ b/crates/mir-analyzer/src/collector.rs
@@ -20,7 +20,7 @@ use mir_codebase::storage::{
     TraitStorage, Visibility,
 };
 use mir_codebase::{ClassStorage, Codebase};
-use mir_issues::{Issue, IssueBuffer};
+use mir_issues::{Issue, IssueBuffer, IssueKind};
 use mir_types::Union;
 
 // ---------------------------------------------------------------------------
@@ -353,6 +353,35 @@ impl<'a> DefinitionCollector<'a> {
     }
 
     // -----------------------------------------------------------------------
+    // Docblock issue emission
+    // -----------------------------------------------------------------------
+
+    fn emit_docblock_issues(&mut self, doc: &crate::parser::ParsedDocblock, span_start: u32) {
+        if self.php_version.is_some() || doc.invalid_annotations.is_empty() {
+            return;
+        }
+        let lc = self.source_map.offset_to_line_col(span_start);
+        let line = lc.line + 1;
+        let suppressed = doc.suppressed_issues.iter().any(|s| s == "InvalidDocblock");
+        for msg in &doc.invalid_annotations {
+            let issue = Issue::new(
+                IssueKind::InvalidDocblock {
+                    message: msg.clone(),
+                },
+                mir_issues::Location {
+                    file: self.file.clone(),
+                    line,
+                    line_end: line,
+                    col_start: 0,
+                    col_end: 0,
+                },
+            );
+            self.issues
+                .add(if suppressed { issue.suppress() } else { issue });
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Visibility conversion
     // -----------------------------------------------------------------------
 
@@ -543,6 +572,7 @@ impl<'a> DefinitionCollector<'a> {
             return;
         };
         let parsed = crate::parser::DocblockParser::parse(&doc_text);
+        self.emit_docblock_issues(&parsed, stmt.span.start);
         let Some(var_type) = parsed.var_type else {
             return;
         };
@@ -621,6 +651,10 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     .as_ref()
                     .map(|c| crate::parser::DocblockParser::parse(c.text))
                     .unwrap_or_default();
+
+                if let Some(c) = decl.doc_comment.as_ref() {
+                    self.emit_docblock_issues(&doc, c.span.start);
+                }
 
                 if !self.version_allows(&doc) {
                     return ControlFlow::Continue(());
@@ -729,6 +763,13 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     })
                     .unwrap_or_default();
 
+                let class_doc_span = decl
+                    .doc_comment
+                    .as_ref()
+                    .map(|c| c.span.start)
+                    .unwrap_or(stmt.span.start);
+                self.emit_docblock_issues(&class_doc, class_doc_span);
+
                 if !self.version_allows(&class_doc) {
                     return ControlFlow::Continue(());
                 }
@@ -788,6 +829,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                 })
                                 .unwrap_or_default();
+                            let prop_doc_span = p
+                                .doc_comment
+                                .as_ref()
+                                .map(|c| c.span.start)
+                                .unwrap_or(member.span.start);
+                            self.emit_docblock_issues(&prop_doc, prop_doc_span);
                             if !self.version_allows(&prop_doc) {
                                 continue;
                             }
@@ -818,6 +865,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                 })
                                 .unwrap_or_default();
+                            let const_doc_span = c
+                                .doc_comment
+                                .as_ref()
+                                .map(|c| c.span.start)
+                                .unwrap_or(member.span.start);
+                            self.emit_docblock_issues(&const_doc, const_doc_span);
                             if !self.version_allows(&const_doc) {
                                 continue;
                             }
@@ -956,6 +1009,13 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                     })
                     .unwrap_or_default();
 
+                let iface_doc_span = decl
+                    .doc_comment
+                    .as_ref()
+                    .map(|c| c.span.start)
+                    .unwrap_or(stmt.span.start);
+                self.emit_docblock_issues(&iface_doc, iface_doc_span);
+
                 if !self.version_allows(&iface_doc) {
                     return ControlFlow::Continue(());
                 }
@@ -1005,6 +1065,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                 })
                                 .unwrap_or_default();
+                            let const_doc_span = c
+                                .doc_comment
+                                .as_ref()
+                                .map(|c| c.span.start)
+                                .unwrap_or(member.span.start);
+                            self.emit_docblock_issues(&const_doc, const_doc_span);
                             if !self.version_allows(&const_doc) {
                                 continue;
                             }
@@ -1056,6 +1122,13 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                             .map(|t| crate::parser::DocblockParser::parse(&t))
                     })
                     .unwrap_or_default();
+
+                let trait_doc_span = decl
+                    .doc_comment
+                    .as_ref()
+                    .map(|c| c.span.start)
+                    .unwrap_or(stmt.span.start);
+                self.emit_docblock_issues(&trait_doc, trait_doc_span);
 
                 if !self.version_allows(&trait_doc) {
                     return ControlFlow::Continue(());
@@ -1127,6 +1200,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                 })
                                 .unwrap_or_default();
+                            let prop_doc_span = p
+                                .doc_comment
+                                .as_ref()
+                                .map(|c| c.span.start)
+                                .unwrap_or(member.span.start);
+                            self.emit_docblock_issues(&prop_doc, prop_doc_span);
                             if !self.version_allows(&prop_doc) {
                                 continue;
                             }
@@ -1163,6 +1242,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                 })
                                 .unwrap_or_default();
+                            let const_doc_span = c
+                                .doc_comment
+                                .as_ref()
+                                .map(|c| c.span.start)
+                                .unwrap_or(member.span.start);
+                            self.emit_docblock_issues(&const_doc, const_doc_span);
                             if !self.version_allows(&const_doc) {
                                 continue;
                             }
@@ -1295,6 +1380,12 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                 .map(|t| crate::parser::DocblockParser::parse(&t))
                         })
                         .unwrap_or_default();
+                    let const_doc_span = item
+                        .doc_comment
+                        .as_ref()
+                        .map(|c| c.span.start)
+                        .unwrap_or(item.span.start);
+                    self.emit_docblock_issues(&const_doc, const_doc_span);
                     if !self.version_allows(&const_doc) {
                         continue;
                     }
@@ -1326,6 +1417,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
                                     )
                                     .map(|t| crate::parser::DocblockParser::parse(&t))
                                     .unwrap_or_default();
+                                    self.emit_docblock_issues(&define_doc, stmt.span.start);
                                     if self.version_allows(&define_doc) {
                                         let fqn: Arc<str> = Arc::from(&**name);
                                         self.slice.constants.push((fqn, Union::mixed()));
@@ -1345,7 +1437,7 @@ impl<'a, 'arena, 'src> Visitor<'arena, 'src> for DefinitionCollector<'a> {
 
 impl<'a> DefinitionCollector<'a> {
     fn build_method_storage(
-        &self,
+        &mut self,
         m: &php_ast::ast::MethodDecl<'_, '_>,
         class_fqcn: &str,
         span: Option<&php_ast::Span>,
@@ -1356,6 +1448,10 @@ impl<'a> DefinitionCollector<'a> {
             .as_ref()
             .map(|c| crate::parser::DocblockParser::parse(c.text))
             .unwrap_or_default();
+
+        if let Some(c) = m.doc_comment.as_ref() {
+            self.emit_docblock_issues(&doc, c.span.start);
+        }
 
         if !self.version_allows(&doc) {
             return None;

--- a/crates/mir-analyzer/src/parser/docblock.rs
+++ b/crates/mir-analyzer/src/parser/docblock.rs
@@ -26,19 +26,39 @@ impl DocblockParser {
                     name: Some(n),
                     ..
                 } => {
+                    if let Some(msg) = validate_type_str(ty_s, "param") {
+                        result.invalid_annotations.push(msg);
+                    }
                     result.params.push((
                         n.trim_start_matches('$').to_string(),
                         parse_type_string(ty_s),
                     ));
                 }
+                // @param with a type but no variable name — can happen when an unclosed generic
+                // swallows the rest of the tag body (e.g. `@param array< $x`).
+                PhpDocTag::Param {
+                    type_str: Some(ty_s),
+                    name: None,
+                    ..
+                } => {
+                    if let Some(msg) = validate_type_str(ty_s, "param") {
+                        result.invalid_annotations.push(msg);
+                    }
+                }
                 PhpDocTag::Return {
                     type_str: Some(ty_s),
                     ..
                 } => {
+                    if let Some(msg) = validate_type_str(ty_s, "return") {
+                        result.invalid_annotations.push(msg);
+                    }
                     result.return_type = Some(parse_type_string(ty_s));
                 }
                 PhpDocTag::Var { type_str, name, .. } => {
                     if let Some(ty_s) = type_str {
+                        if let Some(msg) = validate_type_str(ty_s, "var") {
+                            result.invalid_annotations.push(msg);
+                        }
                         result.var_type = Some(parse_type_string(ty_s));
                     }
                     if let Some(n) = name {
@@ -64,6 +84,11 @@ impl DocblockParser {
                     );
                 }
                 PhpDocTag::Template { name, bound } => {
+                    if let Some(b) = bound {
+                        if let Some(msg) = validate_type_str(b, "template") {
+                            result.invalid_annotations.push(msg);
+                        }
+                    }
                     result.templates.push((
                         name.to_string(),
                         bound.map(parse_type_string),
@@ -71,6 +96,11 @@ impl DocblockParser {
                     ));
                 }
                 PhpDocTag::TemplateCovariant { name, bound } => {
+                    if let Some(b) = bound {
+                        if let Some(msg) = validate_type_str(b, "template-covariant") {
+                            result.invalid_annotations.push(msg);
+                        }
+                    }
                     result.templates.push((
                         name.to_string(),
                         bound.map(parse_type_string),
@@ -78,6 +108,11 @@ impl DocblockParser {
                     ));
                 }
                 PhpDocTag::TemplateContravariant { name, bound } => {
+                    if let Some(b) = bound {
+                        if let Some(msg) = validate_type_str(b, "template-contravariant") {
+                            result.invalid_annotations.push(msg);
+                        }
+                    }
                     result.templates.push((
                         name.to_string(),
                         bound.map(parse_type_string),
@@ -364,6 +399,8 @@ pub struct ParsedDocblock {
     pub since: Option<String>,
     /// `@removed X.Y` — first PHP version this symbol no longer exists in.
     pub removed: Option<String>,
+    /// Malformed type annotations detected during parsing.
+    pub invalid_annotations: Vec<String>,
 }
 
 impl ParsedDocblock {
@@ -721,6 +758,28 @@ fn is_inside_generics(s: &str) -> bool {
 fn normalize_fqcn(s: &str) -> String {
     // Strip leading backslash if present — we normalize all FQCNs without leading `\`
     s.trim_start_matches('\\').to_string()
+}
+
+/// Returns an error message if `s` is a malformed PHPDoc type expression, otherwise `None`.
+///
+/// Detects:
+/// - unclosed generics (`array<`, `Foo<Bar`)
+/// - `$variable` in type position (only `$this` is valid)
+fn validate_type_str(s: &str, tag: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if is_inside_generics(s) {
+        return Some(format!("@{tag} has unclosed generic type `{s}`"));
+    }
+    for part in split_union(s) {
+        let p = part.trim();
+        if p.starts_with('$') && p != "$this" {
+            return Some(format!("@{tag} contains variable `{p}` in type position"));
+        }
+    }
+    None
 }
 
 /// Parse `[static] [ReturnType] name(...)` for @method tags.
@@ -1116,5 +1175,51 @@ mod tests {
         assert!(intersection[1].contains(
             |t| matches!(t, Atomic::TNamedObject { fqcn, .. } if fqcn.as_ref() == "Countable")
         ));
+    }
+
+    #[test]
+    fn validate_unclosed_generic_return() {
+        let parsed = DocblockParser::parse("/** @return array< */");
+        assert_eq!(parsed.invalid_annotations.len(), 1);
+        assert!(
+            parsed.invalid_annotations[0].contains("unclosed generic"),
+            "got: {}",
+            parsed.invalid_annotations[0]
+        );
+    }
+
+    #[test]
+    fn validate_variable_in_type_position_param() {
+        let parsed = DocblockParser::parse("/** @param Foo|$invalid $x */");
+        assert_eq!(parsed.invalid_annotations.len(), 1);
+        assert!(
+            parsed.invalid_annotations[0].contains("$invalid"),
+            "got: {}",
+            parsed.invalid_annotations[0]
+        );
+    }
+
+    #[test]
+    fn validate_this_is_valid_in_type_position() {
+        let parsed = DocblockParser::parse("/** @return $this */");
+        assert!(
+            parsed.invalid_annotations.is_empty(),
+            "unexpected error: {:?}",
+            parsed.invalid_annotations
+        );
+    }
+
+    #[test]
+    fn validate_unclosed_generic_var() {
+        let parsed = DocblockParser::parse("/** @var array<string */");
+        assert_eq!(parsed.invalid_annotations.len(), 1);
+        assert!(parsed.invalid_annotations[0].contains("@var"));
+    }
+
+    #[test]
+    fn validate_variable_in_template_bound() {
+        let parsed = DocblockParser::parse("/** @template T of $invalid */");
+        assert_eq!(parsed.invalid_annotations.len(), 1);
+        assert!(parsed.invalid_annotations[0].contains("$invalid"));
     }
 }

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/does_not_report_this_in_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/does_not_report_this_in_return.phpt
@@ -1,0 +1,9 @@
+===file===
+<?php
+class Foo {
+    /**
+     * @return $this
+     */
+    public function self(): static { return $this; }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/does_not_report_valid_nested_generic.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/does_not_report_valid_nested_generic.phpt
@@ -1,0 +1,7 @@
+===file===
+<?php
+/**
+ * @return array<string, array<int>>
+ */
+function foo(): array { return []; }
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_on_class_method.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_on_class_method.phpt
@@ -1,0 +1,10 @@
+===file===
+<?php
+class Foo {
+    /**
+     * @return array<
+     */
+    public function bar(): mixed { return []; }
+}
+===expect===
+InvalidDocblock: Invalid docblock: @return has unclosed generic type `array<`

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_unclosed_generic_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_unclosed_generic_param.phpt
@@ -1,0 +1,9 @@
+===file===
+<?php
+/**
+ * @param array< $items
+ */
+function foo(mixed $items): void {}
+===expect===
+InvalidDocblock: Invalid docblock: @param has unclosed generic type `array< $items`
+UnusedParam: Parameter $items is never used

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_variable_in_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/reports_variable_in_return.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+/**
+ * @return $bar
+ */
+function foo(): mixed { return null; }
+===expect===
+InvalidDocblock: Invalid docblock: @return contains variable `$bar` in type position

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/suppressed_via_psalm_suppress.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/suppressed_via_psalm_suppress.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+/**
+ * @psalm-suppress InvalidDocblock
+ * @return array<
+ */
+function foo(): mixed { return []; }
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/unclosed_generic_return.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/unclosed_generic_return.phpt
@@ -1,0 +1,8 @@
+===file===
+<?php
+/**
+ * @return array<
+ */
+function foo(): mixed { return []; }
+===expect===
+InvalidDocblock: Invalid docblock: @return has unclosed generic type `array<`

--- a/crates/mir-analyzer/tests/fixtures/invalid_docblock/variable_in_type_position_param.phpt
+++ b/crates/mir-analyzer/tests/fixtures/invalid_docblock/variable_in_type_position_param.phpt
@@ -1,0 +1,9 @@
+===file===
+<?php
+/**
+ * @param Foo|$invalid $x
+ */
+function foo(mixed $x): void {}
+===expect===
+InvalidDocblock: Invalid docblock: @param contains variable `$invalid` in type position
+UnusedParam: Parameter $x is never used


### PR DESCRIPTION
## Summary

Implements #142 — makes the existing `InvalidDocblock` issue kind actually emit issues instead of silently discarding malformed PHPDoc type annotations.

Two classes of malformed annotations are now detected:

- **Unclosed generics**: `@return array<`, `@param Foo< $x`
- **Variables in type position**: `@param Foo|$invalid $x`, `@return $bar` — `$this` is the only dollar-sign type that is valid

## Changes

**`crates/mir-analyzer/src/parser/docblock.rs`**
- Add `pub invalid_annotations: Vec<String>` field to `ParsedDocblock`
- Add `fn validate_type_str(s: &str, tag: &str) -> Option<String>` using the existing `is_inside_generics` / `split_union` helpers
- Wire validation into `DocblockParser::parse` for `@param` (named and nameless), `@return`, `@var`, `@template`, `@template-covariant`, `@template-contravariant`
- Handle the edge case where an unclosed generic swallows the variable name — `@param array< $x` causes php-rs-parser to return `name: None`, so we validate the type_str even in that case

**`crates/mir-analyzer/src/collector.rs`**
- Add `emit_docblock_issues(&mut self, doc, span_start)` helper that:
  - Is a no-op for stub files (`php_version.is_some()`)
  - Respects `@psalm-suppress InvalidDocblock` on the same docblock
- Change `build_method_storage` from `&self` to `&mut self`
- Propagate `emit_docblock_issues` to all docblock parse sites: functions, classes, interfaces, traits, enums, properties, constants, `define()` calls, and global-var annotations

## Test plan

- [ ] 8 new `.phpt` fixture cases:
  - `unclosed_generic_return` — `@return array<` triggers InvalidDocblock
  - `variable_in_type_position_param` — `@param Foo|$invalid $x` triggers InvalidDocblock
  - `reports_variable_in_return` — `@return $bar` triggers InvalidDocblock
  - `reports_unclosed_generic_param` — `@param array< $items` triggers InvalidDocblock (nameless-param path)
  - `reports_on_class_method` — same detection works on class methods, not just functions
  - `does_not_report_this_in_return` — `@return $this` does NOT trigger
  - `does_not_report_valid_nested_generic` — `@return array<string, array<int>>` does NOT trigger
  - `suppressed_via_psalm_suppress` — `@psalm-suppress InvalidDocblock` silences the issue
- [ ] 5 new unit tests in `docblock.rs` module
- [ ] All 382 existing fixture tests continue to pass