### PR TITLE
fix(diagnostics): report accurate line/col for UnusedVariable and UnusedParam

### DIFF
--- a/crates/mir-analyzer/src/context.rs
+++ b/crates/mir-analyzer/src/context.rs
@@ -1,5 +1,5 @@
 /// Analysis context — carries type state through statement/expression analysis.
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -65,6 +65,10 @@ pub struct Context {
     /// return" so that variables assigned only in the try body are
     /// considered definitely assigned after the try/catch.
     pub diverges: bool,
+
+    /// Pre-converted (line, col_start, line_end, col_end) of the first assignment
+    /// to each variable. Used to emit accurate locations for UnusedVariable / UnusedParam.
+    pub var_locations: HashMap<String, (u32, u16, u32, u16)>,
 }
 
 impl Context {
@@ -86,6 +90,7 @@ impl Context {
             param_names: HashSet::new(),
             byref_param_names: HashSet::new(),
             diverges: false,
+            var_locations: HashMap::new(),
         };
         // PHP superglobals — always in scope in any context
         for sg in &[
@@ -227,6 +232,21 @@ impl Context {
         self.tainted_vars.contains(name)
     }
 
+    /// Record the location of the first assignment to a variable (first-write-wins).
+    pub fn record_var_location(
+        &mut self,
+        name: &str,
+        line: u32,
+        col_start: u16,
+        line_end: u32,
+        col_end: u16,
+    ) {
+        let name = name.trim_start_matches('$');
+        self.var_locations
+            .entry(name.to_string())
+            .or_insert((line, col_start, line_end, col_end));
+    }
+
     /// Remove a variable from the context (after `unset`).
     pub fn unset_var(&mut self, name: &str) {
         let name = name.trim_start_matches('$');
@@ -334,6 +354,15 @@ impl Context {
         // Read vars: union — if either branch reads a var, it counts as read
         for name in if_ctx.read_vars.iter().chain(else_ctx.read_vars.iter()) {
             result.read_vars.insert(name.clone());
+        }
+
+        // Var locations: keep the earliest known span for each variable
+        for (name, loc) in if_ctx
+            .var_locations
+            .iter()
+            .chain(else_ctx.var_locations.iter())
+        {
+            result.var_locations.entry(name.clone()).or_insert(*loc);
         }
 
         // After merging branches, the merged context does not diverge

--- a/crates/mir-analyzer/src/diagnostics.rs
+++ b/crates/mir-analyzer/src/diagnostics.rs
@@ -159,6 +159,8 @@ pub(crate) fn emit_unused_params(
     for p in params {
         let name = p.name.as_ref().trim_start_matches('$');
         if !ctx.read_vars.contains(name) {
+            let (line, col_start, line_end, col_end) =
+                ctx.var_locations.get(name).copied().unwrap_or((1, 0, 1, 0));
             issues.push(
                 mir_issues::Issue::new(
                     mir_issues::IssueKind::UnusedParam {
@@ -166,10 +168,10 @@ pub(crate) fn emit_unused_params(
                     },
                     mir_issues::Location {
                         file: file.clone(),
-                        line: 1,
-                        line_end: 1,
-                        col_start: 0,
-                        col_end: 0,
+                        line,
+                        line_end,
+                        col_start,
+                        col_end: col_end.max(col_start + 1),
                     },
                 )
                 .with_snippet(format!("${name}")),
@@ -200,14 +202,19 @@ pub(crate) fn emit_unused_variables(
             continue;
         }
         if !ctx.read_vars.contains(name) {
+            let (line, col_start, line_end, col_end) = ctx
+                .var_locations
+                .get(name.as_str())
+                .copied()
+                .unwrap_or((1, 0, 1, 0));
             issues.push(mir_issues::Issue::new(
                 mir_issues::IssueKind::UnusedVariable { name: name.clone() },
                 mir_issues::Location {
                     file: file.clone(),
-                    line: 1,
-                    line_end: 1,
-                    col_start: 0,
-                    col_end: 0,
+                    line,
+                    line_end,
+                    col_start,
+                    col_end: col_end.max(col_start + 1),
                 },
             ));
         }

--- a/crates/mir-analyzer/src/expr.rs
+++ b/crates/mir-analyzer/src/expr.rs
@@ -1382,7 +1382,10 @@ impl<'a> ExpressionAnalyzer<'a> {
                 if ctx.byref_param_names.contains(&name_str) {
                     ctx.read_vars.insert(name_str.clone());
                 }
-                ctx.set_var(name_str, ty);
+                ctx.set_var(name_str.clone(), ty);
+                let (line, col_start) = self.offset_to_line_col(target.span.start);
+                let (line_end, col_end) = self.offset_to_line_col(target.span.end);
+                ctx.record_var_location(&name_str, line, col_start, line_end, col_end);
             }
             ExprKind::Array(elements) => {
                 // [$a, $b] = $arr  — destructuring

--- a/crates/mir-analyzer/src/pass2.rs
+++ b/crates/mir-analyzer/src/pass2.rs
@@ -414,6 +414,7 @@ impl<'a> Pass2Driver<'a> {
         };
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false, true);
+        seed_param_locations(&mut ctx, &decl.params, source, source_map);
         let mut buf = IssueBuffer::new();
         let mut sa = StatementsAnalyzer::new(
             self.codebase,
@@ -524,6 +525,7 @@ impl<'a> Pass2Driver<'a> {
                 is_ctor,
                 method.is_static,
             );
+            seed_param_locations(&mut ctx, &method.params, source, source_map);
 
             let mut buf = IssueBuffer::new();
             let mut sa = StatementsAnalyzer::new(
@@ -628,6 +630,7 @@ impl<'a> Pass2Driver<'a> {
         };
 
         let mut ctx = Context::for_function(&params, return_ty, None, None, None, false, true);
+        seed_param_locations(&mut ctx, &decl.params, source, source_map);
         let mut buf = IssueBuffer::new();
         let mut sa = StatementsAnalyzer::new(
             self.codebase,
@@ -751,6 +754,7 @@ impl<'a> Pass2Driver<'a> {
                 is_ctor,
                 method.is_static,
             );
+            seed_param_locations(&mut ctx, &method.params, source, source_map);
 
             let mut buf = IssueBuffer::new();
             let mut sa = StatementsAnalyzer::new(
@@ -926,6 +930,7 @@ impl<'a> Pass2Driver<'a> {
                 is_ctor,
                 method.is_static,
             );
+            seed_param_locations(&mut ctx, &method.params, source, source_map);
 
             let mut buf = IssueBuffer::new();
             let mut sa = StatementsAnalyzer::new(
@@ -1029,6 +1034,7 @@ impl<'a> Pass2Driver<'a> {
                 is_ctor,
                 method.is_static,
             );
+            seed_param_locations(&mut ctx, &method.params, source, source_map);
 
             let mut buf = IssueBuffer::new();
             let mut sa = StatementsAnalyzer::new(
@@ -1135,6 +1141,23 @@ impl<'a> Pass2Driver<'a> {
 }
 
 // ---------------------------------------------------------------------------
+
+/// Seed `ctx.var_locations` for function/method parameters using their AST spans.
+fn seed_param_locations(
+    ctx: &mut crate::context::Context,
+    ast_params: &php_ast::ast::ArenaVec<'_, php_ast::ast::Param<'_, '_>>,
+    source: &str,
+    source_map: &php_rs_parser::source_map::SourceMap,
+) {
+    for p in ast_params.iter() {
+        let name = p.name.trim_start_matches('$');
+        let (line, col_start) =
+            crate::diagnostics::offset_to_line_col(source, p.span.start, source_map);
+        let (line_end, col_end) =
+            crate::diagnostics::offset_to_line_col(source, p.span.end, source_map);
+        ctx.record_var_location(name, line, col_start, line_end, col_end);
+    }
+}
 
 pub fn merge_return_types(return_types: &[Union]) -> Union {
     if return_types.is_empty() {


### PR DESCRIPTION
## Summary

- `UnusedVariable` and `UnusedParam` were always reported at `line: 1, col: 0` regardless of where the variable was declared or assigned.
- Add `var_locations: HashMap<String, (line, col_start, line_end, col_end)>` to `Context` with first-write-wins semantics via `record_var_location()`.
- `assign_to_target` (expr.rs) records the LHS `$variable` span on plain assignments, including list-destructuring elements.
- New `seed_param_locations()` helper (pass2.rs) populates locations from `Param.span` right after each context is created — covers functions, class methods, and trait methods in both the untyped and typed analysis passes.
- `merge_branches` unions `var_locations` from both branches.
- `emit_unused_params` and `emit_unused_variables` look up the stored location instead of emitting `line: 1`.