### PR TITLE
feat(playground): interactive WASM playground in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - 'crates/**'
   workflow_dispatch:
 
 permissions:
@@ -19,12 +20,23 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - uses: actions/setup-node@v6
         with:
@@ -32,11 +44,14 @@ jobs:
           cache: npm
           cache-dependency-path: site/package-lock.json
 
-      - name: Install dependencies
+      - name: Install npm dependencies
         run: npm ci
         working-directory: site
 
-      - name: Build
+      - name: Build WASM
+        run: wasm-pack build --target web crates/mir-wasm --out-dir ../../site/public/wasm
+
+      - name: Build docs
         run: npm run build
         working-directory: site
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   create-release:
@@ -124,3 +126,54 @@ jobs:
           curl -fsSL -XPOST -H 'content-type:application/json' \
             'https://packagist.org/api/update-package?username=Jorg%20Sowa&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}' \
             -d '{"repository":{"url":"https://github.com/jorgsowa/mir"}}'
+
+  deploy-docs:
+    name: Deploy docs
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+        working-directory: site
+
+      - name: Build WASM
+        run: wasm-pack build --target web crates/mir-wasm --out-dir ../../site/public/wasm
+
+      - name: Build docs
+        run: npm run build
+        working-directory: site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./site/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /book
 crates/mir-analyzer/benches/fixtures/
