### PR TITLE
feat(stubs): injectable user stubs and phpVersion root attribute

### DIFF
--- a/crates/mir-analyzer/src/project.rs
+++ b/crates/mir-analyzer/src/project.rs
@@ -36,6 +36,10 @@ pub struct ProjectAnalyzer {
     /// Target PHP language version. `None` means "not configured"; resolved to
     /// `PhpVersion::LATEST` when passed down to `StatementsAnalyzer`.
     pub php_version: Option<PhpVersion>,
+    /// Additional stub files to parse before analysis (absolute paths).
+    pub stub_files: Vec<PathBuf>,
+    /// Additional stub directories to walk and parse before analysis (absolute paths).
+    pub stub_dirs: Vec<PathBuf>,
 }
 
 impl ProjectAnalyzer {
@@ -48,6 +52,8 @@ impl ProjectAnalyzer {
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
             php_version: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         }
     }
 
@@ -61,6 +67,8 @@ impl ProjectAnalyzer {
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
             php_version: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         }
     }
 
@@ -80,6 +88,8 @@ impl ProjectAnalyzer {
             stubs_loaded: std::sync::atomic::AtomicBool::new(false),
             find_dead_code: false,
             php_version: None,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         };
         Ok((analyzer, map))
     }
@@ -110,6 +120,7 @@ impl ProjectAnalyzer {
             .swap(true, std::sync::atomic::Ordering::SeqCst)
         {
             crate::stubs::load_stubs_for_version(&self.codebase, self.resolved_php_version());
+            crate::stubs::load_user_stubs(&self.codebase, &self.stub_files, &self.stub_dirs);
         }
     }
 

--- a/crates/mir-analyzer/src/stubs.rs
+++ b/crates/mir-analyzer/src/stubs.rs
@@ -15,6 +15,7 @@
 /// let src  = stub_vfs.get(&file).unwrap();           // → &'static str PHP source
 /// ```
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
 use mir_codebase::Codebase;
@@ -64,6 +65,54 @@ pub fn load_stubs_for_version(codebase: &Codebase, php_version: PhpVersion) {
                 .with_php_version(php_version);
         let _ = collector.collect(&result.program);
     });
+}
+
+/// Parse user-provided stub files and directories into `codebase`.
+///
+/// Called after built-in stubs are loaded so user definitions can override or
+/// supplement built-ins (e.g. framework-specific classes, IDE helpers).
+pub fn load_user_stubs(codebase: &Codebase, files: &[PathBuf], dirs: &[PathBuf]) {
+    for path in files {
+        parse_stub_file(codebase, path);
+    }
+    for dir in dirs {
+        walk_stub_dir(codebase, dir);
+    }
+}
+
+fn parse_stub_file(codebase: &Codebase, path: &Path) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("mir: cannot read stub file {}: {}", path.display(), e);
+            return;
+        }
+    };
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, &content);
+    let file: Arc<str> = Arc::from(path.to_string_lossy().as_ref());
+    let collector =
+        crate::collector::DefinitionCollector::new(codebase, file, &content, &result.source_map);
+    let _ = collector.collect(&result.program);
+}
+
+fn walk_stub_dir(codebase: &Codebase, dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("mir: cannot read stub directory {}: {}", dir.display(), e);
+            return;
+        }
+    };
+    let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
+    paths.sort_unstable();
+    for path in paths {
+        if path.is_dir() {
+            walk_stub_dir(codebase, &path);
+        } else if path.extension().is_some_and(|e| e == "php") {
+            parse_stub_file(codebase, &path);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mir-analyzer/src/test_utils.rs
+++ b/crates/mir-analyzer/src/test_utils.rs
@@ -28,12 +28,19 @@
 //! ===config===
 //! php_version=8.1
 //! find_dead_code=true
+//! stub_file=stubs/helpers.php
+//! stub_dir=stubs
 //! ===file===
 //! <?php
 //! ...
 //! ===expect===
 //! ...
 //! ```
+//!
+//! `stub_file=path` and `stub_dir=path` refer to files/directories already declared
+//! with `===file:path===` markers. They are passed to `ProjectAnalyzer::stub_files` /
+//! `stub_dirs` and excluded from the analysis file list, so only the non-stub PHP
+//! files are analysed. Multiple `stub_file=` and `stub_dir=` lines are allowed.
 //!
 //! **With Composer/PSR-4**:
 //! ```text
@@ -61,6 +68,7 @@
 //! - `php_version` is parsed via [`PhpVersion::from_str`] (same parser as the
 //!   real CLI config); invalid values fail the test.
 //! - `find_dead_code` accepts only the literals `true` or `false`.
+//! - `stub_file` and `stub_dir` accept a relative path (matching a `===file:===` name).
 //!
 //! # Expect format
 //!
@@ -87,6 +95,10 @@ static COUNTER: AtomicU64 = AtomicU64::new(0);
 struct FixtureConfig {
     php_version: Option<PhpVersion>,
     find_dead_code: bool,
+    /// Paths (relative to temp dir) to pass as `analyzer.stub_files`.
+    stub_files: Vec<String>,
+    /// Paths (relative to temp dir) to pass as `analyzer.stub_dirs`.
+    stub_dirs: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -268,8 +280,14 @@ fn parse_config_section(text: &str, path: &str) -> FixtureConfig {
                     ),
                 };
             }
+            "stub_file" => {
+                config.stub_files.push(value.trim().to_string());
+            }
+            "stub_dir" => {
+                config.stub_dirs.push(value.trim().to_string());
+            }
             other => panic!(
-                "fixture {path}: unknown config key {other:?} — valid keys: php_version, find_dead_code"
+                "fixture {path}: unknown config key {other:?} — valid keys: php_version, find_dead_code, stub_file, stub_dir"
             ),
         }
     }
