### PR TITLE
fix(docblock): parse conditional return type annotation

### DIFF
--- a/crates/mir-analyzer/src/parser/docblock.rs
+++ b/crates/mir-analyzer/src/parser/docblock.rs
@@ -446,6 +446,14 @@ pub fn parse_type_string(s: &str) -> Union {
         return u;
     }
 
+    // Conditional type: `($param is TypeName ? TrueType : FalseType)`
+    if s.starts_with('(') && s.ends_with(')') {
+        let inner = s[1..s.len() - 1].trim();
+        if let Some(conditional) = parse_conditional_type(inner) {
+            return conditional;
+        }
+    }
+
     // Union: `A|B|C`
     if s.contains('|') && !is_inside_generics(s) {
         let parts = split_union(s);
@@ -927,6 +935,40 @@ fn is_inside_generics(s: &str) -> bool {
         }
     }
     depth != 0
+}
+
+/// Parses `$param is TypeName ? TrueType : FalseType` into a `TConditional`.
+fn parse_conditional_type(s: &str) -> Option<Union> {
+    if !s.starts_with('$') {
+        return None;
+    }
+    let is_pos = s.find(" is ")?;
+    let after_is = s[is_pos + 4..].trim();
+    let q_pos = find_char_at_depth(after_is, '?')?;
+    let subject_str = after_is[..q_pos].trim();
+    let rest = after_is[q_pos + 1..].trim();
+    let colon_pos = find_char_at_depth(rest, ':')?;
+    let true_str = rest[..colon_pos].trim();
+    let false_str = rest[colon_pos + 1..].trim();
+    Some(Union::single(Atomic::TConditional {
+        subject: Box::new(parse_type_string(subject_str)),
+        if_true: Box::new(parse_type_string(true_str)),
+        if_false: Box::new(parse_type_string(false_str)),
+    }))
+}
+
+/// Finds `target` in `s` at nesting depth 0 (not inside `<>`, `()`, `{}`).
+fn find_char_at_depth(s: &str, target: char) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '<' | '(' | '{' => depth += 1,
+            '>' | ')' | '}' => depth -= 1,
+            _ if ch == target && depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn normalize_fqcn(s: &str) -> String {

--- a/crates/mir-analyzer/src/stmt/mod.rs
+++ b/crates/mir-analyzer/src/stmt/mod.rs
@@ -230,8 +230,9 @@ impl<'a> StatementsAnalyzer<'a> {
                         // Check return type compatibility. Special case: `void` functions must not
                         // return any value (named_object_return_compatible considers TVoid compatible
                         // with TNull, so handle void separately to avoid false suppression).
-                        if (declared.is_void() && !check_ty.is_void() && !check_ty.is_mixed())
-                            || (!check_ty.is_subtype_of_simple(declared)
+                        if !declared.contains(|t| matches!(t, Atomic::TConditional { .. }))
+                            && ((declared.is_void() && !check_ty.is_void() && !check_ty.is_mixed())
+                                || (!check_ty.is_subtype_of_simple(declared)
                                 && !declared.is_mixed()
                                 && !check_ty.is_mixed()
                                 && !named_object_return_compatible(&check_ty, declared, self.codebase, &self.file)
@@ -254,7 +255,7 @@ impl<'a> StatementsAnalyzer<'a> {
                                 // Suppress LessSpecificReturnStatement (level 4): actual is a
                                 // supertype of declared (not flagged at default error level).
                                 && !named_object_return_compatible(declared, &check_ty, self.codebase, &self.file)
-                                && !named_object_return_compatible(&declared.remove_null(), &check_ty.remove_null(), self.codebase, &self.file))
+                                && !named_object_return_compatible(&declared.remove_null(), &check_ty.remove_null(), self.codebase, &self.file)))
                         {
                             let (line, col_start) = self.offset_to_line_col(stmt.span.start);
                             let (line_end, col_end) = if stmt.span.start < stmt.span.end {

--- a/crates/mir-analyzer/tests/fixtures/docblock_parity/conditional_return_type.phpt
+++ b/crates/mir-analyzer/tests/fixtures/docblock_parity/conditional_return_type.phpt
@@ -1,0 +1,19 @@
+===file===
+<?php
+class Foo
+{
+    protected string $var = '';
+
+    /**
+     * @return ($var is null ? string : $this)
+     */
+    public function bar(?string $var = null): static|string
+    {
+        if ($var === null) {
+            return $this->var;
+        }
+        $this->var = $var;
+        return $this;
+    }
+}
+===expect===

--- a/crates/mir-analyzer/tests/fixtures/docblock_parity/conditional_return_type_nested.phpt
+++ b/crates/mir-analyzer/tests/fixtures/docblock_parity/conditional_return_type_nested.phpt
@@ -1,0 +1,14 @@
+===file===
+<?php
+/**
+ * @param string|null $value
+ * @return ($value is null ? array<string> : non-empty-string)
+ */
+function wrap(?string $value): array|string
+{
+    if ($value === null) {
+        return [];
+    }
+    return $value . '!';
+}
+===expect===


### PR DESCRIPTION
## Summary

- Adds parsing for `@return ($param is TypeName ? TrueType : FalseType)` into the existing `Atomic::TConditional` type instead of falling through to `mixed`
- Skips return-type compatibility checks when the declared return type contains a conditional type, since per-branch narrowing is not yet implemented
- Adds two `.phpt` fixtures covering the exact example from the issue and a case with nested branch types

Closes #148