### PR TITLE
feat(generics): infer class type params at `new`, resolve unannotated generic returns, docblock fixes

### DIFF
--- a/crates/mir-analyzer/src/collector/class.rs
+++ b/crates/mir-analyzer/src/collector/class.rs
@@ -85,14 +85,40 @@ impl<'a> DefinitionCollector<'a> {
             match &member.kind {
                 ClassMemberKind::Method(m) => {
                     if m.name.as_deref() == Some("__construct") {
+                        // Promoted-constructor properties take their type from the
+                        // native type hint, falling back to the constructor's
+                        // `@param` docblock — so `@param T $value` (with `@template T`
+                        // on the class) types the promoted `$value` property as the
+                        // template param `T`, enabling generic member inference.
+                        let ctor_doc = self.parse_docblock_from_node_or_preceding(
+                            m.doc_comment.as_ref(),
+                            member.span.start,
+                        );
+                        let ctor_template_names: std::collections::HashSet<String> = ctor_doc
+                            .templates
+                            .iter()
+                            .map(|(n, _, _)| n.to_string())
+                            .chain(class_template_names.iter().cloned())
+                            .collect();
                         for p in m.params.iter() {
                             if p.visibility.is_some() {
                                 let param_name = p.name.as_deref().unwrap_or_default();
-                                let ty = self.resolve_union_opt(
-                                    p.type_hint
-                                        .as_ref()
-                                        .map(|h| type_from_hint_owned(h, Some(&fqcn))),
-                                );
+                                let ty = self
+                                    .resolve_union_opt(
+                                        p.type_hint
+                                            .as_ref()
+                                            .map(|h| type_from_hint_owned(h, Some(&fqcn))),
+                                    )
+                                    .or_else(|| {
+                                        ctor_doc.get_param_type(param_name).cloned().map(|u| {
+                                            self.resolve_union_doc_with_templates(
+                                                u,
+                                                &ctor_template_names,
+                                                &fqcn,
+                                                &class_template_params,
+                                            )
+                                        })
+                                    });
                                 let prop = PropertyDef {
                                     name: Arc::from(param_name),
                                     ty,

--- a/crates/mir-analyzer/src/expr/objects.rs
+++ b/crates/mir-analyzer/src/expr/objects.rs
@@ -7,6 +7,29 @@ use mir_types::{Atomic, Type};
 use php_ast::owned::{Expr, ExprKind, NewExpr, PropertyAccessExpr, StaticAccessExpr};
 use std::sync::Arc;
 
+/// Widen scalar literal atomics to their base type when forming a `new`
+/// receiver's generic `type_params`. Carrying a literal type param into the
+/// receiver (e.g. `Box<5>` from `new Box(5)`) is over-narrow and risks false
+/// positives downstream (e.g. `$box->set(6)` where `set(T)` and `T=5` would
+/// wrongly reject `6`). Mirrors `stmt::widen_for_check`, plus `true`/`false`
+/// → `bool`.
+fn widen_type_param(ty: &Type) -> Type {
+    let mut out = Type::empty();
+    out.from_docblock = ty.from_docblock;
+    out.possibly_undefined = ty.possibly_undefined;
+    for atomic in &ty.types {
+        let widened = match atomic {
+            Atomic::TLiteralInt(_) | Atomic::TIntRange { .. } => Atomic::TInt,
+            Atomic::TLiteralString(_) => Atomic::TString,
+            Atomic::TLiteralFloat(_, _) => Atomic::TFloat,
+            Atomic::TTrue | Atomic::TFalse => Atomic::TBool,
+            other => other.clone(),
+        };
+        out.add_type(widened);
+    }
+    out
+}
+
 fn is_valid_class_name_type(ty: &Type) -> bool {
     // Class names must be strings or class-string types only.
     // Mixed is not allowed - must be explicit string or class-string.
@@ -40,6 +63,68 @@ fn expr_name_str(expr: &Expr) -> Option<&str> {
 }
 
 impl<'a> ExpressionAnalyzer<'a> {
+    /// Infer the class-level generic type params for `new Class(...)` from the
+    /// constructor argument types.
+    ///
+    /// Given `@template T` on the class and a constructor parameter typed `T`,
+    /// `new Box(5)` binds `T → int` and returns `[int]` (in the class's declared
+    /// template-param order) so the result is `Box<int>`. Returns the cached
+    /// empty params when the class is non-generic or nothing could be inferred,
+    /// preserving the previous behaviour for ordinary instantiations.
+    fn infer_new_type_params(
+        &self,
+        fqcn: &Arc<str>,
+        ctor_params: Option<&[mir_codebase::storage::FnParam]>,
+        arg_types: &[Type],
+    ) -> Arc<[Type]> {
+        let empty = mir_types::union::empty_type_params();
+        let class_tps = match crate::db::class_template_params(self.db, fqcn) {
+            Some(tps) if !tps.is_empty() => tps,
+            _ => return empty,
+        };
+        let Some(ctor_params) = ctor_params else {
+            return empty;
+        };
+
+        // Bind class templates ONLY from constructor ARGUMENTS (no bound/mixed
+        // fallback). A template the constructor never binds is absent from the
+        // map, so it stays `mixed` (bare) in the emitted `type_params` — it must
+        // NOT be fabricated to its declared bound, or a later `T`-typed method
+        // call would falsely substitute the param to the bound and reject valid
+        // args (e.g. `@template T of Base`, `__construct(int $id)` → `new Repo(5)`
+        // must be bare `Repo`, never `Repo<Base>`).
+        let bindings =
+            crate::generic::infer_arg_template_bindings(&class_tps, ctor_params, arg_types);
+
+        // Emit the inferred bindings in the class's declared template-param order
+        // so `build_class_bindings` zips them back correctly at the call site.
+        // A template bound from an argument → its (widened) inferred type;
+        // otherwise → `mixed`. Only consider the receiver "concrete" when at
+        // least one template was bound from an argument — otherwise keep the
+        // bare (un-parameterised) type, preserving prior behaviour for ordinary
+        // / non-generic / uninferable instantiations.
+        let mut params: Vec<Type> = Vec::with_capacity(class_tps.len());
+        let mut any_concrete = false;
+        for tp in class_tps.iter() {
+            match bindings.get(&mir_types::Name::from(tp.name.as_ref())) {
+                Some(ty) if !ty.is_mixed() => {
+                    // Widen scalar literals to their base type so the receiver
+                    // does not carry an over-narrow type param (e.g. `new Box(5)`
+                    // → `Box<int>`, not `Box<5>`, so a later `$box->set(6)` for
+                    // `set(T)` is not wrongly rejected).
+                    any_concrete = true;
+                    params.push(widen_type_param(ty));
+                }
+                _ => params.push(Type::mixed()),
+            }
+        }
+        if any_concrete {
+            mir_types::union::vec_to_type_params(params)
+        } else {
+            empty
+        }
+    }
+
     pub(super) fn analyze_new(
         &mut self,
         n: &NewExpr,
@@ -70,6 +155,9 @@ impl<'a> ExpressionAnalyzer<'a> {
             .map(|a| expr_can_be_passed_by_reference_owned(&a.value))
             .collect();
 
+        // Generic type params inferred from constructor arguments, attached to
+        // the resulting `TNamedObject` so member-access substitution works.
+        let mut inferred_type_params: Arc<[Type]> = mir_types::union::empty_type_params();
         let class_ty = match &n.class.kind {
             ExprKind::Identifier(name) => {
                 let resolved = crate::db::resolve_name(self.db, &self.file, name.as_ref());
@@ -126,23 +214,35 @@ impl<'a> ExpressionAnalyzer<'a> {
                         "__construct",
                     )
                     .map(|(_, s)| (s.params.to_vec(), s.template_params.clone()));
-                    if let Some((ctor_params, ctor_templates)) = ctor_params_and_templates {
+                    if let Some((ctor_params, ctor_templates)) = &ctor_params_and_templates {
                         crate::call::check_constructor_args(
                             self,
                             &fqcn,
                             crate::call::CheckArgsParams {
                                 fn_name: "__construct",
-                                params: &ctor_params,
+                                params: ctor_params,
                                 arg_types: &arg_types,
                                 arg_spans: &arg_spans,
                                 arg_names: &arg_names,
                                 arg_can_be_byref: &arg_can_be_byref,
                                 call_span,
                                 has_spread: n.args.iter().any(|a| a.unpack),
-                                template_params: &ctor_templates,
+                                template_params: ctor_templates,
                             },
                         );
                     }
+                    // Infer class-level generic type params from the constructor
+                    // arguments (e.g. `new Box(5)` → `Box<int>` for `@template T`
+                    // with `__construct(T $value)`). This lets later member access
+                    // (`$b->get()`) substitute the receiver's bindings into return
+                    // types, including UNANNOTATED inferred returns.
+                    inferred_type_params = self.infer_new_type_params(
+                        &fqcn,
+                        ctor_params_and_templates
+                            .as_ref()
+                            .map(|(p, _)| p.as_slice()),
+                        &arg_types,
+                    );
                 }
                 crate::call::ARG_TYPES_BUF.with(|b| {
                     let mut g = b.borrow_mut();
@@ -152,7 +252,10 @@ impl<'a> ExpressionAnalyzer<'a> {
                 });
                 let ty = Type::single(Atomic::TNamedObject {
                     fqcn: mir_types::Name::from(fqcn.as_ref()),
-                    type_params: mir_types::union::empty_type_params(),
+                    type_params: std::mem::replace(
+                        &mut inferred_type_params,
+                        mir_types::union::empty_type_params(),
+                    ),
                 });
                 self.record_symbol(
                     n.class.span,

--- a/crates/mir-analyzer/src/generic.rs
+++ b/crates/mir-analyzer/src/generic.rs
@@ -22,6 +22,32 @@ pub fn infer_template_bindings(
     params: &[FnParam],
     arg_types: &[Type],
 ) -> FxHashMap<Name, Type> {
+    let mut bindings = infer_arg_template_bindings(template_params, params, arg_types);
+
+    // For any template not bound through arguments, fall back to its bound
+    // (or mixed if no bound is declared).
+    for tp in template_params {
+        bindings
+            .entry(Name::from(tp.name.as_ref()))
+            .or_insert_with(|| tp.bound.clone().unwrap_or_else(Type::mixed));
+    }
+
+    bindings
+}
+
+/// Infer template parameter bindings ONLY from the argument types, without the
+/// bound/mixed fallback fill that [`infer_template_bindings`] applies.
+///
+/// A template that no argument binds is simply ABSENT from the returned map —
+/// it is *not* inferred to its declared bound. This is the correct primitive for
+/// parameterising a `new` receiver: a bounded template the constructor never
+/// references must stay `mixed` (bare) downstream, so a later `T`-typed method
+/// call does not falsely substitute the param to the bound and reject valid args.
+pub fn infer_arg_template_bindings(
+    template_params: &[TemplateParam],
+    params: &[FnParam],
+    arg_types: &[Type],
+) -> FxHashMap<Name, Type> {
     let mut bindings: FxHashMap<Name, Type> = FxHashMap::default();
     let template_names: std::collections::HashSet<Name> = template_params
         .iter()
@@ -32,14 +58,6 @@ pub fn infer_template_bindings(
         if let Some(param_ty) = &param.ty {
             infer_from_pair(param_ty, arg_ty, &template_names, &mut bindings);
         }
-    }
-
-    // For any template not bound through arguments, fall back to its bound
-    // (or mixed if no bound is declared).
-    for tp in template_params {
-        bindings
-            .entry(Name::from(tp.name.as_ref()))
-            .or_insert_with(|| tp.bound.clone().unwrap_or_else(Type::mixed));
     }
 
     bindings

--- a/crates/mir-analyzer/src/parser/docblock.rs
+++ b/crates/mir-analyzer/src/parser/docblock.rs
@@ -135,12 +135,12 @@ impl DocblockParser {
                         ));
                     }
                 }
-                "extends" => {
+                "extends" | "template-extends" | "phpstan-extends" => {
                     if let Some(body_str) = body_text(&tag.body) {
                         result.extends = Some(parse_type_string(body_str.trim()));
                     }
                 }
-                "implements" => {
+                "implements" | "template-implements" | "phpstan-implements" => {
                     if let Some(body_str) = body_text(&tag.body) {
                         result.implements.push(parse_type_string(body_str.trim()));
                     }
@@ -927,13 +927,35 @@ fn find_matching_paren(s: &str) -> Option<usize> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parse template tag format: `T`, `T of Bound`, or `T as Bound`
+/// Parse template tag format: `T`, `T of Bound`, or `T as Bound`.
+///
+/// For single-line docblocks (e.g. `/** @template T @param T $x @return T */`)
+/// `phpdoc_parser` hands us a body that runs all the way to the closing `*/`,
+/// so the body may carry trailing tags (`T @param T $x @return T`). The template
+/// name is the first whitespace-delimited token and any `of`/`as` bound is only
+/// parsed up to the next `@` tag.
 fn parse_template_line(_tag_name: &str, body: Option<String>) -> Option<(String, Option<String>)> {
     let body = body?;
+    let body = body.trim();
+    // Stop at the next embedded tag so single-line docblocks don't swallow the
+    // following `@param`/`@return` tokens into the template name/bound.
+    let body = match body.find(" @") {
+        Some(idx) => body[..idx].trim_end(),
+        None => body,
+    };
+    if body.is_empty() {
+        return None;
+    }
     if let Some((name, bound)) = body.split_once(" of ").or_else(|| body.split_once(" as ")) {
-        Some((name.trim().to_string(), Some(bound.trim().to_string())))
+        let bound = bound.trim();
+        Some((
+            name.trim().to_string(),
+            (!bound.is_empty()).then(|| bound.to_string()),
+        ))
     } else {
-        Some((body.trim().to_string(), None))
+        // No bound: take just the first whitespace-delimited token as the name.
+        let name = body.split_whitespace().next().unwrap_or(body);
+        Some((name.to_string(), None))
     }
 }
 
@@ -1492,6 +1514,74 @@ mod tests {
         assert_eq!(parsed.templates.len(), 1);
         assert_eq!(parsed.templates[0].0, "T");
         assert_eq!(parsed.templates[0].2, Variance::Contravariant);
+    }
+
+    #[test]
+    fn parse_template_single_line_does_not_over_read() {
+        // E1: single-line docblock — the @template body runs to the closing `*/`,
+        // so the parser used to take `T @param T $x @return T` as the template name.
+        let doc = "/** @template T @param T $x @return T */";
+        let parsed = DocblockParser::parse(doc);
+        assert_eq!(parsed.templates.len(), 1);
+        assert_eq!(parsed.templates[0].0, "T");
+        assert!(parsed.templates[0].1.is_none(), "expected no bound");
+    }
+
+    #[test]
+    fn parse_template_multiline_with_bound_still_works() {
+        // E1 regression guard: a normal multi-line `@template T of Base` keeps name + bound.
+        let doc = r#"/**
+         * @template T of Base
+         */"#;
+        let parsed = DocblockParser::parse(doc);
+        assert_eq!(parsed.templates.len(), 1);
+        assert_eq!(parsed.templates[0].0, "T");
+        let bound = parsed.templates[0].1.as_ref().expect("expected a bound");
+        assert!(bound.contains(
+            |t| matches!(t, Atomic::TNamedObject { fqcn, .. } if fqcn.as_ref() == "Base")
+        ));
+    }
+
+    #[test]
+    fn parse_template_extends_alias() {
+        // E2: `@template-extends` / `@phpstan-extends` route into `extends`.
+        for tag in ["template-extends", "phpstan-extends"] {
+            let doc = format!("/** @{tag} Base<User> */");
+            let parsed = DocblockParser::parse(&doc);
+            let extends = parsed
+                .extends
+                .unwrap_or_else(|| panic!("@{tag} should populate extends"));
+            assert!(
+                extends.contains(|t| matches!(
+                    t,
+                    Atomic::TNamedObject { fqcn, type_params }
+                        if fqcn.as_ref() == "Base" && !type_params.is_empty()
+                )),
+                "@{tag} should produce a generic Base<User>"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_template_implements_alias() {
+        // E2: `@template-implements` / `@phpstan-implements` route into `implements`.
+        for tag in ["template-implements", "phpstan-implements"] {
+            let doc = format!("/** @{tag} Iter<User> */");
+            let parsed = DocblockParser::parse(&doc);
+            assert_eq!(
+                parsed.implements.len(),
+                1,
+                "@{tag} should populate implements"
+            );
+            assert!(
+                parsed.implements[0].contains(|t| matches!(
+                    t,
+                    Atomic::TNamedObject { fqcn, type_params }
+                        if fqcn.as_ref() == "Iter" && !type_params.is_empty()
+                )),
+                "@{tag} should produce a generic Iter<User>"
+            );
+        }
     }
 
     #[test]

--- a/crates/mir-analyzer/tests/inferred_generic_returns.rs
+++ b/crates/mir-analyzer/tests/inferred_generic_returns.rs
@@ -1,0 +1,532 @@
+// Integration tests for cross-file UNANNOTATED inferred generic method returns (E3).
+//
+// `$b = new Box(5); $b->get();` where `Box` has `@template T`,
+// a constructor that types `$value` as `T` (`@param T $value`), and a method
+// `get()` with NO `@return` whose body is `return $this->value;` — with `Box`
+// defined in a DIFFERENT file from the call site — must resolve to `int`, not
+// `mixed`.
+//
+// Two layers cooperate to make this work:
+//   1. `analyze_new` infers the class-level type params from the constructor
+//      args, so `new Box(5)` is typed `Box<int>` (not bare `Box`).
+//   2. The promoted-property collector types `$value` as the template param `T`
+//      from the constructor's `@param T $value`, so the unannotated `get()` body
+//      `return $this->value;` infers `T`, which the call site substitutes to int.
+
+mod common;
+
+use mir_analyzer::symbol::ReferenceKind;
+use mir_analyzer::{AnalysisSession, BatchOptions, PhpVersion};
+use mir_types::Atomic;
+
+use self::common::{create_temp_dir, path_to_str, write_file};
+
+/// Locate the resolved type of the named method call recorded in `caller_file`.
+fn resolved_method_type(
+    result: &mir_analyzer::AnalysisResult,
+    caller_file: &str,
+    method: &str,
+) -> mir_types::Type {
+    result
+        .symbols
+        .iter()
+        .find(|s| {
+            s.file.as_ref() == caller_file
+                && matches!(&s.kind, ReferenceKind::MethodCall { method: m, .. } if m.as_ref() == method)
+        })
+        .map(|s| s.resolved_type.clone())
+        .unwrap_or_else(|| panic!("MethodCall({method}) must be recorded in the caller file"))
+}
+
+/// Locate the resolved receiver type recorded for the `new ClassName(...)`
+/// expression (the `ClassReference` symbol) in `caller_file`.
+fn resolved_new_receiver_type(
+    result: &mir_analyzer::AnalysisResult,
+    caller_file: &str,
+    class: &str,
+) -> mir_types::Type {
+    result
+        .symbols
+        .iter()
+        .find(|s| {
+            s.file.as_ref() == caller_file
+                && matches!(&s.kind, ReferenceKind::ClassReference(n) if n.as_ref() == class)
+        })
+        .map(|s| s.resolved_type.clone())
+        .unwrap_or_else(|| panic!("ClassReference({class}) must be recorded in the caller file"))
+}
+
+/// True when the receiver type is a bare `TNamedObject` (no generic type params)
+/// for `class`.
+fn is_bare_named_object(ty: &mir_types::Type, class: &str) -> bool {
+    ty.types.iter().any(|t| {
+        matches!(
+            t,
+            Atomic::TNamedObject { fqcn, type_params }
+                if fqcn.as_ref() == class && type_params.is_empty()
+        )
+    })
+}
+
+/// Count diagnostics recorded against `caller_file` matching `pred`.
+fn count_issues(
+    result: &mir_analyzer::AnalysisResult,
+    caller_file: &str,
+    pred: impl Fn(&mir_issues::IssueKind) -> bool,
+) -> usize {
+    result
+        .issues
+        .iter()
+        .filter(|i| i.location.file.as_ref() == caller_file && pred(&i.kind))
+        .count()
+}
+
+/// True when any diagnostic of Error severity was recorded against `caller_file`.
+fn has_error(result: &mir_analyzer::AnalysisResult, caller_file: &str) -> bool {
+    result.issues.iter().any(|i| {
+        i.location.file.as_ref() == caller_file && i.severity == mir_issues::Severity::Error
+    })
+}
+
+/// Generic `Box` whose promoted `$value` is typed `T` via the constructor's
+/// `@param T $value`, with an UNANNOTATED `get()` returning `$this->value`.
+const BOX_SRC: &str = "<?php\n\
+/**\n\
+ * @template T\n\
+ */\n\
+class Box {\n\
+    /** @param T $value */\n\
+    public function __construct(public $value) {}\n\
+    public function get() { return $this->value; }\n\
+}\n";
+
+#[test]
+fn cross_file_unannotated_generic_return_resolves_int() {
+    let dir = create_temp_dir("cross_file_unannotated_generic_return_int");
+    let box_file = write_file(&dir, "box.php", BOX_SRC);
+
+    // Call site lives in a different file.
+    let app_src = "<?php\nfunction app(): void { $b = new Box(5); $b->get(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[box_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // The `new Box(5)` receiver carries a WIDENED `int` type param (not the
+    // literal `5`), so the unannotated `get()` resolves to `int`.
+    let ty = resolved_method_type(&result, app_str, "get");
+    assert!(
+        ty.contains(|t| matches!(t, Atomic::TInt)),
+        "expected $b->get() to resolve to widened int, got {ty}"
+    );
+    assert!(
+        !ty.contains(|t| matches!(t, Atomic::TLiteralInt(_))),
+        "expected the literal 5 to be widened to int, got {ty}"
+    );
+    assert!(
+        !ty.is_mixed(),
+        "expected a concrete int, not mixed, got {ty}"
+    );
+}
+
+#[test]
+fn cross_file_unannotated_generic_return_resolves_string() {
+    let dir = create_temp_dir("cross_file_unannotated_generic_return_string");
+    let box_file = write_file(&dir, "box.php", BOX_SRC);
+
+    let app_src = "<?php\nfunction app(): void { $b = new Box(\"hello\"); $b->get(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[box_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // The `new Box("hello")` receiver carries a WIDENED `string` type param (not
+    // the literal `"hello"`), so the unannotated `get()` resolves to `string`.
+    let ty = resolved_method_type(&result, app_str, "get");
+    assert!(
+        ty.contains(|t| matches!(t, Atomic::TString)),
+        "expected $b->get() to resolve to widened string, got {ty}"
+    );
+    assert!(
+        !ty.contains(|t| matches!(t, Atomic::TLiteralString(_))),
+        "expected the literal \"hello\" to be widened to string, got {ty}"
+    );
+    assert!(
+        !ty.is_mixed(),
+        "expected a concrete string, not mixed, got {ty}"
+    );
+}
+
+#[test]
+fn cross_file_unannotated_generic_return_explicit_var_property() {
+    // The same outcome via an explicit `@var T` property + a non-promoted
+    // constructor that assigns it — exercises `resolve_property_type` reading the
+    // declared template type directly.
+    let dir = create_temp_dir("cross_file_unannotated_generic_return_explicit_var");
+    let box_src = "<?php\n\
+/**\n\
+ * @template T\n\
+ */\n\
+class Holder {\n\
+    /** @var T */\n\
+    public $value;\n\
+    /** @param T $v */\n\
+    public function __construct($v) { $this->value = $v; }\n\
+    public function get() { return $this->value; }\n\
+}\n";
+    let box_file = write_file(&dir, "holder.php", box_src);
+
+    let app_src = "<?php\nfunction app(): void { $h = new Holder(42); $h->get(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[box_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    let ty = resolved_method_type(&result, app_str, "get");
+    assert!(
+        ty.contains(|t| matches!(t, Atomic::TInt | Atomic::TLiteralInt(_))),
+        "expected $h->get() to resolve to int, got {ty}"
+    );
+}
+
+#[test]
+fn cross_file_unannotated_non_generic_return_still_works() {
+    // Regression guard: an unannotated return on a NON-generic class must keep
+    // inferring its concrete type from the body (here: a literal int), and the
+    // `analyze_new` type-param inference must NOT spuriously parameterise it.
+    let dir = create_temp_dir("cross_file_unannotated_non_generic_return");
+
+    let lib_src = "<?php\n\
+class Counter {\n\
+    public function answer() { return 42; }\n\
+}\n";
+    let lib_file = write_file(&dir, "counter.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { $c = new Counter(); $c->answer(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    let ty = resolved_method_type(&result, app_str, "answer");
+    assert!(
+        ty.contains(|t| matches!(t, Atomic::TInt | Atomic::TLiteralInt(_))),
+        "expected answer() to resolve to int, got {ty}"
+    );
+}
+
+#[test]
+fn cross_file_self_referential_unannotated_return_falls_back_without_hanging() {
+    // A method whose unannotated body returns the result of calling itself must
+    // fall back to a safe type via the INFER_IN_PROGRESS cycle guard, and must
+    // NOT hang. The key assertion is that analysis terminates and records the
+    // call; the resolved type is allowed to be a safe fallback.
+    let dir = create_temp_dir("cross_file_self_referential_unannotated_return");
+
+    let rec_src = "<?php\n\
+/**\n\
+ * @template T\n\
+ */\n\
+class Rec {\n\
+    /** @param T $value */\n\
+    public function __construct(public $value) {}\n\
+    public function loop() { return $this->loop(); }\n\
+}\n";
+    let rec_file = write_file(&dir, "rec.php", rec_src);
+
+    let app_src = "<?php\nfunction app(): void { $r = new Rec(1); $r->loop(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[rec_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // Must terminate and record the call (type may be a safe fallback).
+    let _ty = resolved_method_type(&result, app_str, "loop");
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for the bound-fallback false positive (review finding E3).
+//
+// `infer_new_type_params` must parameterise the `new` receiver ONLY from
+// template bindings derived from constructor ARGUMENTS. A bounded template the
+// constructor never binds must stay `mixed` (bare type), so a later `T`-typed
+// method call does NOT falsely substitute the param to the bound and reject
+// otherwise-valid arguments.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bounded_unbound_template_does_not_fabricate_receiver_param() {
+    // The exact repro from the review: `@template T of Base` whose ctor does NOT
+    // bind T (`__construct(int $id)`), with a `@param T $item` method. Before the
+    // fix, `new Repo(5)` was fabricated as `Repo<Base>` (T fell back to its bound
+    // `Base`), and `$r->add(new Other())` was rejected with a false
+    // `InvalidArgument`. The receiver must instead be bare `Repo`, and the call
+    // must emit NO diagnostic.
+    let dir = create_temp_dir("bounded_unbound_template_no_false_positive");
+
+    let lib_src = "<?php\n\
+class Base {}\n\
+class Other {}\n\
+/**\n\
+ * @template T of Base\n\
+ */\n\
+class Repo {\n\
+    public function __construct(int $id) {}\n\
+    /** @param T $item */\n\
+    public function add($item): void {}\n\
+}\n";
+    let lib_file = write_file(&dir, "repo.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { $r = new Repo(5); $r->add(new Other()); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // The receiver of `new Repo(5)` must be bare `Repo`, NOT `Repo<Base>`.
+    let recv = resolved_new_receiver_type(&result, app_str, "Repo");
+    assert!(
+        is_bare_named_object(&recv, "Repo"),
+        "expected `new Repo(5)` to be bare `Repo`, got {recv}"
+    );
+
+    // No false InvalidArgument (or any error) on the later `T`-typed method call.
+    assert_eq!(
+        count_issues(&result, app_str, |k| matches!(
+            k,
+            mir_issues::IssueKind::InvalidArgument { .. }
+                | mir_issues::IssueKind::PossiblyInvalidArgument { .. }
+        )),
+        0,
+        "expected NO InvalidArgument on $r->add(new Other()); issues: {:?}",
+        result.issues
+    );
+    assert!(
+        !has_error(&result, app_str),
+        "expected NO error-severity diagnostic; issues: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn partial_inference_leaves_unbound_template_mixed() {
+    // Two templates where the ctor binds only one (`K` from a `T`-typed first
+    // arg) and never references the bounded second (`V of Base`). The unbound `V`
+    // must stay `mixed` — not fabricated to `Base` — so a `V`-typed method still
+    // accepts an unrelated argument with no false positive.
+    let dir = create_temp_dir("partial_inference_unbound_template_mixed");
+
+    let lib_src = "<?php\n\
+class Base {}\n\
+class Other {}\n\
+/**\n\
+ * @template K\n\
+ * @template V of Base\n\
+ */\n\
+class Map {\n\
+    /** @param K $key */\n\
+    public function __construct($key) {}\n\
+    /** @param V $value */\n\
+    public function put($value): void {}\n\
+}\n";
+    let lib_file = write_file(&dir, "map.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { $m = new Map(\"k\"); $m->put(new Other()); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // K bound from the literal arg (widened to string); V must NOT be `Base`.
+    let recv = resolved_new_receiver_type(&result, app_str, "Map");
+    let v_is_base = recv.types.iter().any(|t| {
+        matches!(t, Atomic::TNamedObject { fqcn, type_params }
+            if fqcn.as_ref() == "Map"
+                && type_params.get(1).is_some_and(|p| {
+                    p.types
+                        .iter()
+                        .any(|a| matches!(a, Atomic::TNamedObject { fqcn, .. } if fqcn.as_ref() == "Base"))
+                }))
+    });
+    assert!(
+        !v_is_base,
+        "expected unbound V to be mixed, not fabricated to Base, got {recv}"
+    );
+
+    assert_eq!(
+        count_issues(&result, app_str, |k| matches!(
+            k,
+            mir_issues::IssueKind::InvalidArgument { .. }
+                | mir_issues::IssueKind::PossiblyInvalidArgument { .. }
+        )),
+        0,
+        "expected NO InvalidArgument on $m->put(new Other()); issues: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn generic_class_without_constructor_is_bare_and_does_not_panic() {
+    // A generic class with templates but NO constructor must yield a bare type
+    // (early-return path) and must not panic.
+    let dir = create_temp_dir("generic_class_no_constructor_bare");
+
+    let lib_src = "<?php\n\
+/**\n\
+ * @template T of \\Stringable\n\
+ */\n\
+class Bag {\n\
+    /** @param T $item */\n\
+    public function add($item): void {}\n\
+}\n";
+    let lib_file = write_file(&dir, "bag.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { $b = new Bag(); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    let recv = resolved_new_receiver_type(&result, app_str, "Bag");
+    assert!(
+        is_bare_named_object(&recv, "Bag"),
+        "expected `new Bag()` to be bare `Bag`, got {recv}"
+    );
+    assert!(
+        !has_error(&result, app_str),
+        "expected NO error-severity diagnostic; issues: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn variadic_union_nullable_ctor_args_do_not_panic_or_false_positive() {
+    // A constructor mixing a variadic `T`-typed parameter, plus a bounded second
+    // template `U of Base` that is taken via a nullable/union-typed parameter
+    // that does NOT reference U. U must stay mixed; binding `T` from the variadic
+    // args must not panic, and a later `U`-typed method must accept an unrelated
+    // argument with no false positive.
+    let dir = create_temp_dir("variadic_union_nullable_ctor_args");
+
+    let lib_src = "<?php\n\
+class Base {}\n\
+class Other {}\n\
+/**\n\
+ * @template T\n\
+ * @template U of Base\n\
+ */\n\
+class Coll {\n\
+    /**\n\
+     * @param T ...$items\n\
+     */\n\
+    public function __construct(?string $label, int|string $tag, ...$items) {}\n\
+    /** @param U $value */\n\
+    public function setValue($value): void {}\n\
+}\n";
+    let lib_file = write_file(&dir, "coll.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { \
+$c = new Coll(null, 7, 1, 2, 3); $c->setValue(new Other()); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // The receiver must exist and the bounded, ctor-unbound `U` must not be Base.
+    let recv = resolved_new_receiver_type(&result, app_str, "Coll");
+    let u_is_base = recv.types.iter().any(|t| {
+        matches!(t, Atomic::TNamedObject { fqcn, type_params }
+            if fqcn.as_ref() == "Coll"
+                && type_params.get(1).is_some_and(|p| {
+                    p.types
+                        .iter()
+                        .any(|a| matches!(a, Atomic::TNamedObject { fqcn, .. } if fqcn.as_ref() == "Base"))
+                }))
+    });
+    assert!(
+        !u_is_base,
+        "expected unbound U to be mixed, not fabricated to Base, got {recv}"
+    );
+
+    assert_eq!(
+        count_issues(&result, app_str, |k| matches!(
+            k,
+            mir_issues::IssueKind::InvalidArgument { .. }
+                | mir_issues::IssueKind::PossiblyInvalidArgument { .. }
+        )),
+        0,
+        "expected NO InvalidArgument; issues: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn literal_int_type_param_is_widened_so_setter_accepts_other_int() {
+    // `new Box(5)` must carry `Box<int>` (widened), NOT `Box<5>`, so a later
+    // `$b->set(6)` for `set(T $v)` is accepted (T = int, not the literal 5).
+    let dir = create_temp_dir("literal_int_type_param_widened");
+
+    let lib_src = "<?php\n\
+/**\n\
+ * @template T\n\
+ */\n\
+class Box {\n\
+    /** @param T $value */\n\
+    public function __construct(public $value) {}\n\
+    /** @param T $value */\n\
+    public function set($value): void { $this->value = $value; }\n\
+}\n";
+    let lib_file = write_file(&dir, "box.php", lib_src);
+
+    let app_src = "<?php\nfunction app(): void { $b = new Box(5); $b->set(6); }\n";
+    let app_file = write_file(&dir, "app.php", app_src);
+    let app_str = path_to_str(&app_file);
+
+    let analyzer = AnalysisSession::new(PhpVersion::LATEST);
+    let result =
+        analyzer.analyze_paths(&[lib_file.clone(), app_file.clone()], &BatchOptions::new());
+
+    // Receiver type param must be widened int, not the literal 5.
+    let recv = resolved_new_receiver_type(&result, app_str, "Box");
+    let param_is_widened_int = recv.types.iter().any(|t| {
+        matches!(t, Atomic::TNamedObject { fqcn, type_params }
+        if fqcn.as_ref() == "Box"
+            && type_params.first().is_some_and(|p| {
+                p.contains(|a| matches!(a, Atomic::TInt))
+                    && !p.contains(|a| matches!(a, Atomic::TLiteralInt(_)))
+            }))
+    });
+    assert!(
+        param_is_widened_int,
+        "expected `new Box(5)` receiver to be `Box<int>` (widened), got {recv}"
+    );
+
+    assert_eq!(
+        count_issues(&result, app_str, |k| matches!(
+            k,
+            mir_issues::IssueKind::InvalidArgument { .. }
+                | mir_issues::IssueKind::PossiblyInvalidArgument { .. }
+        )),
+        0,
+        "expected NO InvalidArgument on $b->set(6) after widening; issues: {:?}",
+        result.issues
+    );
+}


### PR DESCRIPTION
## Summary

Improves generic resolution so downstream consumers (notably language servers) get **concrete
types for common generic patterns without explicit `@var`/`@return` annotations**, plus two
docblock-parsing fixes. No public API changes.

### 1. Constructor-argument template inference (`expr/objects.rs`)
`new Box(5)` now infers `Box<int>` by binding the class's `@template` params from the constructor
argument types (reusing the existing `infer_*_template_bindings`). Key safety properties:
- Scalar **literals are widened**: `new Box(5)` → `Box<int>` (not `Box<5>`), avoiding over-narrow
  downstream types.
- Only templates **actually bound by an argument** are attached. A template the constructor never
  binds stays `mixed` — **not** its declared bound. This is the critical correctness point: a
  naive "fill every template with its bound" would fabricate `new Repo(5)` as `Repo<Base>` for
  `@template T of Base` and then **falsely reject** a valid later `$r->add(new Foo())`. The new
  `generic::infer_arg_template_bindings` (a non-filling sibling of `infer_template_bindings`)
  computes argument-only bindings; the existing `infer_template_bindings` is unchanged for its
  other callers (it still applies the bound/mixed fill on top).
- Non-generic / nothing-inferred `new` keeps its **bare** type → existing instantiations and
  argument-checks are unaffected.

### 2. Unannotated generic method returns (`call/method.rs` path + inference)
A method with **no `@return`** whose body returns a `@template`-typed value now resolves at call
sites via the inferred return + receiver bindings — e.g. `Box<int>::get()` returning
`$this->value` (a promoted `@param T $value`) resolves to `int`, **including cross-file**.
Self-referential/cyclic inference falls back to `mixed` via the existing `INFER_IN_PROGRESS` guard.

### 3. Promoted-constructor property typing (`collector/class.rs`)
Promoted properties take their type from the constructor `@param` docblock (template-aware) when
there is **no native type hint** — so `public $value` with `/** @param T $value */` is typed `T`.
Gated to the no-native-hint case (`.or_else`); properties with a native hint are unchanged.

### 4. Docblock parsing fixes (`parser/docblock.rs`)
- **Single-line over-read**: `/** @template T @param T $x @return T */` no longer swallows the
  trailing tags into the template name (truncate at the next ` @`, first token = name).
- **Inheritance-tag aliases**: `@template-extends`/`@template-implements` (and `@phpstan-extends`/
  `@phpstan-implements`) are now recognized as inheritance tags with type arguments, routing to
  `extends`/`implements` like the bare forms.

## Test plan
Adds `crates/mir-analyzer/tests/inferred_generic_returns.rs` and docblock unit tests covering:
- `Box<int>` / `Box<string>` element resolution via an **unannotated** `get()` (incl. cross-file),
- **regression guards**: bounded-but-unbound template (the `Repo<Base>` false-positive repro —
  asserts the receiver is bare `Repo` and **no** `InvalidArgument`), partial inference,
  no-constructor, variadic / union / nullable constructors, literal widening,
- E1 single-line and E2 alias docblock parsing.

Gates (full workspace): `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo test --workspace` — all green (mir-analyzer: 1045 lib +
13 new tests, 0 failures).

## Motivation
Surfaced while implementing PHP-generics support in a language server built on mir: these were
engine-level gaps the LSP had to work around (single-line docblock sanitizing, inheritance-alias
normalization) or could not resolve at all (cross-file unannotated generic returns). Fixing them
in mir lets every consumer benefit and removes the workarounds.

> Reviewed for false-positive safety with a baseline-vs-change differential (the bounded-unbound
> case above was caught and fixed before this PR).

---
> **AI-assisted** (Megamind multi-agent run): implemented + adversarially reviewed by Claude (Opus).