@@ -400,6 +418,23 @@ fn run_analyzer(files: &[(&str, &str)], config: &FixtureConfig) -> Vec<Issue> {
         analyzer = analyzer.with_php_version(version);
     }
 
+    // Register user stub files and directories from the fixture config.
+    for stub_file in &config.stub_files {
+        analyzer.stub_files.push(tmp_dir.join(stub_file));
+    }
+    for stub_dir in &config.stub_dirs {
+        analyzer.stub_dirs.push(tmp_dir.join(stub_dir));
+    }
+
+    // Build a set of paths that belong to user stubs so they are excluded from
+    // the list of files passed to `analyze()` (stubs are loaded separately).
+    let stub_file_set: HashSet<PathBuf> =
+        config.stub_files.iter().map(|f| tmp_dir.join(f)).collect();
+    let stub_dir_set: Vec<PathBuf> = config.stub_dirs.iter().map(|d| tmp_dir.join(d)).collect();
+    let is_stub = |p: &PathBuf| -> bool {
+        stub_file_set.contains(p) || stub_dir_set.iter().any(|d| p.starts_with(d))
+    };
+
     let has_composer = files.iter().any(|(name, _)| *name == "composer.json");
     let explicit_paths: Vec<PathBuf> = if has_composer {
         match crate::composer::Psr4Map::from_composer(&tmp_dir) {
@@ -409,16 +444,22 @@ fn run_analyzer(files: &[(&str, &str)], config: &FixtureConfig) -> Vec<Issue> {
                 let explicit: Vec<PathBuf> = paths
                     .iter()
                     .filter(|p| p.extension().map(|e| e == "php").unwrap_or(false))
-                    .filter(|p| !psr4_files.contains(*p))
+                    .filter(|p| !psr4_files.contains(*p) && !is_stub(p))
                     .cloned()
                     .collect();
                 analyzer.psr4 = Some(psr4);
                 explicit
             }
-            Err(_) => php_files_only(&paths),
+            Err(_) => php_files_only(&paths)
+                .into_iter()
+                .filter(|p| !is_stub(p))
+                .collect(),
         }
     } else {
         php_files_only(&paths)
+            .into_iter()
+            .filter(|p| !is_stub(p))
+            .collect()
     };
 
     let result = analyzer.analyze(&explicit_paths);

