### PR TITLE
Name cache temp files without asking for a pid

### DIFF
--- a/crates/mir-analyzer/src/cache.rs
+++ b/crates/mir-analyzer/src/cache.rs
@@ -421,7 +421,7 @@ impl AnalysisCache {
             // same pattern as stub_cache.rs. A crash mid-write leaves only
             // the tmp file; the prior cache.bin (or none, on a first run)
             // stays intact instead of being truncated in place.
-            let tmp = cache_file.with_extension(format!("bin.tmp.{}", std::process::id()));
+            let tmp = cache_file.with_extension(format!("bin.tmp.{}", crate::tmp_suffix::next()));
             if std::fs::write(&tmp, &bytes).is_ok() {
                 let _ = std::fs::rename(&tmp, &cache_file);
             }

--- a/crates/mir-analyzer/src/lib.rs
+++ b/crates/mir-analyzer/src/lib.rs
@@ -40,6 +40,7 @@ pub mod stubs;
 pub(crate) mod subtype;
 pub mod suppression;
 pub(crate) mod taint;
+mod tmp_suffix;
 pub(crate) mod type_env;
 pub(crate) mod util;
 

--- a/crates/mir-analyzer/src/stub_cache.rs
+++ b/crates/mir-analyzer/src/stub_cache.rs
@@ -321,7 +321,7 @@ fn write_entry(job: WriteJob) {
     }
     // Tempfile in the same directory so the rename is atomic on every
     // POSIX filesystem (cross-mount renames would degrade to copy).
-    let tmp = entry_path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
+    let tmp = entry_path.with_extension(format!("tmp.{}.{}", crate::tmp_suffix::next(), seq));
     if std::fs::write(&tmp, &buf).is_err() {
         return;
     }

--- a/crates/mir-analyzer/src/tmp_suffix.rs
+++ b/crates/mir-analyzer/src/tmp_suffix.rs
@@ -1,0 +1,70 @@
+//! A per-writer suffix for the temp files the caches rename into place.
+//!
+//! Both call sites used `std::process::id()`, which is not available on every
+//! target this crate builds for: wasm has no pids and the call panics. That
+//! target is not hypothetical — `crates/mir-wasm` builds for
+//! `wasm32-unknown-unknown` and the docs playground ships it. It survives only
+//! because analysing one source string never reaches either cache; an embedder
+//! that opens a project does, on the analysis cache's periodic flush, so the
+//! panic arrives seconds in rather than at start-up where it would be obvious.
+//!
+//! The suffix only has to keep two writers racing on the same entry from
+//! choosing the same name; the rename that follows is what makes the write
+//! atomic. A pid gives that between processes and a counter gives it within
+//! one, so take the pid where there is one — where there is not, one process is
+//! all there is.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A suffix unique among concurrent writers of the same cache entry.
+pub(crate) fn next() -> u32 {
+    process_id().unwrap_or_else(counter)
+}
+
+/// This process's id, or `None` on a target that has no processes.
+fn process_id() -> Option<u32> {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        Some(std::process::id())
+    }
+    #[cfg(target_family = "wasm")]
+    {
+        None
+    }
+}
+
+/// A suffix that separates writers within one process.
+fn counter() -> u32 {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// The one thing the suffix has to guarantee.
+    #[test]
+    fn the_counter_separates_concurrent_writers() {
+        let threads: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(|| (0..200).map(|_| counter()).collect::<Vec<_>>()))
+            .collect();
+        let all: Vec<u32> = threads
+            .into_iter()
+            .flat_map(|t| t.join().unwrap())
+            .collect();
+        assert_eq!(
+            all.iter().collect::<HashSet<_>>().len(),
+            all.len(),
+            "two writers chose the same temp suffix"
+        );
+    }
+
+    /// Whatever the target, asking for a suffix answers instead of panicking.
+    #[test]
+    fn next_answers_without_a_pid() {
+        assert_ne!(counter(), counter());
+        let _ = next();
+    }
+}


### PR DESCRIPTION
`AnalysisCache::save` and the stub cache's `write_entry` both build their temp-file name from `std::process::id()`. That call is not available on every target this crate builds for: wasm has no pids and it panics outright -- "no pids on this platform" -- which on a target that compiles panics to `abort` takes the process down.

That target is already supported and already built in CI. `crates/mir-wasm` is a workspace member, `docs.yml` runs `wasm-pack build --target web` on it for `wasm32-unknown-unknown` on every push touching `crates/**`, and the playground ships the result. It survives only because analysing a single source string never reaches either cache. An embedder that opens a project does reach them, on the analysis cache's periodic flush, so the failure arrives a few seconds after start-up rather than at it -- an analyzer that answers every request correctly and then dies.

The suffix only has to keep two writers racing on the same entry from choosing the same temp name; the rename that follows is what makes the write atomic. A pid does that between processes, an atomic counter does it within one, and on a target with no processes one process is all there is. `tmp_suffix::next()` picks whichever the target has, so the cross-process guarantee is unchanged everywhere it was available before.

`counter()` is compiled on every target rather than only on wasm, so the invariant it exists for is testable where the tests actually run: eight threads taking two hundred suffixes each must not collide.

The other two `std::process::id()` calls in library code are not reachable here. `mir-plugin`'s is inside `psalm`, which the manifest gates behind the `psalm-bridge` feature and documents as "not available on wasm"; `default = []` and `mir-analyzer` enables neither that nor `dylib`, so it is not compiled. `test_utils`'s builds a temp fixture directory and is called only from tests.

Verified with `cargo check -p mir-wasm --target wasm32-unknown-unknown` and `cargo check -p mir-analyzer --target wasm32-wasip1`.