+site/public/wasm/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "mir-analyzer"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "bumpalo",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "mir-codebase"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "dashmap",
  "indexmap",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "mir-issues"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "mir-types",
  "owo-colors",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "mir-php"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -677,11 +677,21 @@ dependencies = [
 
 [[package]]
 name = "mir-types"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "indexmap",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "mir-wasm"
+version = "0.12.0"
+dependencies = [
+ "mir-analyzer",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/mir-codebase",
     "crates/mir-analyzer",
     "crates/mir-cli",
+    "crates/mir-wasm",
 ]
 
 [workspace.package]

--- a/crates/mir-wasm/Cargo.toml
+++ b/crates/mir-wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name    = "mir-wasm"
+version.workspace  = true
+edition.workspace  = true
+license.workspace  = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mir-analyzer = { workspace = true }
+wasm-bindgen = "0.2"
+serde        = { workspace = true }
+serde_json   = { workspace = true }

--- a/crates/mir-wasm/src/lib.rs
+++ b/crates/mir-wasm/src/lib.rs
@@ -1,0 +1,78 @@
+use wasm_bindgen::prelude::*;
+
+use mir_analyzer::{PhpVersion, ProjectAnalyzer};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct WasmIssue {
+    name: &'static str,
+    message: String,
+    severity: String,
+    line: u32,
+    line_end: u32,
+    col_start: u16,
+    col_end: u16,
+    snippet: Option<String>,
+}
+
+/// Stateful playground analyzer. Stubs are loaded once on construction and
+/// reused across `analyze` calls. Re-initialized when the PHP version changes.
+#[wasm_bindgen]
+pub struct Playground {
+    analyzer: ProjectAnalyzer,
+    php_version: PhpVersion,
+}
+
+impl Default for Playground {
+    fn default() -> Self {
+        let version = PhpVersion::LATEST;
+        let analyzer = make_analyzer(version);
+        Self {
+            analyzer,
+            php_version: version,
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl Playground {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Analyze a PHP source string and return a JSON array of issues.
+    /// `php_version` is a string like `"8.3"` — falls back to latest if unparseable.
+    pub fn analyze(&mut self, source: &str, php_version: &str) -> String {
+        let version = php_version
+            .parse::<PhpVersion>()
+            .unwrap_or(PhpVersion::LATEST);
+        if version != self.php_version {
+            self.analyzer = make_analyzer(version);
+            self.php_version = version;
+        }
+        let result = self.analyzer.re_analyze_file("<playground>", source);
+        let issues: Vec<WasmIssue> = result
+            .issues
+            .iter()
+            .filter(|i| !i.suppressed)
+            .map(|i| WasmIssue {
+                name: i.kind.name(),
+                message: i.kind.message(),
+                severity: i.severity.to_string(),
+                line: i.location.line,
+                line_end: i.location.line_end,
+                col_start: i.location.col_start,
+                col_end: i.location.col_end,
+                snippet: i.snippet.clone(),
+            })
+            .collect();
+        serde_json::to_string(&issues).unwrap_or_default()
+    }
+}
+
+fn make_analyzer(version: PhpVersion) -> ProjectAnalyzer {
+    let analyzer = ProjectAnalyzer::new().with_php_version(version);
+    analyzer.load_stubs();
+    analyzer
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,6 +6,7 @@ export default defineConfig({
   base: '/mir',
   integrations: [
     starlight({
+      customCss: ['./src/styles/custom.css'],
       title: 'mir',
       description: 'A fast, incremental PHP static analyzer written in Rust.',
       logo: {
@@ -21,6 +22,7 @@ export default defineConfig({
       },
       sidebar: [
         { label: 'Introduction', link: '/' },
+        { label: 'Playground', link: '/playground/' },
         {
           label: 'Guides',
           items: [

--- a/site/src/pages/playground.astro
+++ b/site/src/pages/playground.astro
@@ -1,0 +1,209 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+const cargoToml = readFileSync(join(process.cwd(), '../Cargo.toml'), 'utf-8');
+const version = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1] ?? 'unknown';
+const commit = (() => {
+  try { return execSync('git rev-parse --short HEAD', { cwd: process.cwd() }).toString().trim(); }
+  catch { return 'unknown'; }
+})();
+
+const PHP_VERSIONS = ['8.1', '8.2', '8.3', '8.4', '8.5'];
+const DEFAULT_PHP = '8.5';
+
+const DEFAULT_CODE = `<?php
+
+function add(int $a, int $b): int {
+    return $a + $b;
+}
+
+$result = add("not a number", 42);
+`;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Playground',
+    description: 'Try mir in your browser — no install required.',
+    tableOfContents: false,
+  }}
+>
+  <div
+    class="playground not-content"
+    data-base={import.meta.env.BASE_URL.replace(/\/$/, '')}
+  >
+    <div class="pg-toolbar">
+      <select id="pg-version" class="pg-select">
+        {PHP_VERSIONS.map(v => (
+          <option value={v} selected={v === DEFAULT_PHP}>{`PHP ${v}`}</option>
+        ))}
+      </select>
+      <button id="pg-btn" class="pg-btn" disabled>Loading…</button>
+      <span id="pg-status" class="pg-status"></span>
+      <span class="pg-meta">mir&nbsp;v{version}&nbsp;·&nbsp;{commit}</span>
+    </div>
+
+    <div class="pg-editor">
+      <pre id="pg-gutter" class="pg-gutter" aria-hidden="true">1</pre>
+      <div class="pg-input-wrap">
+        <textarea
+          id="pg-input"
+          class="pg-input"
+          spellcheck="false"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+        >{DEFAULT_CODE}</textarea>
+        <div id="pg-overlay" class="pg-overlay" aria-hidden="true">
+          <div id="pg-underline" class="pg-underline" style="display:none"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="pg-diag" class="pg-diag" aria-live="polite"></div>
+  </div>
+</StarlightPage>
+
+<script is:inline>
+  const root    = document.querySelector('.playground');
+  const BASE    = root.dataset.base;
+  const WASM_JS = `${BASE}/wasm/mir_wasm.js`;
+
+  const btn     = document.getElementById('pg-btn');
+  const input   = document.getElementById('pg-input');
+  const sel     = document.getElementById('pg-version');
+  const gutter  = document.getElementById('pg-gutter');
+  const diag    = document.getElementById('pg-diag');
+  const status  = document.getElementById('pg-status');
+
+  let playground = null;
+  let debounce   = null;
+
+  // Line numbers
+  function updateGutter() {
+    const n = input.value.split('\n').length;
+    gutter.textContent = Array.from({ length: n }, (_, i) => i + 1).join('\n');
+  }
+  input.addEventListener('input', updateGutter);
+  updateGutter();
+
+  // WASM
+  async function loadWasm() {
+    try {
+      const mod = await import(WASM_JS);
+      await mod.default();
+      playground = new mod.Playground();
+      btn.textContent = 'Analyze';
+      btn.disabled = false;
+      runAnalysis();
+    } catch (e) {
+      status.textContent = 'Failed to load analyzer.';
+      console.error(e);
+    }
+  }
+
+  function esc(s) {
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  // Overlay highlight
+  const overlay    = document.getElementById('pg-overlay');
+  const underline  = document.getElementById('pg-underline');
+
+  // Measure monospace char width once (re-measure if font changes)
+  let charW = null;
+  function getCharWidth() {
+    if (charW) return charW;
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.font = getComputedStyle(input).font;
+    charW = ctx.measureText('x').width;
+    return charW;
+  }
+
+  function positionUnderline() {
+    if (!underline._issue) return;
+    const { line, colStart, colEnd, sev } = underline._issue;
+    const computed  = getComputedStyle(input);
+    const lineH     = parseFloat(computed.lineHeight) || 22;
+    const padTop    = parseFloat(computed.paddingTop)  || 16;
+    const padLeft   = parseFloat(computed.paddingLeft) || 16;
+    const cw        = getCharWidth();
+    const lineText  = input.value.split('\n')[line - 1] ?? '';
+    const endCol    = colEnd > 0 ? colEnd : lineText.length;
+
+    const top   = padTop + (line - 1) * lineH + lineH - 4 - input.scrollTop;
+    const left  = padLeft + colStart * cw - input.scrollLeft;
+    const width = Math.max(cw * 2, (endCol - colStart) * cw);
+
+    const colors = { error: 'var(--sl-color-red)', warning: 'var(--sl-color-orange)', info: 'var(--sl-color-blue)' };
+    underline.style.cssText = `display:block; top:${top}px; left:${left}px; width:${width}px; border-color:${colors[sev] ?? colors.error};`;
+    overlay.scrollTop  = input.scrollTop;
+    overlay.scrollLeft = input.scrollLeft;
+  }
+
+  input.addEventListener('scroll', () => {
+    gutter.scrollTop = input.scrollTop;
+    positionUnderline();
+  });
+
+  diag.addEventListener('mouseover', e => {
+    const card = e.target.closest('.pg-issue');
+    if (!card) return;
+    const sev = card.classList.contains('pg-issue--error') ? 'error'
+              : card.classList.contains('pg-issue--warning') ? 'warning' : 'info';
+    underline._issue = { line: +card.dataset.line, lineEnd: +card.dataset.lineEnd,
+                         colStart: +card.dataset.colStart, colEnd: +card.dataset.colEnd, sev };
+    // Scroll textarea to bring the line into view
+    const lineH = parseFloat(getComputedStyle(input).lineHeight) || 22;
+    input.scrollTop = Math.max(0, (+card.dataset.line - 1) * lineH - input.clientHeight / 3);
+    positionUnderline();
+  });
+
+  diag.addEventListener('mouseleave', () => {
+    underline._issue = null;
+    underline.style.display = 'none';
+  });
+
+  function renderIssues(issues) {
+    if (!issues.length) {
+      diag.innerHTML = '<p class="pg-empty">No issues found.</p>';
+      return;
+    }
+    diag.innerHTML = issues.map(i => {
+      const s = i.severity.toLowerCase();
+      return `<div class="pg-issue pg-issue--${s}"
+          data-line="${i.line}" data-line-end="${i.line_end}"
+          data-col-start="${i.col_start}" data-col-end="${i.col_end}">
+        <div class="pg-issue-head">
+          <span class="pg-dot"></span>
+          <span class="pg-issue-name">${esc(i.name)}</span>
+          <span class="pg-issue-loc">line&nbsp;${i.line}:${i.col_start}</span>
+        </div>
+        <div class="pg-issue-msg">${esc(i.message)}</div>
+      </div>`;
+    }).join('');
+  }
+
+  function runAnalysis() {
+    if (!playground) return;
+    try {
+      renderIssues(JSON.parse(playground.analyze(input.value, sel.value)));
+    } catch (e) {
+      diag.innerHTML = '<p class="pg-empty">Analysis error.</p>';
+      console.error(e);
+    }
+  }
+
+  btn.addEventListener('click', runAnalysis);
+  sel.addEventListener('change', runAnalysis);
+  input.addEventListener('input', () => {
+    clearTimeout(debounce);
+    debounce = setTimeout(runAnalysis, 400);
+  });
+
+  loadWasm();
+</script>

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,0 +1,239 @@
+/* Right sidebar — same background as left sidebar */
+.right-sidebar {
+  background-color: var(--sl-color-bg-sidebar);
+}
+
+/* ── Playground ──────────────────────────────────────────────────────────── */
+
+.playground {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+/* Toolbar */
+.pg-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pg-select {
+  appearance: none;
+  padding: 0.4375rem 2rem 0.4375rem 0.875rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  font-family: inherit;
+  line-height: 1.1875;
+  border-radius: 999rem;
+  border: 1px solid var(--sl-color-gray-4);
+  background-color: var(--sl-color-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23999' d='M5 6 0 0h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  color: var(--sl-color-white);
+  cursor: pointer;
+  outline-offset: 0.25rem;
+}
+
+.pg-select:focus-visible {
+  outline: 2px solid var(--sl-color-text-accent);
+}
+
+.pg-btn {
+  padding: 0.4375rem 1.125rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.1875;
+  border-radius: 999rem;
+  border: 1px solid var(--sl-color-text-accent);
+  background: var(--sl-color-text-accent);
+  color: var(--sl-color-black);
+  cursor: pointer;
+  outline-offset: 0.25rem;
+  transition: opacity 0.15s;
+}
+
+.pg-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pg-btn:not(:disabled):hover {
+  opacity: 0.88;
+}
+
+.pg-status {
+  font-size: var(--sl-text-sm, 0.875rem);
+  color: var(--sl-color-gray-3);
+}
+
+.pg-meta {
+  margin-inline-start: auto;
+  font-size: 0.75rem;
+  color: var(--sl-color-gray-4);
+  font-family: var(--__sl-font-mono, monospace);
+  white-space: nowrap;
+}
+
+/* Editor frame */
+.pg-editor {
+  display: flex !important;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--sl-color-bg-nav);
+  transition: border-color 0.15s;
+}
+
+.pg-editor:focus-within {
+  border-color: var(--sl-color-text-accent);
+}
+
+/* Input wrapper + overlay */
+.pg-input-wrap {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+}
+
+.pg-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.pg-underline {
+  position: absolute;
+  height: 0;
+  border-bottom: 2px dashed;
+  border-radius: 1px;
+}
+
+.pg-gutter {
+  padding: 1rem 0.625rem;
+  font-family: var(--__sl-font-mono, monospace);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  text-align: right;
+  color: var(--sl-color-gray-4);
+  background: var(--sl-color-bg-sidebar);
+  border-inline-end: 1px solid var(--sl-color-gray-6);
+  user-select: none;
+  min-width: 2.25rem;
+  overflow: hidden;
+  flex-shrink: 0;
+  margin: 0;
+  white-space: pre;
+}
+
+.pg-input {
+  flex: 1;
+  width: 100%;
+  min-height: 240px;
+  padding: 1rem;
+  font-family: var(--__sl-font-mono, monospace);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--sl-color-white);
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: vertical;
+  tab-size: 4;
+  overflow-wrap: normal;
+  overflow-x: auto;
+}
+
+/* Diagnostics */
+.pg-diag {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.pg-empty {
+  font-size: var(--sl-text-sm, 0.875rem);
+  color: var(--sl-color-gray-3);
+  margin: 0;
+  padding: 0.25rem 0;
+}
+
+.pg-issue {
+  border-radius: 0.4rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-inline-start-width: 3px;
+  padding: 0.5rem 0.875rem;
+  background: var(--sl-color-bg-nav);
+  cursor: default;
+  transition: background 0.12s, box-shadow 0.12s;
+}
+
+.pg-issue:hover {
+  background: var(--sl-color-bg-sidebar);
+}
+
+.pg-issue--error:hover   { box-shadow: 0 0 0 1px var(--sl-color-red),    inset 3px 0 0 var(--sl-color-red);    }
+.pg-issue--warning:hover { box-shadow: 0 0 0 1px var(--sl-color-orange),  inset 3px 0 0 var(--sl-color-orange); }
+.pg-issue--info:hover    { box-shadow: 0 0 0 1px var(--sl-color-blue),    inset 3px 0 0 var(--sl-color-blue);   }
+
+.pg-issue:hover .pg-dot {
+  box-shadow: 0 0 6px 2px currentColor;
+}
+
+.pg-issue--error:hover   .pg-dot { color: var(--sl-color-red);    }
+.pg-issue--warning:hover .pg-dot { color: var(--sl-color-orange); }
+.pg-issue--info:hover    .pg-dot { color: var(--sl-color-blue);   }
+
+.pg-issue:hover .pg-issue-name {
+  color: var(--sl-color-white);
+}
+
+.pg-issue:hover .pg-issue-msg {
+  color: var(--sl-color-gray-1);
+}
+
+.pg-issue--error   { border-inline-start-color: var(--sl-color-red);    }
+.pg-issue--warning { border-inline-start-color: var(--sl-color-orange); }
+.pg-issue--info    { border-inline-start-color: var(--sl-color-blue);   }
+
+.pg-issue-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.2rem;
+}
+
+.pg-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pg-issue--error   .pg-dot { background: var(--sl-color-red);    }
+.pg-issue--warning .pg-dot { background: var(--sl-color-orange); }
+.pg-issue--info    .pg-dot { background: var(--sl-color-blue);   }
+
+.pg-issue-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--sl-color-white);
+}
+
+.pg-issue-loc {
+  margin-inline-start: auto;
+  font-size: 0.75rem;
+  font-family: var(--__sl-font-mono, monospace);
+  color: var(--sl-color-gray-3);
+  white-space: nowrap;
+}
+
+.pg-issue-msg {
+  font-size: 0.8125rem;
+  color: var(--sl-color-gray-2);
+  padding-inline-start: 1rem;
+}


### PR DESCRIPTION
## Summary

- Adds a new `crates/mir-wasm` crate that compiles `mir-analyzer` to WebAssembly via `wasm-bindgen`, exposing a stateful `Playground` struct (stubs loaded once, re-initialized only on PHP version change)
- Adds an interactive playground page to the Starlight docs site: PHP version select (8.1–8.5), live analysis on keystroke (400 ms debounce), line-number gutter, version + commit hash in the toolbar
- Diagnostics panel shows severity-colored cards; hovering a card draws a dashed underline overlay at the exact character range in the editor, plus a colored glow on the card
- CI updated: `docs.yml` builds WASM before `astro build` and now also triggers on `crates/**` changes; `release.yml` deploys docs as part of every release
- `site/public/wasm/` added to `.gitignore` — always built from source in CI, never committed

## Test plan

- [ ] `~/.cargo/bin/wasm-pack build --target web crates/mir-wasm --out-dir ../../site/public/wasm` then `cd site && npm run dev` — playground loads and analyzes the default snippet
- [ ] Changing PHP version re-runs analysis
- [ ] Hovering a diagnostic card scrolls the editor to the line and shows a dashed underline at the correct column range
- [ ] `cargo clippy` and `cargo fmt --check` pass
- [ ] `npm run build` in `site/` produces a clean build