--- a/crates/mir-analyzer/tests/fixtures/user_stubs/stub_dir_function_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/user_stubs/stub_dir_function_no_error.phpt
@@ -1,0 +1,16 @@
+===config===
+stub_dir=stubs
+===file:stubs/auth.php===
+<?php
+function auth_check(string $token): bool { return strlen($token) > 0; }
+===file:stubs/cache.php===
+<?php
+function cache_get(string $key): mixed { return null; }
+===file:App.php===
+<?php
+function handle(string $token, string $key): void {
+    if (auth_check($token)) {
+        $val = cache_get($key);
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_class_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_class_no_error.phpt
@@ -1,0 +1,14 @@
+===config===
+stub_file=stubs/framework.php
+===file:stubs/framework.php===
+<?php
+class FrameworkClient {
+    public function connect(string $url): bool { return true; }
+}
+===file:App.php===
+<?php
+function boot(): void {
+    $client = new FrameworkClient();
+    $client->connect('https://example.com');
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_function_no_error.phpt
+++ b/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_function_no_error.phpt
@@ -1,0 +1,9 @@
+===config===
+stub_file=stubs/helpers.php
+===file:stubs/helpers.php===
+<?php
+function my_helper(string $s): string { return $s; }
+===file:App.php===
+<?php
+$result = my_helper('hello');
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_function_type_checked.phpt
+++ b/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_function_type_checked.phpt
@@ -1,0 +1,10 @@
+===config===
+stub_file=stubs/helpers.php
+===file:stubs/helpers.php===
+<?php
+function my_helper(string $s): string { return $s; }
+===file:App.php===
+<?php
+function test(): void { my_helper(42); }
+===expect===
+App.php: InvalidArgument: Argument $s of my_helper() expects 'string', got '42'

--- a/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_not_analysed_for_errors.phpt
+++ b/crates/mir-analyzer/tests/fixtures/user_stubs/stub_file_not_analysed_for_errors.phpt
@@ -1,0 +1,10 @@
+===config===
+stub_file=stubs/helpers.php
+===file:stubs/helpers.php===
+<?php
+// Stub files are not analysed — errors inside them must not be reported.
+function my_helper(string $s): void { undeclared_call(); }
+===file:App.php===
+<?php
+function test(): void { my_helper('hello'); }
+===expect===

--- a/crates/mir-analyzer/tests/user_stubs.rs
+++ b/crates/mir-analyzer/tests/user_stubs.rs
@@ -1,0 +1,76 @@
+// Integration tests for user-injectable stubs via ProjectAnalyzer::stub_files/stub_dirs.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mir_analyzer::ProjectAnalyzer;
+use tempfile::TempDir;
+
+fn write(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn stub_file_function_resolves_without_undefined_function_error() {
+    let stubs_dir = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+
+    let stub_file = write(
+        &stubs_dir,
+        "helpers.php",
+        "<?php\nfunction my_helper(string $s): string { return $s; }\n",
+    );
+    let src_file = write(
+        &src_dir,
+        "main.php",
+        "<?php\n$result = my_helper('hello');\n",
+    );
+
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.stub_files = vec![stub_file];
+    let result = analyzer.analyze(&[src_file]);
+
+    let undefined: Vec<_> = result
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .collect();
+
+    assert!(
+        undefined.is_empty(),
+        "my_helper should be defined via stub file; got: {undefined:?}"
+    );
+}
+
+#[test]
+fn stub_directory_function_resolves_without_undefined_function_error() {
+    let stubs_dir = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+
+    write(
+        &stubs_dir,
+        "framework.php",
+        "<?php\nfunction framework_fn(int $x): int { return $x; }\n",
+    );
+    let src_file = write(&src_dir, "main.php", "<?php\n$v = framework_fn(42);\n");
+
+    let mut analyzer = ProjectAnalyzer::new();
+    analyzer.stub_dirs = vec![stubs_dir.path().to_path_buf()];
+    let result = analyzer.analyze(&[src_file]);
+
+    let undefined: Vec<_> = result
+        .issues
+        .iter()
+        .filter(|i| i.kind.name() == "UndefinedFunction")
+        .collect();
+
+    assert!(
+        undefined.is_empty(),
+        "framework_fn should be defined via stub directory; got: {undefined:?}"
+    );
+}

--- a/crates/mir-cli/src/config.rs
+++ b/crates/mir-cli/src/config.rs
@@ -38,12 +38,16 @@ pub struct Config {
     pub issue_handlers: HashMap<String, ErrorLevel>,
     /// Global error level 1–8 (lower = stricter). 1 = errors only, 2 = +warnings, 3+ = +info.
     pub error_level: u8,
-    /// Target PHP version string (e.g. `"8.2"`).
+    /// Target PHP version string (e.g. `"8.2"`). Accepts both root attribute and child element.
     pub php_version: Option<String>,
     /// Whether dead-code detection is enabled.
     pub find_unused_code: bool,
     /// Whether unused-variable checking is enabled.
     pub find_unused_variables: bool,
+    /// External stub files to load (from `<stubs><file name="..."/>`).
+    pub stub_files: Vec<String>,
+    /// External stub directories to load (from `<stubs><directory name="..."/>`).
+    pub stub_dirs: Vec<String>,
 }
 
 impl Default for Config {
@@ -56,6 +60,8 @@ impl Default for Config {
             php_version: None,
             find_unused_code: false,
             find_unused_variables: false,
+            stub_files: Vec::new(),
+            stub_dirs: Vec::new(),
         }
     }
 }
@@ -127,6 +133,20 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
             Ok(Event::Start(e)) => {
                 let name = bytes_to_string(e.name().as_ref());
 
+                // phpVersion as attribute on the root element: <mir phpVersion="8.2">
+                if path.is_empty() && (name == "mir" || name == "psalm") {
+                    for attr in e.attributes().flatten() {
+                        if bytes_to_string(attr.key.as_ref()) == "phpVersion"
+                            && config.php_version.is_none()
+                        {
+                            let val = bytes_to_string(&attr.value);
+                            if !val.is_empty() {
+                                config.php_version = Some(val);
+                            }
+                        }
+                    }
+                }
+
                 // Issue handler: <SomeIssueKind errorLevel="..." />  inside <issueHandlers>
                 if path.last().is_some_and(|s: &String| s == "issueHandlers") {
                     for attr in e.attributes().flatten() {
@@ -142,6 +162,11 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
                 // <directory name="..."> inside <projectFiles> or <ignoreFiles>
                 if name == "directory" {
                     collect_directory(&e, &path, &mut config);
+                }
+
+                // <file name="..."> or <directory name="..."> inside <stubs>
+                if name == "file" || name == "directory" {
+                    collect_stub_entry(&e, &path, &mut config);
                 }
 
                 text_buf.clear();
@@ -165,6 +190,11 @@ fn parse_xml(xml: &str) -> Result<Config, ConfigError> {
 
                 if name == "directory" {
                     collect_directory(&e, &path, &mut config);
+                }
+
+                // <file name="..."/> or <directory name="..."/> inside <stubs>
+                if name == "file" || name == "directory" {
+                    collect_stub_entry(&e, &path, &mut config);
                 }
             }
 
@@ -221,6 +251,28 @@ fn collect_directory<'a>(
             match parent {
                 "projectFiles" => config.project_dirs.push(val),
                 "ignoreFiles" => config.ignore_dirs.push(val),
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Handle `<file name="..."/>` and `<directory name="..."/>` inside `<stubs>`.
+fn collect_stub_entry<'a>(
+    e: &quick_xml::events::BytesStart<'a>,
+    path: &[String],
+    config: &mut Config,
+) {
+    if path.last().map_or("", |s| s.as_str()) != "stubs" {
+        return;
+    }
+    let elem = bytes_to_string(e.name().as_ref());
+    for attr in e.attributes().flatten() {
+        if bytes_to_string(attr.key.as_ref()) == "name" {
+            let val = bytes_to_string(&attr.value);
+            match elem.as_str() {
+                "file" => config.stub_files.push(val),
+                "directory" => config.stub_dirs.push(val),
                 _ => {}
             }
         }
@@ -420,4 +472,75 @@ fn parse_baseline_xml(xml: &str) -> Result<Baseline, ConfigError> {
     }
 
     Ok(baseline)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_php_version_child_element() {
+        let cfg = Config::parse(r#"<mir><phpVersion>8.1</phpVersion></mir>"#).unwrap();
+        assert_eq!(cfg.php_version.as_deref(), Some("8.1"));
+    }
+
+    #[test]
+    fn parses_php_version_root_attribute() {
+        let cfg = Config::parse(r#"<mir phpVersion="8.2"></mir>"#).unwrap();
+        assert_eq!(cfg.php_version.as_deref(), Some("8.2"));
+    }
+
+    #[test]
+    fn root_attribute_does_not_override_cli_override() {
+        // Simulate: config file has attribute, CLI flag would overwrite in main.rs.
+        // The XML parser itself should accept the attribute form.
+        let cfg = Config::parse(r#"<psalm phpVersion="7.4"></psalm>"#).unwrap();
+        assert_eq!(cfg.php_version.as_deref(), Some("7.4"));
+    }
+
+    #[test]
+    fn parses_stubs_file_entries() {
+        let cfg = Config::parse(
+            r#"<mir>
+                <stubs>
+                    <file name="stubs/helpers.php"/>
+                    <file name="stubs/ide.php"/>
+                </stubs>
+            </mir>"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.stub_files, vec!["stubs/helpers.php", "stubs/ide.php"]);
+        assert!(cfg.stub_dirs.is_empty());
+    }
+
+    #[test]
+    fn parses_stubs_directory_entries() {
+        let cfg = Config::parse(
+            r#"<mir>
+                <stubs>
+                    <directory name="stubs/doctrine"/>
+                </stubs>
+            </mir>"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.stub_dirs, vec!["stubs/doctrine"]);
+        assert!(cfg.stub_files.is_empty());
+    }
+
+    #[test]
+    fn stubs_directory_does_not_pollute_project_dirs() {
+        let cfg = Config::parse(
+            r#"<mir>
+                <projectFiles>
+                    <directory name="src"/>
+                </projectFiles>
+                <stubs>
+                    <directory name="stubs/ext"/>
+                </stubs>
+            </mir>"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.project_dirs, vec!["src"]);
+        assert_eq!(cfg.stub_dirs, vec!["stubs/ext"]);
+    }
 }

--- a/crates/mir-cli/src/main.rs
+++ b/crates/mir-cli/src/main.rs
@@ -224,6 +224,14 @@ fn main() {
 
         analyzer.find_dead_code = cli.find_dead_code;
 
+        if let Some(raw) = &config.php_version {
+            match raw.parse::<PhpVersion>() {
+                Ok(v) => analyzer = analyzer.with_php_version(v),
+                Err(e) => eprintln!("mir: {}; using default PHP {}", e, PhpVersion::LATEST),
+            }
+        }
+        apply_stub_config(&mut analyzer, &config, &config_base);
+
         let vendor_files = map.vendor_files();
 
         // Resolve ignore dirs to absolute paths (relative to config file location)
@@ -416,6 +424,7 @@ fn main() {
     }
 
     analyzer.find_dead_code = cli.find_dead_code;
+    apply_stub_config(&mut analyzer, &config, &config_base);
 
     // Load type stubs first (needed before collect_types_only)
     analyzer.load_stubs();
@@ -467,6 +476,31 @@ fn main() {
         let elapsed = start.elapsed();
         let baseline = load_baseline(&cli, &config);
         run_output(&cli, &config, &files, result, baseline, elapsed);
+    }
+}
+
+/// Copy stub file/directory paths from `Config` into `ProjectAnalyzer`, resolving
+/// relative paths against `config_base` (the directory containing `mir.xml`).
+fn apply_stub_config(
+    analyzer: &mut ProjectAnalyzer,
+    config: &Config,
+    config_base: &std::path::Path,
+) {
+    for f in &config.stub_files {
+        let p = PathBuf::from(f);
+        analyzer.stub_files.push(if p.is_absolute() {
+            p
+        } else {
+            config_base.join(f)
+        });
+    }
+    for d in &config.stub_dirs {
+        let p = PathBuf::from(d);
+        analyzer.stub_dirs.push(if p.is_absolute() {
+            p
+        } else {
+            config_base.join(d)
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

Ports the still-applicable parts of #232 (closed, original head `b92e588`) onto the post-#283 stub architecture.

- **`<stubs>` XML config** — `<file name="..."/>` and `<directory name="..."/>` entries load external PHP stub files (Laravel helpers, IDE helpers, Doctrine, etc.) before analysis
- **`phpVersion` as root attribute** — `<mir phpVersion="8.2">` and `<psalm phpVersion="...">` accepted in addition to the existing child-element form (Psalm-compatible)
- **`load_user_stubs()`** — public API on `stubs` module; walks user paths through the standard PHP parser + `DefinitionCollector` pipeline so type info is available during analysis
- **`ProjectAnalyzer::stub_files` / `stub_dirs`** — public fields, set before calling `load_stubs()`; loaded automatically after built-in stubs
- **Fix: `php_version` not applied in composer path** — pre-existing gap where the configured PHP version was ignored when running in composer auto-detection mode
- **Fixture runner: `stub_file=` / `stub_dir=` config keys** — `.phpt` fixtures can now declare user stub files/directories; 5 new fixtures in `tests/fixtures/user_stubs/`

## What was dropped from #232 (deferred to separate PRs)

| Dropped | Reason |
|---------|--------|
| `<enableExtensions>` / `<disableExtensions>` | Auto-detect from `composer.json` restricts extensions to only listed ones → silent false positives for any unlisted ext |
| `EXTENSION_MIN_PHP` table | Superseded by per-symbol `@since`/`@removed` in `DefinitionCollector` (merged in #283) |
| Stub snapshot cache | Codebase shape shifted under #283; merits its own PR with full integration tests |

Original work recoverable from `b92e588bacf972988e0ef20650a15b87979ff3b7`.

## Test plan

- [x] `cargo test` passes (415 fixture tests + unit tests, 0 failures)
- [x] `stub_file_function_no_error`: function from stub file resolves without `UndefinedFunction`
- [x] `stub_file_function_type_checked`: wrong-type call to stub-defined function gives `InvalidArgument`
- [x] `stub_file_class_no_error`: class from stub file instantiates without `UndefinedClass`
- [x] `stub_dir_function_no_error`: functions from stub directory resolve
- [x] `stub_file_not_analysed_for_errors`: errors inside stub files are not reported
- [x] Config unit tests: `phpVersion` attribute, `<stubs>` entries, no pollution of `project_dirs`